### PR TITLE
LinearSolve interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.jl.mem
 /docs/build/
 Manifest.toml
+
+*.swp

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,9 @@ version = "0.1.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
+KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
@@ -22,7 +24,9 @@ UnPack = "1"
 julia = "1"
 
 [extras]
+DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "OrdinaryDiffEq", "DiffEqProblemLibrary"]

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ArrayInterface = "3"
+IterativeSolvers = "0.9.2"
 Krylov = "0.7"
 Reexport = "1"
 SciMLBase = "1.18.6"

--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,11 @@ IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 Krylov = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
 KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -3,7 +3,6 @@ module LinearSolve
 using ArrayInterface: lu_instance
 using Base: cache_dependencies, Bool
 using LinearAlgebra
-using Reexport
 using SciMLBase: AbstractDiffEqOperator, AbstractLinearAlgorithm
 using Setfield
 using UnPack
@@ -13,6 +12,7 @@ import Krylov
 import KrylovKit
 import IterativeSolvers
 
+using Reexport
 @reexport using SciMLBase
 
 abstract type SciMLLinearSolveAlgorithm <: SciMLBase.AbstractLinearAlgorithm end
@@ -22,6 +22,6 @@ include("factorization.jl")
 include("krylov.jl")
 
 export LUFactorization, SVDFactorization, QRFactorization
-export KrylovJL
+export KrylovJL, IterativeSolversJL, KrylovKitJL 
 
 end

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -26,7 +26,8 @@ include("wrappers.jl")
 export DefaultLinSolve
 export LUFactorization, SVDFactorization, QRFactorization
 export KrylovJL, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB,
+       KrylovJL_MINRES, 
        IterativeSolversJL, IterativeSolversJL_CG, IterativeSolversJL_GMRES,
-       IterativeSolversJL_BICGSTAB
+       IterativeSolversJL_BICGSTAB, IterativeSolversJL_MINRES
 
 end

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -17,6 +17,7 @@ using Reexport
 
 abstract type SciMLLinearSolveAlgorithm <: SciMLBase.AbstractLinearAlgorithm end
 abstract type AbstractFactorization <: SciMLLinearSolveAlgorithm end
+abstract type AbstractKrylovSubspaceMethod <: SciMLLinearSolveAlgorithm end
 
 include("common.jl")
 include("default.jl")

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -9,8 +9,9 @@ using Setfield
 using UnPack
 
 # wrap
-using Krylov
-#using IterativeSolvers
+import Krylov
+import KrylovKit
+import IterativeSolvers
 
 @reexport using SciMLBase
 

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -16,6 +16,7 @@ using Reexport
 @reexport using SciMLBase
 
 abstract type SciMLLinearSolveAlgorithm <: SciMLBase.AbstractLinearAlgorithm end
+abstract type AbstractFactorization <: SciMLLinearSolveAlgorithm end
 
 include("common.jl")
 include("default.jl")

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -26,9 +26,21 @@ include("factorization.jl")
 include("wrappers.jl")
 include("default.jl")
 
-export LUFactorization, SVDFactorization, QRFactorization, DefaultFactorization
+const IS_OPENBLAS = Ref(true)
+isopenblas() = IS_OPENBLAS[]
+
+function __init__()
+  @static if VERSION < v"1.7beta"
+    blas = BLAS.vendor()
+    IS_OPENBLAS[] = blas == :openblas64 || blas == :openblas
+  else
+    IS_OPENBLAS[] = occursin("openblas", BLAS.get_config().loaded_libs[1].libname)
+  end
+end
+
+export LUFactorization, SVDFactorization, QRFactorization, GenericFactorization
 export KrylovJL, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB,
-       KrylovJL_MINRES, 
+       KrylovJL_MINRES,
        IterativeSolversJL, IterativeSolversJL_CG, IterativeSolversJL_GMRES,
        IterativeSolversJL_BICGSTAB, IterativeSolversJL_MINRES
 export DefaultLinSolve

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -18,10 +18,15 @@ using Reexport
 abstract type SciMLLinearSolveAlgorithm <: SciMLBase.AbstractLinearAlgorithm end
 
 include("common.jl")
+include("default.jl")
 include("factorization.jl")
-include("krylov.jl")
+include("wrappers.jl")
 
+export DefaultLinSolve
 export LUFactorization, SVDFactorization, QRFactorization
-export KrylovJL, IterativeSolversJL, KrylovKitJL 
+export KrylovJL #, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB
+export IterativeSolversJL #, IterativeSolversJL_CG, IterativeSolversJL_GMRES,
+       #IterativeSolversJL_BICGSTAB
+export KrylovKitJL #, KrylovKitJL_CG, KrylovKitJL_GMRES, KrylovKitJL_BICGSTAB
 
 end

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -2,16 +2,19 @@ module LinearSolve
 
 using ArrayInterface: lu_instance
 using Base: cache_dependencies, Bool
-using Krylov
 using LinearAlgebra
 using Reexport
 using SciMLBase: AbstractDiffEqOperator, AbstractLinearAlgorithm
 using Setfield
 using UnPack
 
+# wrap
+using Krylov
+#using IterativeSolvers
+
 @reexport using SciMLBase
 
-abstract type SciMLLinearSolveAlgorithm end
+abstract type SciMLLinearSolveAlgorithm <: SciMLBase.AbstractLinearAlgorithm end
 
 include("common.jl")
 include("factorization.jl")

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -25,7 +25,7 @@ include("wrappers.jl")
 
 export DefaultLinSolve
 export LUFactorization, SVDFactorization, QRFactorization
-export KrylovJL #, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB
+export KrylovJL, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB
 export IterativeSolversJL #, IterativeSolversJL_CG, IterativeSolversJL_GMRES,
        #IterativeSolversJL_BICGSTAB
 export KrylovKitJL #, KrylovKitJL_CG, KrylovKitJL_GMRES, KrylovKitJL_BICGSTAB

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -25,9 +25,8 @@ include("wrappers.jl")
 
 export DefaultLinSolve
 export LUFactorization, SVDFactorization, QRFactorization
-export KrylovJL, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB
-export IterativeSolversJL #, IterativeSolversJL_CG, IterativeSolversJL_GMRES,
-       #IterativeSolversJL_BICGSTAB
-export KrylovKitJL #, KrylovKitJL_CG, KrylovKitJL_GMRES, KrylovKitJL_BICGSTAB
+export KrylovJL, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB,
+       IterativeSolversJL, IterativeSolversJL_CG, IterativeSolversJL_GMRES,
+       IterativeSolversJL_BICGSTAB
 
 end

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -1,8 +1,10 @@
 module LinearSolve
 
-using ArrayInterface: lu_instance
+using ArrayInterface
+using RecursiveFactorization
 using Base: cache_dependencies, Bool
 using LinearAlgebra
+using SparseArrays
 using SciMLBase: AbstractDiffEqOperator, AbstractLinearAlgorithm
 using Setfield
 using UnPack
@@ -20,15 +22,15 @@ abstract type AbstractFactorization <: SciMLLinearSolveAlgorithm end
 abstract type AbstractKrylovSubspaceMethod <: SciMLLinearSolveAlgorithm end
 
 include("common.jl")
-include("default.jl")
 include("factorization.jl")
 include("wrappers.jl")
+include("default.jl")
 
-export DefaultLinSolve
-export LUFactorization, SVDFactorization, QRFactorization
+export LUFactorization, SVDFactorization, QRFactorization, DefaultFactorization
 export KrylovJL, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB,
        KrylovJL_MINRES, 
        IterativeSolversJL, IterativeSolversJL_CG, IterativeSolversJL_GMRES,
        IterativeSolversJL_BICGSTAB, IterativeSolversJL_MINRES
+export DefaultLinSolve
 
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,12 +6,11 @@ struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tl,Tr}
     alg::Talg
     cacheval::Tc  # store alg cache here 
     isfresh::Bool # false => cacheval is set wrt A, true => update cacheval wrt A
-#
     Pl::Tl        # store final preconditioner here. not being used rn
     Pr::Tr        # wrappers are using preconditioner in cache.alg for now
 end
 
-function set_A(cache::LinearCache, A) # and ! to function name
+function set_A(cache::LinearCache, A)
     @set! cache.A = A
     @set! cache.isfresh = true
     return cache
@@ -49,10 +48,10 @@ function SciMLBase.init(prob::LinearProblem, alg, args...;
                        )
     @unpack A, b, u0, p = prob
 
-    u0 = (u0 == nothing) ? zero(b) : u0
+    u0 = (u0 === nothing) ? zero(b) : u0
 
     cacheval = init_cacheval(alg, A, b, u0)
-    isfresh = cacheval == nothing
+    isfresh = cacheval === nothing
     Tc = isfresh ? Any : typeof(cacheval)
 
     Pl = LinearAlgebra.I

--- a/src/common.jl
+++ b/src/common.jl
@@ -121,7 +121,6 @@ function (cache::LinearCache)(prob::LinearProblem, args...; kwargs...)
 end
 
 function (cache::LinearCache)(x, A, b, args...; kwargs...)
-
     prob = LinearProblem(A, b; u0=x)
     x = cache(prob, args...; kwargs...)
     return x

--- a/src/common.jl
+++ b/src/common.jl
@@ -42,6 +42,11 @@ function SciMLBase.init(
     kwargs...,
 )
     @unpack A, b, u0, p = prob
+
+    if u0 == nothing
+        u0 = zero(b)
+    end
+
     if alg isa LUFactorization
         fact = lu_instance(A)
         Tfact = typeof(fact)
@@ -52,12 +57,10 @@ function SciMLBase.init(
     Pr = LinearAlgebra.I
     Pl = LinearAlgebra.I
 
+#   @show (A, b, u0, p) |> typeof
+
     A = alias_A ? A : copy(A)
     b = alias_b ? b : copy(b)
-
-    if u0 == nothing
-        u0 = zero(b)
-    end
 
     cache = LinearCache{
         typeof(A),

--- a/src/common.jl
+++ b/src/common.jl
@@ -78,3 +78,9 @@ SciMLBase.solve(prob::LinearProblem, alg, args...; kwargs...) =
     solve(init(prob, alg, args...; kwargs...))
 
 SciMLBase.solve(cache) = solve(cache, cache.alg)
+
+function (alg::SciMLLinearSolveAlgorithm)(x,A,b,args...;u0=nothing,kwargs...)
+    prob = LinearProblem(A,b;u0=x)
+    x = solve(prob,alg,args...;kwargs...)
+    return x
+end

--- a/src/common.jl
+++ b/src/common.jl
@@ -10,29 +10,29 @@ struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tl,Tr}
     Pr::Tr
 end
 
-function set_A(cache, A) # and ! to function name
+function set_A(cache::LinearCache, A) # and ! to function name
     @set! cache.A = A
     @set! cache.isfresh = true
     return cache
 end
 
-function set_b(cache, b)
+function set_b(cache::LinearCache, b)
     @set! cache.b = b
     return cache
 end
 
-function set_u(cache, u)
+function set_u(cache::LinearCache, u)
     @set! cache.u = u
     return cache
 end
 
-function set_p(cache, p)
+function set_p(cache::LinearCache, p)
     @set! cache.p = p
 #   @set! cache.isfresh = true
     return cache
 end
 
-function set_cacheval(cache, alg_cache)
+function set_cacheval(cache::LinearCache, alg_cache)
     if cache.isfresh
         @set! cache.cacheval = alg_cache
         @set! cache.isfresh = false
@@ -53,8 +53,8 @@ function SciMLBase.init(prob::LinearProblem, alg, args...;
     end
 
     cacheval = init_cacheval(alg, A, b, u0)
-    Tc = cacheval == nothing ? Any : typeof(cacheval)
     isfresh = cacheval == nothing
+    Tc = isfresh ? Any : typeof(cacheval)
 
     Pl = LinearAlgebra.I
     Pr = LinearAlgebra.I
@@ -108,8 +108,8 @@ end
 
 function (cache::LinearCache)(prob::LinearProblem, args...; kwargs...)
 
-    if(prob.A  != cache.A) cache = set_A(cache, prob.A) end
-    if(prob.b  != cache.b) cache = set_b(cache, prob.b) end
+    if(prob.A != cache.A) cache = set_A(cache, prob.A) end
+    if(prob.b != cache.b) cache = set_b(cache, prob.b) end
 
     if(prob.u0 == nothing)
         prob.u0 = zero(x)

--- a/src/common.jl
+++ b/src/common.jl
@@ -40,7 +40,7 @@ function set_cacheval(cache, alg_cache)
     return cache
 end
 
-init_cacheval(A, alg::SciMLLinearSolveAlgorithm) = nothing
+init_cacheval(alg::SciMLLinearSolveAlgorithm, A, b, u) = nothing
 
 function SciMLBase.init(prob::LinearProblem, alg, args...;
                         alias_A = false, alias_b = false,
@@ -52,7 +52,7 @@ function SciMLBase.init(prob::LinearProblem, alg, args...;
         u0 = zero(b)
     end
 
-    cacheval = init_cacheval(prob.A, alg)
+    cacheval = init_cacheval(alg, A, b, u0)
     Tc = cacheval == nothing ? Any : typeof(cacheval)
     isfresh = cacheval == nothing
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,8 +6,9 @@ struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tl,Tr}
     alg::Talg
     cacheval::Tc  # store alg cache here 
     isfresh::Bool # false => cacheval is set wrt A, true => update cacheval wrt A
-    Pl::Tl        # store final preconditioner here
-    Pr::Tr
+#
+    Pl::Tl        # store final preconditioner here. not being used rn
+    Pr::Tr        # wrappers are using preconditioner in cache.alg for now
 end
 
 function set_A(cache::LinearCache, A) # and ! to function name

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,12 +1,14 @@
-struct LinearCache{TA,Tb,Tp,Talg,Tc,Tr,Tl}
+struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tr,Tl}
     A::TA
     b::Tb
+    u::Tu
     p::Tp
     alg::Talg
     cacheval::Tc
     isfresh::Bool
     Pr::Tr
     Pl::Tl
+#   k::Tk # iteration count
 end
 
 function set_A(cache, A)
@@ -39,7 +41,7 @@ function SciMLBase.init(
     alias_b = false,
     kwargs...,
 )
-    @unpack A, b, p = prob
+    @unpack A, b, u0, p = prob
     if alg isa LUFactorization
         fact = lu_instance(A)
         Tfact = typeof(fact)
@@ -47,15 +49,20 @@ function SciMLBase.init(
         fact = nothing
         Tfact = Any
     end
-    Pr = nothing
-    Pl = nothing
+    Pr = LinearAlgebra.I
+    Pl = LinearAlgebra.I
 
     A = alias_A ? A : copy(A)
     b = alias_b ? b : copy(b)
 
+    if u0 == nothing
+        u0 = zero(b)
+    end
+
     cache = LinearCache{
         typeof(A),
         typeof(b),
+        typeof(u0),
         typeof(p),
         typeof(alg),
         Tfact,
@@ -64,6 +71,7 @@ function SciMLBase.init(
     }(
         A,
         b,
+        u0,
         p,
         alg,
         fact,

--- a/src/common.jl
+++ b/src/common.jl
@@ -4,8 +4,8 @@ struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tl,Tr}
     u::Tu
     p::Tp
     alg::Talg
-    cacheval::Tc # store alg cache here 
-    isfresh::Bool
+    cacheval::Tc  # store alg cache here 
+    isfresh::Bool # false => cacheval is set wrt A, true => update cacheval wrt A
     Pl::Tl
     Pr::Tr
 end
@@ -28,7 +28,7 @@ end
 
 function set_p(cache, p)
     @set! cache.p = p
-    # @set! cache.isfresh = true
+#   @set! cache.isfresh = true
     return cache
 end
 
@@ -40,10 +40,7 @@ function set_cacheval(cache, alg_cache)
     return cache
 end
 
-#function init_cacheval(cacheval, alg::SciMLLinearSolveAlgorithm)
-#
-#    return
-#end
+init_cacheval(A, alg::SciMLLinearSolveAlgorithm) = nothing
 
 function SciMLBase.init(prob::LinearProblem, alg, args...;
                         alias_A = false, alias_b = false,
@@ -55,13 +52,10 @@ function SciMLBase.init(prob::LinearProblem, alg, args...;
         u0 = zero(b)
     end
 
-    if alg isa LUFactorization
-        fact = lu_instance(A)
-        Tfact = typeof(fact)
-    else
-        fact = nothing
-        Tfact = Any
-    end
+    cacheval = init_cacheval(prob.A, alg)
+    Tc = cacheval == nothing ? Any : typeof(cacheval)
+    isfresh = cacheval == nothing
+
     Pl = LinearAlgebra.I
     Pr = LinearAlgebra.I
 
@@ -74,7 +68,7 @@ function SciMLBase.init(prob::LinearProblem, alg, args...;
         typeof(u0),
         typeof(p),
         typeof(alg),
-        Tfact,
+        Tc,
         typeof(Pl),
         typeof(Pr),
     }(
@@ -83,48 +77,52 @@ function SciMLBase.init(prob::LinearProblem, alg, args...;
         u0,
         p,
         alg,
-        fact,
-        true,
+        cacheval,
+        isfresh,
         Pl,
         Pr,
     )
     return cache
 end
 
-SciMLBase.solve(prob::LinearProblem, alg, args...; kwargs...) =
-    solve(init(prob, alg, args...; kwargs...))
+SciMLBase.solve(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm,
+                args...; kwargs...) = solve(init(prob, alg, args...; kwargs...))
 
-SciMLBase.solve(cache) = solve(cache, cache.alg)
+SciMLBase.solve(cache::LinearCache, args...; kwargs...) =
+    solve(cache, cache.alg, args...; kwargs...)
 
-function (alg::SciMLLinearSolveAlgorithm)(prob::LinearProblem,args...;
-                                          u0=nothing,kwargs...)
+## make alg callable
+
+function (alg::SciMLLinearSolveAlgorithm)(prob::LinearProblem,args...; kwargs...)
     x = solve(prob, alg, args...; kwargs...)
     return x
 end
 
 function (alg::SciMLLinearSolveAlgorithm)(x,A,b,args...;u0=nothing,kwargs...)
-    prob = LinearProblem(A,b;u0=x)
+    prob = LinearProblem(A, b; u0=x)
     x = alg(prob, args...; kwargs...)
     return x
 end
 
-function (cache::LinearCache)(prob::LinearProblem,args...;u0=nothing,kwargs...)
+## make cache callable - and reuse
 
-    if prob.u0 == nothing
+function (cache::LinearCache)(prob::LinearProblem, args...; kwargs...)
+
+    if(prob.A  != cache.A) cache = set_A(cache, prob.A) end
+    if(prob.b  != cache.b) cache = set_b(cache, prob.b) end
+
+    if(prob.u0 == nothing)
         prob.u0 = zero(x)
     end
 
-    cache = set_A(cache, prob.A)
-    cache = set_b(cache, prob.b)
     cache = set_u(cache, prob.u0)
-
-    x = solve(cache,args...;kwargs...)
+    x = solve(cache, args...; kwargs...)
     return x
 end
 
-function (cache::LinearCache)(x,A,b,args...;u0=nothing,kwargs...)
+function (cache::LinearCache)(x, A, b, args...; kwargs...)
 
-    prob = LinearProblem(A,b;u0=x)
+    prob = LinearProblem(A, b; u0=x)
     x = cache(prob, args...; kwargs...)
     return x
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -48,9 +48,7 @@ function SciMLBase.init(prob::LinearProblem, alg, args...;
                        )
     @unpack A, b, u0, p = prob
 
-    if u0 == nothing
-        u0 = zero(b)
-    end
+    u0 = (u0 == nothing) ? zero(b) : u0
 
     cacheval = init_cacheval(alg, A, b, u0)
     isfresh = cacheval == nothing

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,7 +6,7 @@ struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tl,Tr}
     alg::Talg
     cacheval::Tc  # store alg cache here 
     isfresh::Bool # false => cacheval is set wrt A, true => update cacheval wrt A
-    Pl::Tl
+    Pl::Tl        # store final preconditioner here
     Pr::Tr
 end
 

--- a/src/default.jl
+++ b/src/default.jl
@@ -22,7 +22,8 @@ function SciMLBase.solve(cache::LinearCache, alg::DefaultLinSolve,
     @unpack A = cache
 
     if alg.isset
-      linalg = if A isa Matrix
+      linalg =
+      if A isa Matrix
           if ArrayInterface.can_setindex(x) && (size(A,1) <= 100 ||
                                                 (p.openblas && size(A,1) <= 500)
                                                )
@@ -37,7 +38,7 @@ function SciMLBase.solve(cache::LinearCache, alg::DefaultLinSolve,
       elseif A isa SparseMatrixCSC
           LUFactorization()
       elseif ArrayInterface.isstructured(A)
-          DefaultFactorization() # change fact_alg=LinearAlgebra.factorize
+          DefaultFactorization()
       elseif !(A isa AbstractDiffEqOperator)
           QRFactorization()
       else

--- a/src/default.jl
+++ b/src/default.jl
@@ -1,5 +1,5 @@
 #
-mutable struct DefaultLinSolve
+mutable struct DefaultLinSolve <: SciMLLinearSolveAlgorithm
     iterable
 end
 
@@ -13,6 +13,3 @@ function SciMLBase.solve(cache::LinearCache,
 
     return A \ u
 end
-
-
-function

--- a/src/default.jl
+++ b/src/default.jl
@@ -1,15 +1,51 @@
-#
-mutable struct DefaultLinSolve <: SciMLLinearSolveAlgorithm
-    iterable
+## Default algorithm
+
+struct DefaultLinSolve{Ta} <: SciMLLinearSolveAlgorithm
+    linalg::Ta
+    ifopenblas::Union{Bool,Nothing}
+    isset::Bool # true => do nothing, false => find alg
 end
 
-DefaultLinSolve() = DefaultLinSolve(nothing, nothing, nothing)
+DefaultLinSolve() = DefaultLinSolve(nothing, nothing, true)
 
-function SciMLBase.solve(cache::LinearCache,
-                         alg::DefaultLinSolve,
-                         args...;kwargs...)
-    @unpack iterable = alg
-    @unpack A, b, u, cacheval = cache
+function isopenblas()
+    @static if VERSION < v"1.7beta"
+        blas = BLAS.vendor()
+        blas == :openblas64 || blas == :openblas
+    else
+        occursin("openblas", BLAS.get_config().loaded_libs[1].libname)
+    end
+end
 
-    return A \ u
+function SciMLBase.solve(cache::LinearCache, alg::DefaultLinSolve,
+                         args...; kwargs...)
+    @unpack A = cache
+
+    if alg.isset
+      linalg = if A isa Matrix
+          if ArrayInterface.can_setindex(x) && (size(A,1) <= 100 ||
+                                                (p.openblas && size(A,1) <= 500)
+                                               )
+              DefaultFactorization(;fact_alg=:(RecursiveFactorization.lu!))
+          else
+              LUFactorization()
+          end
+      elseif A isa Union{Tridiagonal,} # ForwardSensitivityJacobian
+          DefaultFactorization(;fact_alg=lu!)
+      elseif A isa Union{SymTridiagonal}
+          DefaultFactorization(;fact_alg=ldlt!)
+      elseif A isa SparseMatrixCSC
+          LUFactorization()
+      elseif ArrayInterface.isstructured(A)
+          DefaultFactorization() # change fact_alg=LinearAlgebra.factorize
+      elseif !(A isa AbstractDiffEqOperator)
+          QRFactorization()
+      else
+          IterativeSolversJL_GMRES()
+      end
+
+      @set! alg.linalg = linalg
+    end
+
+    SciMLBase.solve(cache, alg.linalg, args...; kwargs...)
 end

--- a/src/default.jl
+++ b/src/default.jl
@@ -1,0 +1,18 @@
+#
+mutable struct DefaultLinSolve
+    iterable
+end
+
+DefaultLinSolve() = DefaultLinSolve(nothing, nothing, nothing)
+
+function SciMLBase.solve(cache::LinearCache,
+                         alg::DefaultLinSolve,
+                         args...;kwargs...)
+    @unpack iterable = alg
+    @unpack A, b, u, cacheval = cache
+
+    return A \ u
+end
+
+
+function

--- a/src/default.jl
+++ b/src/default.jl
@@ -31,9 +31,9 @@ function SciMLBase.solve(cache::LinearCache, alg::DefaultLinSolve,
           else
               LUFactorization()
           end
-      elseif A isa Union{Tridiagonal,} # ForwardSensitivityJacobian
+      elseif A isa Tridiagonal
           DefaultFactorization(;fact_alg=lu!)
-      elseif A isa Union{SymTridiagonal}
+      elseif A isa SymTridiagonal
           DefaultFactorization(;fact_alg=ldlt!)
       elseif A isa SparseMatrixCSC
           LUFactorization()

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -1,4 +1,3 @@
-
 function SciMLBase.solve(cache::LinearCache, alg::AbstractFactorization)
     if cache.isfresh
         fact = init_cacheval(alg, cache.A, cache.b, cache.u)
@@ -71,18 +70,18 @@ function init_cacheval(alg::SVDFactorization, A, b, u)
     return fact
 end
 
-## DefaultFactorization
+## GenericFactorization
 
-struct DefaultFactorization{F} <: AbstractFactorization
+struct GenericFactorization{F} <: AbstractFactorization
     fact_alg::F
 end
 
-DefaultFactorization(;fact_alg = LinearAlgebra.factorize) =
-    DefaultFactorization(fact_alg)
+GenericFactorization(;fact_alg = LinearAlgebra.factorize) =
+    GenericFactorization(fact_alg)
 
-function init_cacheval(alg::DefaultFactorization, A, b, u)
+function init_cacheval(alg::GenericFactorization, A, b, u)
     A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||
-        error("DefaultFactorization is not defined for $(typeof(A))")
+        error("GenericFactorization is not defined for $(typeof(A))")
 
     fact = alg.fact_alg(A)
     return fact

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -72,3 +72,15 @@ function init_cacheval(alg::SVDFactorization, A, b, u)
     return fact
 end
 
+## DefaultFactorization
+
+struct DefaultFactorization <: AbstractFactorization
+end
+
+function init_cacheval(alg::DefaultFactorization, A, b, u)
+    A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||
+        error("DefaultFactorization is not defined for $(typeof(A))")
+
+    fact = factorize(A)
+    return fact
+end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -74,13 +74,20 @@ end
 
 ## DefaultFactorization
 
-struct DefaultFactorization <: AbstractFactorization
+struct DefaultFactorization{F} <: AbstractFactorization
+    fact_alg::F
 end
+
+DefaultFactorization(
+                     # https://github.com/SciML/SciMLBase.jl/pull/119
+#                    ;fact_alg = LinearAlgebra.factorize
+                     ;fact_alg = lu!
+                    ) = DefaultFactorization(fact_alg)
 
 function init_cacheval(alg::DefaultFactorization, A, b, u)
     A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||
         error("DefaultFactorization is not defined for $(typeof(A))")
 
-    fact = factorize(A)
+    fact = alg.fact_alg(A)
     return fact
 end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -16,7 +16,7 @@ function SciMLBase.solve(cache::LinearCache, alg::LUFactorization)
     cache.A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||
         error("LU is not defined for $(typeof(prob.A))")
     cache = set_cacheval(cache, lu!(cache.A, alg.pivot))
-    ldiv!(cache.cacheval, cache.b)
+    ldiv!(cache.u,cache.cacheval, cache.b)
 end
 
 struct QRFactorization{P} <: SciMLLinearSolveAlgorithm
@@ -40,7 +40,7 @@ function SciMLBase.solve(cache::LinearCache, alg::QRFactorization)
         cache,
         qr!(cache.A.A, alg.pivot; blocksize = alg.blocksize),
     )
-    ldiv!(cache.cacheval, cache.b)
+    ldiv!(cache.u,cache.cacheval, cache.b)
 end
 
 struct SVDFactorization{A} <: SciMLLinearSolveAlgorithm
@@ -54,5 +54,5 @@ function SciMLBase.solve(cache::LinearCache, alg::SVDFactorization)
     cache.A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||
         error("SVD is not defined for $(typeof(prob.A))")
     cache = set_cacheval(cache, svd!(cache.A; full = alg.full, alg = alg.alg))
-    ldiv!(cache.cacheval, cache.b)
+    ldiv!(cache.u,cache.cacheval, cache.b)
 end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -1,5 +1,5 @@
 
-struct LUFactorization{P} <: AbstractLinearAlgorithm
+struct LUFactorization{P} <: SciMLLinearSolveAlgorithm
     pivot::P
 end
 
@@ -19,7 +19,7 @@ function SciMLBase.solve(cache::LinearCache, alg::LUFactorization)
     ldiv!(cache.cacheval, cache.b)
 end
 
-struct QRFactorization{P} <: AbstractLinearAlgorithm
+struct QRFactorization{P} <: SciMLLinearSolveAlgorithm
     pivot::P
     blocksize::Int
 end
@@ -43,7 +43,7 @@ function SciMLBase.solve(cache::LinearCache, alg::QRFactorization)
     ldiv!(cache.cacheval, cache.b)
 end
 
-struct SVDFactorization{A} <: AbstractLinearAlgorithm
+struct SVDFactorization{A} <: SciMLLinearSolveAlgorithm
     full::Bool
     alg::A
 end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -15,7 +15,8 @@ end
 function SciMLBase.solve(cache::LinearCache, alg::LUFactorization)
     cache.A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||
         error("LU is not defined for $(typeof(prob.A))")
-    cache = set_cacheval(cache, lu!(cache.A, alg.pivot))
+    fact = lu!(cache.A, alg.pivot)
+    cache = set_cacheval(cache, fact)
     ldiv!(cache.u,cache.cacheval, cache.b)
 end
 
@@ -36,10 +37,8 @@ end
 function SciMLBase.solve(cache::LinearCache, alg::QRFactorization)
     cache.A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||
         error("QR is not defined for $(typeof(prob.A))")
-    cache = set_cacheval(
-        cache,
-        qr!(cache.A.A, alg.pivot; blocksize = alg.blocksize),
-    )
+    fact = qr!(cache.A.A, alg.pivot; blocksize = alg.blocksize)
+    cache = set_cacheval(cache, fact)
     ldiv!(cache.u,cache.cacheval, cache.b)
 end
 
@@ -53,6 +52,7 @@ SVDFactorization() = SVDFactorization(false, LinearAlgebra.DivideAndConquer())
 function SciMLBase.solve(cache::LinearCache, alg::SVDFactorization)
     cache.A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||
         error("SVD is not defined for $(typeof(cache.A))")
-    cache = set_cacheval(cache, svd!(cache.A; full = alg.full, alg = alg.alg))
+    fact = svd!(cache.A; full = alg.full, alg = alg.alg)
+    cache = set_cacheval(cache, fact)
     ldiv!(cache.u,cache.cacheval, cache.b)
 end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -52,7 +52,7 @@ SVDFactorization() = SVDFactorization(false, LinearAlgebra.DivideAndConquer())
 
 function SciMLBase.solve(cache::LinearCache, alg::SVDFactorization)
     cache.A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||
-        error("SVD is not defined for $(typeof(prob.A))")
+        error("SVD is not defined for $(typeof(cache.A))")
     cache = set_cacheval(cache, svd!(cache.A; full = alg.full, alg = alg.alg))
     ldiv!(cache.u,cache.cacheval, cache.b)
 end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -1,5 +1,4 @@
 
-
 function SciMLBase.solve(cache::LinearCache, alg::AbstractFactorization)
     if cache.isfresh
         fact = init_cacheval(alg, cache.A, cache.b, cache.u)
@@ -78,11 +77,8 @@ struct DefaultFactorization{F} <: AbstractFactorization
     fact_alg::F
 end
 
-DefaultFactorization(
-                     # https://github.com/SciML/SciMLBase.jl/pull/119
-#                    ;fact_alg = LinearAlgebra.factorize
-                     ;fact_alg = lu!
-                    ) = DefaultFactorization(fact_alg)
+DefaultFactorization(;fact_alg = LinearAlgebra.factorize) =
+    DefaultFactorization(fact_alg)
 
 function init_cacheval(alg::DefaultFactorization, A, b, u)
     A isa Union{AbstractMatrix,AbstractDiffEqOperator} ||

--- a/src/krylov.jl
+++ b/src/krylov.jl
@@ -1,10 +1,14 @@
+## Krylov.jl
+
+# place Krylov.CGsolver in LinearCache.cacheval, and resule
+
 struct KrylovJL{A,K} <: SciMLLinearSolveAlgorithm
     solver::Function
     args::A
     kwargs::K
 end
 
-function KrylovJL(args...; solver = gmres, kwargs...)
+function KrylovJL(args...; solver = Krylov.gmres, kwargs...)
     return KrylovJL(solver, args, kwargs)
 end
 
@@ -15,3 +19,14 @@ function SciMLBase.solve(cache::LinearCache, alg::KrylovJL,args...;kwargs...)
     retcode = stats.solved ? :Success : :Failure
     return u #SciMLBase.build_solution(prob, alg, x, resid; retcode = retcode)
 end
+
+## IterativeSolvers.jl
+
+struct IterativeSolversJL{A,K} <: SciMLLinearSolveAlgorithm
+    solver::Function
+    args::A
+    kwargs::K
+end
+
+## KrylovKit.jl
+

--- a/src/krylov.jl
+++ b/src/krylov.jl
@@ -9,9 +9,9 @@ function KrylovJL(args...; solver = gmres, kwargs...)
 end
 
 function SciMLBase.solve(cache::LinearCache, alg::KrylovJL,args...;kwargs...)
-    @unpack A, b, Pl,Pr = cache
-    x, stats = alg.solver(A, b, args...; M=Pl, N=Pr, kwargs...)
-    resid = A * x - b
+    @unpack A, b, u, Pr, Pl = cache
+    u, stats = alg.solver(A, b, args...; M=Pl, N=Pr, kwargs...)
+    resid = A * u - b
     retcode = stats.solved ? :Success : :Failure
-    return x #SciMLBase.build_solution(prob, alg, x, resid; retcode = retcode)
+    return u #SciMLBase.build_solution(prob, alg, x, resid; retcode = retcode)
 end

--- a/src/krylov.jl
+++ b/src/krylov.jl
@@ -1,18 +1,16 @@
-struct KrylovJL{AT,bT,A,K} <: SciMLLinearSolveAlgorithm
+struct KrylovJL{A,K} <: SciMLLinearSolveAlgorithm
     solver::Function
-    A::AT
-    b::bT
     args::A
     kwargs::K
 end
 
-function KrylovJL(A, b, args...; solver = gmres, kwargs...)
-    return KrylovJL(solver, A, b, args, kwargs)
+function KrylovJL(args...; solver = gmres, kwargs...)
+    return KrylovJL(solver, args, kwargs)
 end
 
 function SciMLBase.solve(cache::LinearCache, alg::KrylovJL,args...;kwargs...)
-    @unpack A, b = cache
-    x, stats = alg.solver(A, b, args...; kwargs...)
+    @unpack A, b, Pl,Pr = cache
+    x, stats = alg.solver(A, b, args...; M=Pl, N=Pr, kwargs...)
     resid = A * x - b
     retcode = stats.solved ? :Success : :Failure
     return x #SciMLBase.build_solution(prob, alg, x, resid; retcode = retcode)

--- a/src/krylov.jl
+++ b/src/krylov.jl
@@ -10,10 +10,10 @@ function KrylovJL(A, b, args...; solver = gmres, kwargs...)
     return KrylovJL(solver, A, b, args, kwargs)
 end
 
-function SciMLBase.solve(prob::LinearProblem, alg::KrylovJL, args...; kwargs...)
-    @unpack A, b, p = prob
+function SciMLBase.solve(cache::LinearCache, alg::KrylovJL,args...;kwargs...)
+    @unpack A, b = cache
     x, stats = alg.solver(A, b, args...; kwargs...)
     resid = A * x - b
     retcode = stats.solved ? :Success : :Failure
-    return SciMLBase.build_solution(prob, alg, x, resid; retcode = retcode)
+    return x #SciMLBase.build_solution(prob, alg, x, resid; retcode = retcode)
 end

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -65,7 +65,7 @@ KrylovJL_MINRES(args...;kwargs...) =
     KrylovJL(args...; KrylovAlg=Krylov.minres!, kwargs...)
 
 function get_KrylovJL_solver(KrylovAlg)
-    solver = 
+    KS = 
     if     (KrylovAlg === Krylov.lsmr!      ) Krylov.LsmrSolver
     elseif (KrylovAlg === Krylov.cgs!       ) Krylov.CgsSolver
     elseif (KrylovAlg === Krylov.usymlq!    ) Krylov.UsymlqSolver
@@ -99,7 +99,7 @@ function get_KrylovJL_solver(KrylovAlg)
     elseif (KrylovAlg === Krylov.fom!       ) Krylov.FomSolver
     end
 
-    return solver
+    return KS
 end
 
 function init_cacheval(alg::KrylovJL, A, b, u)
@@ -107,17 +107,18 @@ function init_cacheval(alg::KrylovJL, A, b, u)
     KS = get_KrylovJL_solver(alg.KrylovAlg)
 
     solver = if(
-        KS === Krylov.DqgmresSolver ||
-        KS === Krylov.DiomSolver    ||
-        KS === Krylov.GmresSolver   ||
-        KS === Krylov.FomSolver
+        alg.KrylovAlg === Krylov.dqgmres! ||
+        alg.KrylovAlg === Krylov.diom!    ||
+        alg.KrylovAlg === Krylov.gmres!   ||
+        alg.KrylovAlg === Krylov.fom!
        )
         KS(A, b, alg.gmres_restart)
-    elseif(KS === Krylov.MinresSolver ||
-           KS === Krylov.SymmlqSolver ||
-           KS === Krylov.LslqSolver   ||
-           KS === Krylov.LsqrSolver   ||
-           KS === Krylov.LsmrSolver
+    elseif(
+           alg.KrylovAlg === Krylov.minres! ||
+           alg.KrylovAlg === Krylov.symmlq! ||
+           alg.KrylovAlg === Krylov.lslq!   ||
+           alg.KrylovAlg === Krylov.lsqr!   ||
+           alg.KrylovAlg === Krylov.lsmr!
           )
         (alg.window != 0) ? KS(A,b; window=alg.window) : KS(A, b)
     else

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -138,13 +138,13 @@ function SciMLBase.solve(cache::LinearCache, alg::KrylovJL; kwargs...)
     args   = (cache.cacheval, cache.A, cache.b)
     kwargs = (atol=abstol, rtol=reltol, itmax=maxiter, alg.kwargs...)
 
-    if cache.cacheval == Krylov.CgSolver
+    if cache.cacheval == Krylov.GmresSolver
+        Krylov.solve!(args...; M=alg.Pl, N=alg.Pr,
+                      kwargs...)
+    elseif cache.cacheval == Krylov.CgSolver
         alg.Pr != LinearAlgebra.I  &&
             @warn "$(alg.KrylovAlg) doesn't support right preconditioning."
         Krylov.solve!(args...; M=alg.Pl,
-                      kwargs...)
-    elseif cache.cacheval == Krylov.GmresSolver
-        Krylov.solve!(args...; M=alg.Pl, N=alg.Pr,
                       kwargs...)
     else
         Krylov.solve!(args...; M=alg.Pl, N=alg.Pr,

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -1,30 +1,127 @@
+
+"""
+TODO
+    - account for standard kwargs: abstol, reltol, maxiter, restart, window
+        - KrylovJL: memory, window <-- Solver, itmax, atol, rtol <-- Solve
+        - IterativeSolversJL: restart
+"""
+
+
+## Preconditioners
+
+struct ScaleVector{T}
+    s::T
+    isleft::Bool
+end
+
+function LinearAlgebra.ldiv!(v::ScaleVector, x)
+end
+
+function LinearAlgebra.ldiv!(y, v::ScaleVector, x)
+end
+
+struct ComposePreconditioner{Ti,To}
+    inner::Ti
+    outer::To
+    isleft::Bool
+end
+
+function LinearAlgebra.ldiv!(v::ComposePreconditioner, x)
+    @unpack inner, outer, isleft = v
+end
+
+function LinearAlgebra.ldiv!(y, v::ComposePreconditioner, x)
+    @unpack inner, outer, isleft = v
+end
+
 ## Krylov.jl
 
-struct KrylovJL{F,A,K} <: SciMLLinearSolveAlgorithm
+struct KrylovJL{F,Tl,Tr,A,K, T, I} <: SciMLLinearSolveAlgorithm
     KrylovAlg::F
+    Pl::Tl
+    Pr::Tr
+    abstol::T
+    reltol::T
+    maxiter::I
+    restart::I
+    window::I
     args::A
     kwargs::K
 end
 
-function KrylovJL(args...; KrylovAlg = Krylov.gmres!, kwargs...)
-    return KrylovJL(KrylovAlg, args, kwargs)
+function KrylovJL(args...; KrylovAlg = Krylov.gmres!, Pl=I, Pr=I,
+                  abstol=0.0, reltol=0.0, maxiter=0, # for solver call
+                  restart=20, window=0,              # for building solver
+                  kwargs...)
+
+    return KrylovJL(KrylovAlg, Pl, Pr, abstol, reltol, maxiter,
+                    restart, window,
+                    args, kwargs)
 end
 
 KrylovJL_CG(args...;kwargs...) = KrylovJL(Krylov.cg!, args...; kwargs...)
 KrylovJL_GMRES(args...;kwargs...) = KrylovJL(Krylov.gmres!, args...; kwargs...)
 KrylovJL_BICGSTAB(args...;kwargs...) = KrylovJL(Krylov.bicgstab!, args...; kwargs...)
 
+const KrylovJL_solvers = Dict(
+  (Krylov.lsmr!       => Krylov.LsmrSolver          ),
+  (Krylov.cgs!        => Krylov.CgsSolver           ),
+  (Krylov.usymlq!     => Krylov.UsymlqSolver        ),
+  (Krylov.lnlq!       => Krylov.LnlqSolver          ),
+  (Krylov.bicgstab!   => Krylov.BicgstabSolver      ),
+  (Krylov.crls!       => Krylov.CrlsSolver          ),
+  (Krylov.lsqr!       => Krylov.LsqrSolver          ),
+  (Krylov.minres!     => Krylov.MinresSolver        ),
+  (Krylov.cgne!       => Krylov.CgneSolver          ),
+  (Krylov.dqgmres!    => Krylov.DqgmresSolver       ),
+  (Krylov.symmlq!     => Krylov.SymmlqSolver        ),
+  (Krylov.trimr!      => Krylov.TrimrSolver         ),
+  (Krylov.usymqr!     => Krylov.UsymqrSolver        ),
+  (Krylov.bilqr!      => Krylov.BilqrSolver         ),
+  (Krylov.cr!         => Krylov.CrSolver            ),
+  (Krylov.craigmr!    => Krylov.CraigmrSolver       ),
+  (Krylov.tricg!      => Krylov.TricgSolver         ),
+  (Krylov.craig!      => Krylov.CraigSolver         ),
+  (Krylov.diom!       => Krylov.DiomSolver          ),
+  (Krylov.lslq!       => Krylov.LslqSolver          ),
+  (Krylov.trilqr!     => Krylov.TrilqrSolver        ),
+  (Krylov.crmr!       => Krylov.CrmrSolver          ),
+  (Krylov.cg!         => Krylov.CgSolver            ),
+  (Krylov.cg_lanczos! => Krylov.CgLanczosShiftSolver),
+  (Krylov.cgls!       => Krylov.CglsSolver          ),
+  (Krylov.cg_lanczos! => Krylov.CgLanczosSolver     ),
+  (Krylov.bilq!       => Krylov.BilqSolver          ),
+  (Krylov.minres_qlp! => Krylov.MinresQlpSolver     ),
+  (Krylov.qmr!        => Krylov.QmrSolver           ),
+  (Krylov.gmres!      => Krylov.GmresSolver         ),
+  (Krylov.fom!        => Krylov.FomSolver           ),
+ )
+
 function init_cacheval(alg::KrylovJL, A, b, u)
-    cacheval = if alg.KrylovAlg === Krylov.cg!
-        Krylov.CgSolver(A,b)
-    elseif alg.KrylovAlg === Krylov.gmres!
-        Krylov.GmresSolver(A,b,20)
-    elseif alg.KrylovAlg === Krylov.bicgstab!
-        Krylov.BicgstabSolver(A,b)
+
+    KS = KrylovJL_solvers[alg.KrylovAlg]
+
+    solver =
+    if (KS === Krylov.DqgmresSolver ||
+        KS === Krylov.DiomSolver    ||
+        KS === Krylov.GmresSolver   ||
+        KS === Krylov.FormSovler
+       )
+        KS(A, b, alg.restart)
+    elseif(KS === Krylov.MinresSolver ||
+           KS === Krylov.SymmlqSolver ||
+           KS === Krylov.LslqSolver   ||
+           KS === Krylov.LsqrSolver   ||
+           KS === Krylov.LsmrSolver
+          )
+        (alg.window != 0) ? KS(A,b; window=alg.window) : KS(A, b)
     else
-        nothing
+        KS(A, b)
     end
-    return cacheval
+
+    solver.x = u
+
+    return solver
 end
 
 function SciMLBase.solve(cache::LinearCache, alg::KrylovJL; kwargs...)
@@ -33,54 +130,84 @@ function SciMLBase.solve(cache::LinearCache, alg::KrylovJL; kwargs...)
         cache = set_cacheval(cache, solver)
     end
 
-    cache.cacheval.x = cache.u
-    alg.KrylovAlg(cache.cacheval, cache.A, cache.b;
-                  M=cache.Pl, N=cache.Pr, alg.kwargs...)
+    abstol  = (alg.abstol == 0) ? √eps(eltype(cache.b)) : alg.abstol
+    reltol  = (alg.reltol == 0) ? √eps(eltype(cache.b)) : alg.reltol
+    maxiter = (alg.reltol == 0) ? length(cache.b)       : alg.maxiter
+
+    Krylov.solve!(cache.cacheval, cache.A, cache.b;
+                  M=cache.Pl, N=cache.Pr,
+                  atol = abstol, rtol = reltol, itmax = maxiter,
+                  alg.kwargs...)
 
     return cache.u
 end
 
 ## IterativeSolvers.jl
 
-struct IterativeSolversJL{F,A,K} <: SciMLLinearSolveAlgorithm
+struct IterativeSolversJL{F,Tl,Tr,A,K} <: SciMLLinearSolveAlgorithm
     generate_iterator::F
+    Pl::Tl
+    Pr::Tr
     args::A
     kwargs::K
+#   abstol::T
+#   reltol::T
+#   maxiter::I
+#   restart::I
 end
 
 function IterativeSolversJL(args...;
+                            Pl=IterativeSolvers.Identity(),
+                            Pr=IterativeSolvers.Identity(),
                             generate_iterator = IterativeSolvers.gmres_iterable!,
                             kwargs...)
-    return IterativeSolversJL(generate_iterator, args, kwargs)
+    return IterativeSolversJL(generate_iterator, Pl, Pr, args, kwargs)
 end
 
-#IterativeSolversJL_CG(args...; kwargs...)
-#    = IterativeSolversJL(IterativeSolvers.cg_iterator!, args...; kwargs...)
-#IterativeSolversJL_GMRES(args...;kwargs...)
-#    = IterativeSolversJL(IterativeSolvers.gmres_iterable!, args...; kwargs...)
-#IterativeSolversJL_BICGSTAB(args...;kwargs...)
-#    = IterativeSolversJL(IterativeSolvers.bicgstabl_iterator!, args...;kwargs...)
+IterativeSolversJL_CG(args...; kwargs...) =
+    IterativeSolversJL(IterativeSolvers.cg_iterator!, args...; kwargs...)
+IterativeSolversJL_GMRES(args...;kwargs...) =
+    IterativeSolversJL(IterativeSolvers.gmres_iterable!, args...; kwargs...)
+IterativeSolversJL_BICGSTAB(args...;kwargs...) =
+    IterativeSolversJL(IterativeSolvers.bicgstabl_iterator!, args...;kwargs...)
 
-function init_cacheval(alg::IterativeSolversJL, A, b, u)
+function init_cacheval(alg::IterativeSolversJL, A, b, u, Pl, Pr)
+    Pl = (Pl == LinearAlgebra.I) ? IterativeSolvers.Identity() : Pl
+    Pr = (Pr == LinearAlgebra.I) ? IterativeSolvers.Identity() : Pr
+
+    # standard kwargs: abstol, reltol
+    #
+    # cg: kw: maxiter
+    # gmres:  kw: restart=20, maxiter=length(b)
+    # bicgstabl: kw: max_mv_products
+
     cacheval = if alg.generate_iterator === IterativeSolvers.cg_iterator!
-        alg.generate_iterator(u, A, b)
+        Pr != IterativeSolvers.Identity() &&
+            @warn "$(alg.generate_iterator) doesn't support right preconditioning"
+        alg.generate_iterator(u, A, b, Pl; alg.kwargs...)
     elseif alg.generate_iterator === IterativeSolvers.gmres_iterable!
-        alg.generate_iterator(u, A, b)
+        alg.generate_iterator(u, A, b; Pl=Pl, Pr=Pr, alg.kwargs...)
     elseif alg.generate_iterator === IterativeSolvers.bicgstabl_iterator!
-        alg.generate_iterator(u, A, b)
+        Pr != IterativeSolvers.Identity() &&
+            @warn "$(alg.generate_iterator) doesn't support right preconditioning"
+        alg.generate_iterator(u, A, b, alg.args...; Pl=Pl, alg.kwargs...)
     else
-        alg.generate_iterator(u, A, b)
+        alg.generate_iterator(u, A, b, alg.args...; alg.kwargs...)
     end
     return cacheval
 end
 
 function SciMLBase.solve(cache::LinearCache, alg::IterativeSolversJL; kwargs...)
     if cache.isfresh
-        solver = init_cacheval(alg, cache.A, cache.b, cache.u)
+        solver = init_cacheval(alg, cache.A, cache.b, cache.u,
+                               cache.Pl,  cache.Pr)
         cache = set_cacheval(cache, solver)
     end
 
-    for resi in cache.cacheval end
+    for resi in cache.cacheval
+        # allow for verbose, log
+        # inject specific code into KSP solve
+    end
 
     return cache.u
 end

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -64,43 +64,47 @@ KrylovJL_BICGSTAB(args...;kwargs...) =
 KrylovJL_MINRES(args...;kwargs...) =
     KrylovJL(args...; KrylovAlg=Krylov.minres!, kwargs...)
 
-const KrylovJL_solvers = Dict(
-  (Krylov.lsmr!       => Krylov.LsmrSolver          ),
-  (Krylov.cgs!        => Krylov.CgsSolver           ),
-  (Krylov.usymlq!     => Krylov.UsymlqSolver        ),
-  (Krylov.lnlq!       => Krylov.LnlqSolver          ),
-  (Krylov.bicgstab!   => Krylov.BicgstabSolver      ),
-  (Krylov.crls!       => Krylov.CrlsSolver          ),
-  (Krylov.lsqr!       => Krylov.LsqrSolver          ),
-  (Krylov.minres!     => Krylov.MinresSolver        ),
-  (Krylov.cgne!       => Krylov.CgneSolver          ),
-  (Krylov.dqgmres!    => Krylov.DqgmresSolver       ),
-  (Krylov.symmlq!     => Krylov.SymmlqSolver        ),
-  (Krylov.trimr!      => Krylov.TrimrSolver         ),
-  (Krylov.usymqr!     => Krylov.UsymqrSolver        ),
-  (Krylov.bilqr!      => Krylov.BilqrSolver         ),
-  (Krylov.cr!         => Krylov.CrSolver            ),
-  (Krylov.craigmr!    => Krylov.CraigmrSolver       ),
-  (Krylov.tricg!      => Krylov.TricgSolver         ),
-  (Krylov.craig!      => Krylov.CraigSolver         ),
-  (Krylov.diom!       => Krylov.DiomSolver          ),
-  (Krylov.lslq!       => Krylov.LslqSolver          ),
-  (Krylov.trilqr!     => Krylov.TrilqrSolver        ),
-  (Krylov.crmr!       => Krylov.CrmrSolver          ),
-  (Krylov.cg!         => Krylov.CgSolver            ),
-  (Krylov.cg_lanczos! => Krylov.CgLanczosShiftSolver),
-  (Krylov.cgls!       => Krylov.CglsSolver          ),
-  (Krylov.cg_lanczos! => Krylov.CgLanczosSolver     ),
-  (Krylov.bilq!       => Krylov.BilqSolver          ),
-  (Krylov.minres_qlp! => Krylov.MinresQlpSolver     ),
-  (Krylov.qmr!        => Krylov.QmrSolver           ),
-  (Krylov.gmres!      => Krylov.GmresSolver         ),
-  (Krylov.fom!        => Krylov.FomSolver           ),
- )
+function get_KrylovJL_solver(KrylovAlg)
+    solver = 
+    if     (KrylovAlg === Krylov.lsmr!      ) Krylov.LsmrSolver
+    elseif (KrylovAlg === Krylov.cgs!       ) Krylov.CgsSolver
+    elseif (KrylovAlg === Krylov.usymlq!    ) Krylov.UsymlqSolver
+    elseif (KrylovAlg === Krylov.lnlq!      ) Krylov.LnlqSolver
+    elseif (KrylovAlg === Krylov.bicgstab!  ) Krylov.BicgstabSolver
+    elseif (KrylovAlg === Krylov.crls!      ) Krylov.CrlsSolver
+    elseif (KrylovAlg === Krylov.lsqr!      ) Krylov.LsqrSolver
+    elseif (KrylovAlg === Krylov.minres!    ) Krylov.MinresSolver
+    elseif (KrylovAlg === Krylov.cgne!      ) Krylov.CgneSolver
+    elseif (KrylovAlg === Krylov.dqgmres!   ) Krylov.DqgmresSolver
+    elseif (KrylovAlg === Krylov.symmlq!    ) Krylov.SymmlqSolver
+    elseif (KrylovAlg === Krylov.trimr!     ) Krylov.TrimrSolver
+    elseif (KrylovAlg === Krylov.usymqr!    ) Krylov.UsymqrSolver
+    elseif (KrylovAlg === Krylov.bilqr!     ) Krylov.BilqrSolver
+    elseif (KrylovAlg === Krylov.cr!        ) Krylov.CrSolver
+    elseif (KrylovAlg === Krylov.craigmr!   ) Krylov.CraigmrSolver
+    elseif (KrylovAlg === Krylov.tricg!     ) Krylov.TricgSolver
+    elseif (KrylovAlg === Krylov.craig!     ) Krylov.CraigSolver
+    elseif (KrylovAlg === Krylov.diom!      ) Krylov.DiomSolver
+    elseif (KrylovAlg === Krylov.lslq!      ) Krylov.LslqSolver
+    elseif (KrylovAlg === Krylov.trilqr!    ) Krylov.TrilqrSolver
+    elseif (KrylovAlg === Krylov.crmr!      ) Krylov.CrmrSolver
+    elseif (KrylovAlg === Krylov.cg!        ) Krylov.CgSolver
+    elseif (KrylovAlg === Krylov.cg_lanczos!) Krylov.CgLanczosShiftSolver
+    elseif (KrylovAlg === Krylov.cgls!      ) Krylov.CglsSolver
+    elseif (KrylovAlg === Krylov.cg_lanczos!) Krylov.CgLanczosSolver
+    elseif (KrylovAlg === Krylov.bilq!      ) Krylov.BilqSolver
+    elseif (KrylovAlg === Krylov.minres_qlp!) Krylov.MinresQlpSolver
+    elseif (KrylovAlg === Krylov.qmr!       ) Krylov.QmrSolver
+    elseif (KrylovAlg === Krylov.gmres!     ) Krylov.GmresSolver
+    elseif (KrylovAlg === Krylov.fom!       ) Krylov.FomSolver
+    end
+
+    return solver
+end
 
 function init_cacheval(alg::KrylovJL, A, b, u)
 
-    KS = KrylovJL_solvers[alg.KrylovAlg]
+    KS = get_KrylovJL_solver(alg.KrylovAlg)
 
     solver = if(
         KS === Krylov.DqgmresSolver ||

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -1,5 +1,5 @@
 
-#TODO: composed preconditioners, preconditioner setter for cache, 
+#TODO: composed preconditioners, preconditioner setter for cache,
 #   detailed tests for wrappers
 
 ## Preconditioners
@@ -65,7 +65,7 @@ KrylovJL_MINRES(args...;kwargs...) =
     KrylovJL(args...; KrylovAlg=Krylov.minres!, kwargs...)
 
 function get_KrylovJL_solver(KrylovAlg)
-    KS = 
+    KS =
     if     (KrylovAlg === Krylov.lsmr!      ) Krylov.LsmrSolver
     elseif (KrylovAlg === Krylov.cgs!       ) Krylov.CgsSolver
     elseif (KrylovAlg === Krylov.usymlq!    ) Krylov.UsymlqSolver
@@ -260,4 +260,3 @@ function SciMLBase.solve(cache::LinearCache, alg::IterativeSolversJL; kwargs...)
 
     return cache.u
 end
-

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -8,7 +8,7 @@ struct KrylovJL{F,A,K} <: SciMLLinearSolveAlgorithm
     kwargs::K
 end
 
-function KrylovJL(args...; solver = Krylov.gmres, kwargs...)
+function KrylovJL(args...; solver = Krylov.bicgstab, kwargs...)
     return KrylovJL(solver, args, kwargs)
 end
 
@@ -19,6 +19,10 @@ function SciMLBase.solve(cache::LinearCache, alg::KrylovJL,args...;kwargs...)
     retcode = stats.solved ? :Success : :Failure
     return u
 end
+
+KrylovJL_CG(args...;kwargs...) = KrylovJL(Krylov.cg!, args...; kwargs...)
+KrylovJL_GMRES(args...;kwargs...) = KrylovJL(Krylov.gmres!, args...; kwargs...)
+KrylovJL_BICGSTAB(args...;kwargs...) = KrylovJL(Krylov.bicgstab!, args...; kwargs...)
 
 ## IterativeSolvers.jl
 

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -1,17 +1,25 @@
 ## Krylov.jl
 
-# place Krylov.CGsolver in LinearCache.cacheval, and resule
-
 struct KrylovJL{F,A,K} <: SciMLLinearSolveAlgorithm
     solver::F
     args::A
     kwargs::K
 end
 
-function KrylovJL(args...; solver = Krylov.bicgstab, kwargs...)
+function KrylovJL(args...; solver = Krylov.gmres, kwargs...)
     return KrylovJL(solver, args, kwargs)
 end
 
+# place Krylov.CGsolver in LinearCache.cacheval for reuse
+function init_cacheval(prob::LinearProblem, alg::KrylovJL)
+    if alg.solver === Krylov.cg!
+    elseif alg.solver === Krylov.gmres!
+    elseif alg.solver === Krylov.bicgstab!
+    end
+    return
+end
+
+# KrylovJL failing in-place
 function SciMLBase.solve(cache::LinearCache, alg::KrylovJL,args...;kwargs...)
     @unpack A, b, u, Pr, Pl = cache
     u, stats = alg.solver(A, b, args...; M=Pl, N=Pr, kwargs...)

--- a/src/wrappers.jl
+++ b/src/wrappers.jl
@@ -12,11 +12,11 @@ end
 
 function init_cacheval(alg::KrylovJL, A, b, u)
     cacheval = if alg.KrylovAlg === Krylov.cg!
-        CgSolver(A,b)
+        Krylov.CgSolver(A,b)
     elseif alg.KrylovAlg === Krylov.gmres!
-        GmresSolver(A,b,20)
+        Krylov.GmresSolver(A,b,20)
     elseif alg.KrylovAlg === Krylov.bicgstab!
-        BicgstabSolver(A,b)
+        Krylov.BicgstabSolver(A,b)
     else
         nothing
     end
@@ -24,15 +24,14 @@ function init_cacheval(alg::KrylovJL, A, b, u)
 end
 
 function SciMLBase.solve(cache::LinearCache, alg::KrylovJL; kwargs...)
-    @unpack A, b, u, Pr, Pl, cacheval = cache
-
     if cache.isfresh
-        solver = init_cacheval(alg.KrylovAlg, A, b, u)
-        solver.x = u
+        solver = init_cacheval(alg, cache.A, cache.b, cache.u)
         cache = set_cacheval(cache, solver)
     end
 
-    alg.solver(cacheval, A, b; M=Pl, N=Pr, alg.kwargs...)
+    cache.cacheval.x = cache.u
+    alg.KrylovAlg(cache.cacheval, cache.A, cache.b;
+                  M=cache.Pl, N=cache.Pr, alg.kwargs...)
 
     return cache.u
 end

--- a/test/ode_test.jl
+++ b/test/ode_test.jl
@@ -1,0 +1,41 @@
+
+
+n = 10
+dx = 2/(n-1)
+xx = Array(range(start=-1,stop=1,length=n))
+AA = Tridiagonal(ones(n-1),-2ones(n),ones(n-1))/(dx*dx) # rank-deficient sys
+uu = @. sin(pi*xx)
+bb = AA * uu #@. -(pi^2)*uu
+
+id = Matrix(I,n,n)
+R  = id[2:end-1,:]
+
+x = R * xx
+A = R * AA * R' # full rank system
+u = R * uu
+b = A * u #R * bb
+
+# test on some ODEProblem
+using OrdinaryDiffEq
+#   add this problem to DiffEqProblemLibrary
+kx = 1
+kt = 1
+ut(x,t) = sin(kx*pi*x)*cos(kt*pi*t)
+ic(x)   = ut(x,0.0)
+f(x,t)  = ut(x,t)*(kx*pi)^2 - sin(kx*pi*x)*sin(kt*pi*t)*(kt*pi)
+u0 = ic.(x)
+dudt!(du,u,p,t) = -A*u + f.(x,t)
+dt = 0.01
+tspn = (0.0,1.0)
+func = ODEFunction(dudt!)
+prob = ODEProblem(func,u0,tspn)
+
+
+using OrdinaryDiffEq
+using DiffEqProblemLibrary.ODEProblemLibrary
+ODEProblemLibrary.importodeproblems()
+prob = ODEProblemLibrary.prob_ode_linear
+@show prob
+sol  = solve(prob, Rodas5(linsolve=KrylovJL()); saveat=0.1)
+@show sol.retcode
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,55 +51,70 @@ using Test
         return
     end
 
-    kwargs = :()
-    for alg in (
-                :LUFactorization,
-                :QRFactorization,
-                :SVDFactorization,
-    #           :DefaultLinSolve
-               )
-        test_interface(alg, kwargs, prob1, prob2, prob3)
+    @testset "factorization" begin
+        kwargs = :()
+        for alg in (
+                    :LUFactorization,
+                    :QRFactorization,
+                    :SVDFactorization,
+        #           :DefaultLinSolve
+                   )
+            @testset "$alg" begin
+                test_interface(alg, kwargs, prob1, prob2, prob3)
+            end
+        end
+
+        alg = :DefaultFactorization
+        @testset "$alg" begin
+            for fact_alg in (
+                             :lu, :lu!,
+                             :qr, :qr!,
+                             :cholesky, :cholesky!,
+            #                :ldlt, :ldlt!,
+                             :bunchkaufman, :bunchkaufman!,
+                             :lq, :lq!,
+                             :svd, :svd!,
+                             :(LinearAlgebra.factorize), 
+                            )
+                @testset "fact_alg = $fact_alg" begin
+                    kwargs = :(fact_alg=$fact_alg,)
+                    test_interface(alg, kwargs, prob1, prob2, prob3)
+                end
+            end
+        end
+
     end
 
-#   alg = :DefaultFactorization
-#   for fact_alg in (
-#                    :lu, :lu!,
-#                    :qr, :qr!,
-#                    :cholesky, :cholesky!,
-#   #                :ldlt, :ldlt!,
-#                    :bunchkaufman, :bunchkaufman!,
-#                    :lq, :lq!,
-#                    :svd, :svd!,
-#                    :(LinearAlgebra.factorize), 
-#                   )
-#       kwargs = :(fact_alg=$fact_alg,)
-#       test_interface(alg, kwargs, prob1, prob2, prob3)
-#   end
-
-    # KrylovJL
-    kwargs = :(ifverbose=false, abstol=1e-8, reltol=1e-8, maxiter=30,
-               gmres_restart=5)
-    for alg in (
-                :KrylovJL,
-                :KrylovJL_CG,
-                :KrylovJL_GMRES,
-    #           :KrylovJL_BICGSTAB,
-                :KrylovJL_MINRES,
-               )
-        test_interface(alg, kwargs, prob1, prob2, prob3)
+    @testset "KrylovJL" begin
+        kwargs = :(ifverbose=false, abstol=1e-8, reltol=1e-8, maxiter=30,
+                   gmres_restart=5)
+        for alg in (
+                    :KrylovJL,
+                    :KrylovJL_CG,
+                    :KrylovJL_GMRES,
+        #           :KrylovJL_BICGSTAB,
+                    :KrylovJL_MINRES,
+                   )
+            @testset "$alg" begin
+                test_interface(alg, kwargs, prob1, prob2, prob3)
+            end
+        end
     end
 
-    # IterativeSolversJL
-    kwargs = :(ifverbose=false, abstol=1e-8, reltol=1e-8, maxiter=30,
-               gmres_restart=5)
-    for alg in (
-                :IterativeSolversJL,
-                :IterativeSolversJL_CG,
-                :IterativeSolversJL_GMRES,
-    #           :IterativeSolversJL_BICGSTAB,
-                :IterativeSolversJL_MINRES,
-               )
-        test_interface(alg, kwargs, prob1, prob2, prob3)
+    @testset "IterativeSolversJL" begin
+        kwargs = :(ifverbose=false, abstol=1e-8, reltol=1e-8, maxiter=30,
+                   gmres_restart=5)
+        for alg in (
+                    :IterativeSolversJL,
+                    :IterativeSolversJL_CG,
+                    :IterativeSolversJL_GMRES,
+        #           :IterativeSolversJL_BICGSTAB,
+                    :IterativeSolversJL_MINRES,
+                   )
+            @testset "$alg" begin
+                test_interface(alg, kwargs, prob1, prob2, prob3)
+            end
+        end
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,5 +19,6 @@ using Test
 
     # make algorithm callable - interoperable with DiffEq ecosystem
     @test A * LUFactorization()(x,A,b) ≈ b 
+    @test A * KrylovJL()(x,A,b) ≈ b 
     @test_broken A * x ≈ b # in place
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,13 +3,13 @@ using Test
 
 @testset "LinearSolve.jl" begin
     using LinearAlgebra
-    n = 8
+    n = 2
 
     A = Matrix(I,n,n)
     b = ones(n)
-    A1 = A/1; b1 = rand(n); x1 = zero(b)
-    A2 = A/2; b2 = rand(n); x2 = zero(b)
-    A3 = A/3; b3 = rand(n); x3 = zero(b)
+    A1 = A/1; b1 = ones(n); x1 = zero(b)
+    A2 = A/2; b2 = ones(n); x2 = zero(b)
+    A3 = A/3; b3 = ones(n); x3 = zero(b)
 
     prob1 = LinearProblem(A1, b1; u0=x1)
     prob2 = LinearProblem(A2, b2; u0=x2)
@@ -22,7 +22,7 @@ using Test
 
 #               :DefaultLinSolve,
 
-#               :KrylovJL, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB,
+                :KrylovJL, :KrylovJL_CG, :KrylovJL_GMRES, :KrylovJL_BICGSTAB,
 #               :IterativeSolversJL
 #               :KrylovKitJL,
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,35 +47,38 @@ using Test
         return
     end
 
-    # Factorizations
     kwargs = :()
     for alg in (
                 :LUFactorization,
                 :QRFactorization,
                 :SVDFactorization,
+                :DefaultFactorization,
+                :DefaultLinSolve
                )
         test_interface(alg, kwargs, prob1, prob2, prob3)
     end
 
     # KrylovJL
-    kwargs = :(ifverbose=true, abstol=1e-1, reltol=1e-1, maxiter=3, restart=5)
+    kwargs = :(ifverbose=true, abstol=1e-2, reltol=1e-1, maxiter=3,
+               gmres_restart=5)
     for alg in (
                 :KrylovJL,
                 :KrylovJL_CG,
-#               :KrylovJL_GMRES,    # same as default wrapper
-#               :KrylovJL_BICGSTAB, # fails
+                :KrylovJL_GMRES,
+    #           :KrylovJL_BICGSTAB, # fails
                 :KrylovJL_MINRES,
                )
         test_interface(alg, kwargs, prob1, prob2, prob3)
     end
 
     # IterativeSolversJL
-    kwargs = :(abstol=1e-1, reltol=1e-1, maxiter=3, restart=5)
+    kwargs = :(ifverbose=true, abstol=1e-1, reltol=1e-2, maxiter=3,
+               gmres_restart=5)
     for alg in (
                 :IterativeSolversJL,
                 :IterativeSolversJL_CG,
-#               :IterativeSolversJL_GMRES,      # same as default wrapper
-#               :IterativeSolversJL_BICGSTAB,   # fails
+                :IterativeSolversJL_GMRES,
+    #           :IterativeSolversJL_BICGSTAB,   # fails
                 :IterativeSolversJL_MINRES,
                )
         test_interface(alg, kwargs, prob1, prob2, prob3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 
 @testset "LinearSolve.jl" begin
     using LinearAlgebra
-    n = 32
+    n = 8
 
     A = Matrix(I,n,n)
     b = ones(n)
@@ -21,25 +21,26 @@ using Test
         A3 = prob3.A; b3 = prob3.b; x3 = prob3.u0
 
         @eval begin
-            y = solve($prob1, $alg($kwargs...))
+            y = solve($prob1, $alg(;$kwargs...))
             @test $A1 *  y  ≈ $b1 # out of place
             @test $A1 * $x1 ≈ $b1 # in place
 
-            y = $alg($kwargs...)($x2, $A2, $b2)    # alg is callable
+            y = $alg(;$kwargs...)($x2, $A2, $b2)      # alg is callable
             @test $A2 *  y  ≈ $b2
             @test $A2 * $x2 ≈ $b2
 
-            cache = SciMLBase.init($prob1, $alg($kwargs...)) # initialize cache
-            y = cache($x3, $A1, $b1)               # cache is callable
+            cache = SciMLBase.init($prob1,            # initialize cache
+                                   $alg(;$kwargs...)) 
+            y = cache($x3, $A1, $b1)                  # cache is callable
             @test $A1 *  y  ≈ $b1
             @test $A1 * $x3 ≈ $b1
 
-            y = cache($x3, $A1, $b2)               # reuse factorization
+            y = cache($x3, $A1, $b2)                  # reuse factorization
             @test $A1 *  y  ≈ $b2
             @test $A1 * $x3 ≈ $b2
 
-            y = cache($x3, $A2, $b3)               # new factorization
-            @test $A2 *  y  ≈ $b3                  # same old cache
+            y = cache($x3, $A2, $b3)                  # new factorization
+            @test $A2 *  y  ≈ $b3                     # same old cache
             @test $A2 * $x3 ≈ $b3
         end
 
@@ -57,7 +58,7 @@ using Test
     end
 
     # KrylovJL
-    kwargs = :(verbose=1, abstol=1e-1, reltol=1e-1, maxiters=3, restart=5)
+    kwargs = :(verbose=1, abstol=1e-1, reltol=1e-1, maxiter=3, restart=5)
     for alg in (
                 :KrylovJL,
                 :KrylovJL_CG,
@@ -69,7 +70,7 @@ using Test
     end
 
     # IterativeSolversJL
-    kwargs = :(abstol=1e-1, reltol=1e-1, maxiters=3, restart=5)
+    kwargs = :(abstol=1e-1, reltol=1e-1, maxiter=3, restart=5)
     for alg in (
                 :IterativeSolversJL,
                 :IterativeSolversJL_CG,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,18 +2,22 @@ using LinearSolve
 using Test
 
 @testset "LinearSolve.jl" begin
-    A = rand(5, 5)
-    b = rand(5)
+    n = 10
+    A = rand(n, n)
+    b = rand(n)
     prob = LinearProblem(A, b)
 
+    x = rand(n)
+
     # Factorization
-    @test A * solve(prob, LUFactorization(); alias_A = false, alias_b = false) ≈
-          b
-    @test A * solve(prob, QRFactorization(); alias_A = false, alias_b = false) ≈
-          b
-    @test A *
-          solve(prob, SVDFactorization(); alias_A = false, alias_b = false) ≈ b
+    @test A * solve(prob, LUFactorization();)  ≈ b
+    @test A * solve(prob, QRFactorization();)  ≈ b
+    @test A * solve(prob, SVDFactorization();) ≈ b
 
     # Krylov
     @test A * solve(prob, KrylovJL(A, b)) ≈ b
+
+    # make algorithm callable - interoperable with DiffEq ecosystem
+    @test A * LUFactorization()(x,A,b) ≈ b 
+    @test_broken A * x ≈ b # in place
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,8 +29,8 @@ using Test
             @test $A2 *  y  ≈ $b2
             @test $A2 * $x2 ≈ $b2
 
-            cache = SciMLBase.init($prob1,            # initialize cache
-                                   $alg(;$kwargs...)) 
+            cache = SciMLBase.init($prob1,           
+                                   $alg(;$kwargs...)) # initialize cache 
             y = cache($x3, $A1, $b1)                  # cache is callable
             @test $A1 *  y  ≈ $b1
             @test $A1 * $x3 ≈ $b1
@@ -59,7 +59,7 @@ using Test
     end
 
     # KrylovJL
-    kwargs = :(ifverbose=true, abstol=1e-2, reltol=1e-1, maxiter=3,
+    kwargs = :(ifverbose=true, abstol=1e-8, reltol=1e-8, maxiter=30,
                gmres_restart=5)
     for alg in (
                 :KrylovJL,
@@ -72,7 +72,7 @@ using Test
     end
 
     # IterativeSolversJL
-    kwargs = :(ifverbose=true, abstol=1e-1, reltol=1e-2, maxiter=3,
+    kwargs = :(ifverbose=true, abstol=1e-8, reltol=1e-8, maxiter=30,
                gmres_restart=5)
     for alg in (
                 :IterativeSolversJL,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,28 +15,21 @@ using Test
     prob2 = LinearProblem(A2, b2; u0=x2)
     prob3 = LinearProblem(A3, b3; u0=x3)
 
-    for alg in (
-                :LUFactorization,
-                :QRFactorization,
-                :SVDFactorization,
+    function test_interface(alg, kwargs, prob1, prob2, prob3)
+        A1 = prob1.A; b1 = prob1.b; x1 = prob1.u0
+        A2 = prob2.A; b2 = prob2.b; x2 = prob2.u0
+        A3 = prob3.A; b3 = prob3.b; x3 = prob3.u0
 
-#               :DefaultLinSolve,
-
-                :KrylovJL, :KrylovJL_CG, :KrylovJL_GMRES, :KrylovJL_BICGSTAB,
-                :KrylovJL_MINRES,
-                :IterativeSolversJL, :IterativeSolversJL_GMRES,
-                :IterativeSolversJL_BICGSTAB, :IterativeSolversJL_MINRES
-               )
         @eval begin
-            y = solve($prob1, $alg())
+            y = solve($prob1, $alg($kwargs...))
             @test $A1 *  y  ≈ $b1 # out of place
             @test $A1 * $x1 ≈ $b1 # in place
 
-            y = $alg()($x2, $A2, $b2)              # alg is callable
+            y = $alg($kwargs...)($x2, $A2, $b2)    # alg is callable
             @test $A2 *  y  ≈ $b2
             @test $A2 * $x2 ≈ $b2
 
-            cache = SciMLBase.init($prob1, $alg()) # initialize cache
+            cache = SciMLBase.init($prob1, $alg($kwargs...)) # initialize cache
             y = cache($x3, $A1, $b1)               # cache is callable
             @test $A1 *  y  ≈ $b1
             @test $A1 * $x3 ≈ $b1
@@ -49,6 +42,42 @@ using Test
             @test $A2 *  y  ≈ $b3                  # same old cache
             @test $A2 * $x3 ≈ $b3
         end
+
+        return
+    end
+
+    # Factorizations
+    kwargs = :()
+    for alg in (
+                :LUFactorization,
+                :QRFactorization,
+                :SVDFactorization,
+               )
+        test_interface(alg, kwargs, prob1, prob2, prob3)
+    end
+
+    # KrylovJL
+    kwargs = :(verbose=1, abstol=1e-1, reltol=1e-1, maxiters=3, restart=5)
+    for alg in (
+                :KrylovJL,
+                :KrylovJL_CG,
+                :KrylovJL_GMRES,
+                :KrylovJL_BICGSTAB,
+                :KrylovJL_MINRES,
+               )
+        test_interface(alg, kwargs, prob1, prob2, prob3)
+    end
+
+    # IterativeSolversJL
+    kwargs = :(abstol=1e-1, reltol=1e-1, maxiters=3, restart=5)
+    for alg in (
+                :IterativeSolversJL,
+                :IterativeSolversJL_CG,
+                :IterativeSolversJL_GMRES,
+                :IterativeSolversJL_BICGSTAB,
+                :IterativeSolversJL_MINRES,
+               )
+        test_interface(alg, kwargs, prob1, prob2, prob3)
     end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,49 +4,54 @@ using Test
 @testset "LinearSolve.jl" begin
     using LinearAlgebra
     n = 100
-    x = Array(range(start=-1,stop=1,length=n))
-    uu= @. sin(pi*x)
-
     dx = 2/(n-1)
 
-    AA = Tridiagonal(ones(n-1),-2ones(n),ones(n-1))/(dx*dx)
-    bb = @. -(pi^2)*uu
+    xx = Array(range(start=-1,stop=1,length=n))
+    AA = Tridiagonal(ones(n-1),-2ones(n),ones(n-1))/(dx*dx) # rank-deficient sys
+    uu = @. sin(pi*xx)
+    bb = AA * uu #@. -(pi^2)*uu
+
     id = Matrix(I,n,n)
     R  = id[2:end-1,:]
 
-    A = R * AA * R'
+    x = R * xx
+    A = R * AA * R' # full rank system
     u = R * uu
     b = A * u #R * bb
 
-    @test isapprox(A*u,b;atol=1e-2)
-    prob = LinearProblem(A, b)
-
-    x = zero(b)
+    x    = zero(b)
+    prob = LinearProblem(A, b;u0=x)
 
     # Factorization
-    @test A * solve(prob, LUFactorization();)  ≈ b
-    @test A * solve(prob, QRFactorization();)  ≈ b
-    @test A * solve(prob, SVDFactorization();) ≈ b
-
-    # Krylov
-    @test A * solve(prob, KrylovJL(A, b)) ≈ b
-
-    # make algorithm callable - interoperable with DiffEq ecosystem
-    @test A * LUFactorization()(x,A,b)  ≈ b 
-    @test A * QRFactorization()(x,A,b)  ≈ b 
-    @test A * SVDFactorization()(x,A,b) ≈ b 
-    @test A * KrylovJL()(x,A,b)         ≈ b 
-
-    # in place
-    LUFactorization()(x,A,b) 
-    @test A * x ≈ b
-    QRFactorization()(x,A,b) 
-    @test A * x ≈ b
-    SVDFactorization()(x,A,b)
-    @test A * x ≈ b
-    KrylovJL()(x,A,b)        
-    @test A * x ≈ b
+    for alg in (:LUFactorization, :QRFactorization, :SVDFactorization,
+                :KrylovJL)
+        @eval begin
+            @test $A * solve($prob, $alg();) ≈ $b
+            $alg()($x,$A,$b)
+            @test $A * $x ≈ $b
+        end
+    end
 
     # test on some ODEProblem
-#   using OrdinaryDiffEq
+    using OrdinaryDiffEq
+    using DiffEqProblemLibrary.ODEProblemLibrary
+    ODEProblemLibrary.importodeproblems()
+
+    #   add this problem to DiffEqProblemLibrary
+#   kx = 1
+#   kt = 1
+#   ut(x,t) = sin(kx*pi*x)*cos(kt*pi*t)
+#   ic(x)   = ut(x,0.0)
+#   f(x,t)  = ut(x,t)*(kx*pi)^2 - sin(kx*pi*x)*sin(kt*pi*t)*(kt*pi)
+#   u0 = ic.(x)
+#   dudt!(du,u,p,t) = -A*u + f.(x,t)
+#   dt = 0.01
+#   tspn = (0.0,1.0)
+#   func = ODEFunction(dudt!)
+#   prob = ODEProblem(func,u0,tspn)
+
+    prob = ODEProblemLibrary.prob_ode_linear
+    sol  = solve(prob, Rodas5(linsolve=SVDFactorization()); saveat=0.1)
+    @show sol.retcode
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,5 +20,8 @@ using Test
     # make algorithm callable - interoperable with DiffEq ecosystem
     @test A * LUFactorization()(x,A,b) ≈ b 
     @test A * KrylovJL()(x,A,b) ≈ b 
-    @test_broken A * x ≈ b # in place
+
+    # in place
+    KrylovJL()(x,A,b)
+    @test A * x ≈ b
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,18 +25,12 @@ function test_interface(alg, prob1, prob2)
     y = solve(cache)
     @test A2 *  y  ≈ b1
 
-    @show A2, b2
-
     cache = LinearSolve.set_b(cache,b2)
     y = solve(cache)
-    @show cache.A, cache.b, y
     @test A2 *  y  ≈ b2
 
     return
 end
-
-alg = GenericFactorization(fact_alg=cholesky!)
-test_interface(alg, prob1, prob2)
 
 @testset "Concrete Factorizations" begin
     for alg in (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,20 +24,23 @@ using Test
 
     # Factorization
     for alg in (:LUFactorization, :QRFactorization, :SVDFactorization,
-                :KrylovJL)
+                :KrylovJL,
+#               :KrylovKitJL,
+               )
         @eval begin
             @test $A * solve($prob, $alg();) ≈ $b
-            $alg()($x,$A,$b)
+            $alg()($x, $A, $b)
+            @test $A * $x ≈ $b
+
+            cache = SciMLBase.init($prob, $alg())
+            cache($x, $A, $b)
             @test $A * $x ≈ $b
         end
     end
 
     # test on some ODEProblem
-    using OrdinaryDiffEq
-    using DiffEqProblemLibrary.ODEProblemLibrary
-    ODEProblemLibrary.importodeproblems()
-
-    #   add this problem to DiffEqProblemLibrary
+#   using OrdinaryDiffEq
+#   #   add this problem to DiffEqProblemLibrary
 #   kx = 1
 #   kt = 1
 #   ut(x,t) = sin(kx*pi*x)*cos(kt*pi*t)
@@ -50,8 +53,12 @@ using Test
 #   func = ODEFunction(dudt!)
 #   prob = ODEProblem(func,u0,tspn)
 
-    prob = ODEProblemLibrary.prob_ode_linear
-    sol  = solve(prob, Rodas5(linsolve=SVDFactorization()); saveat=0.1)
-    @show sol.retcode
+#   using OrdinaryDiffEq
+#   using DiffEqProblemLibrary.ODEProblemLibrary
+#   ODEProblemLibrary.importodeproblems()
+#   prob = ODEProblemLibrary.prob_ode_linear
+#   @show prob
+#   sol  = solve(prob, Rodas5(linsolve=KrylovJL()); saveat=0.1)
+#   @show sol.retcode
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,8 @@ using Test
 #               :DefaultLinSolve,
 
                 :KrylovJL, :KrylovJL_CG, :KrylovJL_GMRES, :KrylovJL_BICGSTAB,
-                :IterativeSolversJL,#:IterativeSolversJL_GMRES, :IterativeSolversJL_BICGSTAB,
+                :IterativeSolversJL, :IterativeSolversJL_GMRES,
+                :IterativeSolversJL_BICGSTAB,
                )
         @eval begin
             y = solve($prob1, $alg())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,8 +23,9 @@ using Test
 #               :DefaultLinSolve,
 
                 :KrylovJL, :KrylovJL_CG, :KrylovJL_GMRES, :KrylovJL_BICGSTAB,
+                :KrylovJL_MINRES,
                 :IterativeSolversJL, :IterativeSolversJL_GMRES,
-                :IterativeSolversJL_BICGSTAB,
+                :IterativeSolversJL_BICGSTAB, :IterativeSolversJL_MINRES
                )
         @eval begin
             y = solve($prob1, $alg())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,26 @@ using LinearSolve
 using Test
 
 @testset "LinearSolve.jl" begin
-    n = 10
-    A = rand(n, n)
-    b = rand(n)
+    using LinearAlgebra
+    n = 100
+    x = Array(range(start=-1,stop=1,length=n))
+    uu= @. sin(pi*x)
+
+    dx = 2/(n-1)
+
+    AA = Tridiagonal(ones(n-1),-2ones(n),ones(n-1))/(dx*dx)
+    bb = @. -(pi^2)*uu
+    id = Matrix(I,n,n)
+    R  = id[2:end-1,:]
+
+    A = R * AA * R'
+    u = R * uu
+    b = A * u #R * bb
+
+    @test isapprox(A*u,b;atol=1e-2)
     prob = LinearProblem(A, b)
 
-    x = rand(n)
+    x = zero(b)
 
     # Factorization
     @test A * solve(prob, LUFactorization();)  ≈ b
@@ -18,10 +32,21 @@ using Test
     @test A * solve(prob, KrylovJL(A, b)) ≈ b
 
     # make algorithm callable - interoperable with DiffEq ecosystem
-    @test A * LUFactorization()(x,A,b) ≈ b 
-    @test A * KrylovJL()(x,A,b) ≈ b 
+    @test A * LUFactorization()(x,A,b)  ≈ b 
+    @test A * QRFactorization()(x,A,b)  ≈ b 
+    @test A * SVDFactorization()(x,A,b) ≈ b 
+    @test A * KrylovJL()(x,A,b)         ≈ b 
 
     # in place
-    KrylovJL()(x,A,b)
+    LUFactorization()(x,A,b) 
     @test A * x ≈ b
+    QRFactorization()(x,A,b) 
+    @test A * x ≈ b
+    SVDFactorization()(x,A,b)
+    @test A * x ≈ b
+    KrylovJL()(x,A,b)        
+    @test A * x ≈ b
+
+    # test on some ODEProblem
+#   using OrdinaryDiffEq
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,12 +58,12 @@ using Test
     end
 
     # KrylovJL
-    kwargs = :(verbose=1, abstol=1e-1, reltol=1e-1, maxiter=3, restart=5)
+    kwargs = :(ifverbose=true, abstol=1e-1, reltol=1e-1, maxiter=3, restart=5)
     for alg in (
                 :KrylovJL,
                 :KrylovJL_CG,
-                :KrylovJL_GMRES,
-                :KrylovJL_BICGSTAB,
+#               :KrylovJL_GMRES,    # same as default wrapper
+#               :KrylovJL_BICGSTAB, # fails
                 :KrylovJL_MINRES,
                )
         test_interface(alg, kwargs, prob1, prob2, prob3)
@@ -74,8 +74,8 @@ using Test
     for alg in (
                 :IterativeSolversJL,
                 :IterativeSolversJL_CG,
-                :IterativeSolversJL_GMRES,
-                :IterativeSolversJL_BICGSTAB,
+#               :IterativeSolversJL_GMRES,      # same as default wrapper
+#               :IterativeSolversJL_BICGSTAB,   # fails
                 :IterativeSolversJL_MINRES,
                )
         test_interface(alg, kwargs, prob1, prob2, prob3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,45 +3,17 @@ using Test
 
 @testset "LinearSolve.jl" begin
     using LinearAlgebra
-    n = 32
-    dx = 2/(n-1)
+    n = 8
 
-    xx = Array(range(start=-1,stop=1,length=n))
-    AA = Tridiagonal(ones(n-1),-2ones(n),ones(n-1))/(dx*dx) # rank-deficient sys
-    uu = @. sin(pi*xx)
-    bb = AA * uu #@. -(pi^2)*uu
+    A = Matrix(I,n,n)
+    b = ones(n)
+    A1 = A/1; b1 = rand(n); x1 = zero(b)
+    A2 = A/2; b2 = rand(n); x2 = zero(b)
+    A3 = A/3; b3 = rand(n); x3 = zero(b)
 
-    id = Matrix(I,n,n)
-    R  = id[2:end-1,:]
-
-    x = R * xx
-    A = R * AA * R' # full rank system
-    u = R * uu
-    b = A * u #R * bb
-
-    # test on some ODEProblem
-#   using OrdinaryDiffEq
-#   #   add this problem to DiffEqProblemLibrary
-#   kx = 1
-#   kt = 1
-#   ut(x,t) = sin(kx*pi*x)*cos(kt*pi*t)
-#   ic(x)   = ut(x,0.0)
-#   f(x,t)  = ut(x,t)*(kx*pi)^2 - sin(kx*pi*x)*sin(kt*pi*t)*(kt*pi)
-#   u0 = ic.(x)
-#   dudt!(du,u,p,t) = -A*u + f.(x,t)
-#   dt = 0.01
-#   tspn = (0.0,1.0)
-#   func = ODEFunction(dudt!)
-#   prob = ODEProblem(func,u0,tspn)
-
-    x = zero(b)
-    A1 =  A; b1 =  b
-    A2 = 2A; b2 = 3b
-    A3 = 3A; b3 = 2b
-
-    prob1 = LinearProblem(A1, b1; u0=x)
-    prob2 = LinearProblem(A2, b2; u0=x)
-    prob3 = LinearProblem(A3, b3; u0=x)
+    prob1 = LinearProblem(A1, b1; u0=x1)
+    prob2 = LinearProblem(A2, b2; u0=x2)
+    prob3 = LinearProblem(A3, b3; u0=x3)
 
     for alg in (
                 :LUFactorization,
@@ -50,34 +22,33 @@ using Test
 
 #               :DefaultLinSolve,
 
-                :KrylovJL,
 #               :KrylovJL,
+#               :IterativeSolvers.jl
 #               :KrylovKitJL,
 
                )
         @eval begin
             y = solve($prob1, $alg())
-            @test $A1 *  y ≈ $b1
-            @test $A1 * $x ≈ $b1
+            @test $A1 *  y  ≈ $b1
+            @test $A1 * $x1 ≈ $b1
 
-            y = $alg()($x, $A2, $b2)
-            @test $A2 *  y ≈ $b2
-            @test $A2 * $x ≈ $b2
+            y = $alg()($x2, $A2, $b2)
+            @test $A2 *  y  ≈ $b2
+            @test $A2 * $x2 ≈ $b2
 
             cache = SciMLBase.init($prob1, $alg())
-            y = cache($x, $A3, $b3)
-            @test $A3 * $x ≈ $b3
-            @test $A3 *  y ≈ $b3
+            y = cache($x3, $A1, $b1)
+            @test $A1 *  y  ≈ $b1
+            @test $A1 * $x3 ≈ $b1
+
+            y = cache($x3, $A1, $b2)
+            @test $A1 *  y  ≈ $b2
+            @test $A1 * $x3 ≈ $b2
+
+            y = cache($x3, $A2, $b3)
+            @test $A2 *  y  ≈ $b3
+            @test $A2 * $x3 ≈ $b3
         end
     end
-
-
-#   using OrdinaryDiffEq
-#   using DiffEqProblemLibrary.ODEProblemLibrary
-#   ODEProblemLibrary.importodeproblems()
-#   prob = ODEProblemLibrary.prob_ode_linear
-#   @show prob
-#   sol  = solve(prob, Rodas5(linsolve=KrylovJL()); saveat=0.1)
-#   @show sol.retcode
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,13 +36,17 @@ using Test
             @test $A1 * $x3 ≈ $b1
 
             y = cache($x3, $A1, $b2)                  # reuse factorization
-            @test $A1 *  y  ≈ $b2
+            @test $A1 *  y  ≈ $b2                     # with different RHS
             @test $A1 * $x3 ≈ $b2
 
             y = cache($x3, $A2, $b3)                  # new factorization
             @test $A2 *  y  ≈ $b3                     # same old cache
             @test $A2 * $x3 ≈ $b3
         end
+
+        x1 .= 0.0
+        x2 .= 0.0
+        x3 .= 0.0
 
         return
     end
@@ -52,33 +56,47 @@ using Test
                 :LUFactorization,
                 :QRFactorization,
                 :SVDFactorization,
-                :DefaultFactorization,
-                :DefaultLinSolve
+    #           :DefaultLinSolve
                )
         test_interface(alg, kwargs, prob1, prob2, prob3)
     end
 
+#   alg = :DefaultFactorization
+#   for fact_alg in (
+#                    :lu, :lu!,
+#                    :qr, :qr!,
+#                    :cholesky, :cholesky!,
+#   #                :ldlt, :ldlt!,
+#                    :bunchkaufman, :bunchkaufman!,
+#                    :lq, :lq!,
+#                    :svd, :svd!,
+#                    :(LinearAlgebra.factorize), 
+#                   )
+#       kwargs = :(fact_alg=$fact_alg,)
+#       test_interface(alg, kwargs, prob1, prob2, prob3)
+#   end
+
     # KrylovJL
-    kwargs = :(ifverbose=true, abstol=1e-8, reltol=1e-8, maxiter=30,
+    kwargs = :(ifverbose=false, abstol=1e-8, reltol=1e-8, maxiter=30,
                gmres_restart=5)
     for alg in (
                 :KrylovJL,
                 :KrylovJL_CG,
                 :KrylovJL_GMRES,
-    #           :KrylovJL_BICGSTAB, # fails
+    #           :KrylovJL_BICGSTAB,
                 :KrylovJL_MINRES,
                )
         test_interface(alg, kwargs, prob1, prob2, prob3)
     end
 
     # IterativeSolversJL
-    kwargs = :(ifverbose=true, abstol=1e-8, reltol=1e-8, maxiter=30,
+    kwargs = :(ifverbose=false, abstol=1e-8, reltol=1e-8, maxiter=30,
                gmres_restart=5)
     for alg in (
                 :IterativeSolversJL,
                 :IterativeSolversJL_CG,
                 :IterativeSolversJL_GMRES,
-    #           :IterativeSolversJL_BICGSTAB,   # fails
+    #           :IterativeSolversJL_BICGSTAB,
                 :IterativeSolversJL_MINRES,
                )
         test_interface(alg, kwargs, prob1, prob2, prob3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,31 +22,31 @@ using Test
 
 #               :DefaultLinSolve,
 
-#               :KrylovJL,
-#               :IterativeSolvers.jl
+#               :KrylovJL, KrylovJL_CG, KrylovJL_GMRES, KrylovJL_BICGSTAB,
+#               :IterativeSolversJL
 #               :KrylovKitJL,
 
                )
         @eval begin
             y = solve($prob1, $alg())
-            @test $A1 *  y  ≈ $b1
-            @test $A1 * $x1 ≈ $b1
+            @test $A1 *  y  ≈ $b1 # out of place
+            @test $A1 * $x1 ≈ $b1 # in place
 
-            y = $alg()($x2, $A2, $b2)
+            y = $alg()($x2, $A2, $b2)              # alg is callable
             @test $A2 *  y  ≈ $b2
             @test $A2 * $x2 ≈ $b2
 
-            cache = SciMLBase.init($prob1, $alg())
-            y = cache($x3, $A1, $b1)
+            cache = SciMLBase.init($prob1, $alg()) # initialize cache
+            y = cache($x3, $A1, $b1)               # cache is callable
             @test $A1 *  y  ≈ $b1
             @test $A1 * $x3 ≈ $b1
 
-            y = cache($x3, $A1, $b2)
+            y = cache($x3, $A1, $b2)               # reuse factorization
             @test $A1 *  y  ≈ $b2
             @test $A1 * $x3 ≈ $b2
 
-            y = cache($x3, $A2, $b3)
-            @test $A2 *  y  ≈ $b3
+            y = cache($x3, $A2, $b3)               # new factorization
+            @test $A2 *  y  ≈ $b3                  # same old cache
             @test $A2 * $x3 ≈ $b3
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,13 +3,13 @@ using Test
 
 @testset "LinearSolve.jl" begin
     using LinearAlgebra
-    n = 2
+    n = 32
 
     A = Matrix(I,n,n)
     b = ones(n)
-    A1 = A/1; b1 = ones(n); x1 = zero(b)
-    A2 = A/2; b2 = ones(n); x2 = zero(b)
-    A3 = A/3; b3 = ones(n); x3 = zero(b)
+    A1 = A/1; b1 = rand(n); x1 = zero(b)
+    A2 = A/2; b2 = rand(n); x2 = zero(b)
+    A3 = A/3; b3 = rand(n); x3 = zero(b)
 
     prob1 = LinearProblem(A1, b1; u0=x1)
     prob2 = LinearProblem(A2, b2; u0=x2)
@@ -23,9 +23,7 @@ using Test
 #               :DefaultLinSolve,
 
                 :KrylovJL, :KrylovJL_CG, :KrylovJL_GMRES, :KrylovJL_BICGSTAB,
-#               :IterativeSolversJL
-#               :KrylovKitJL,
-
+                :IterativeSolversJL,#:IterativeSolversJL_GMRES, :IterativeSolversJL_BICGSTAB,
                )
         @eval begin
             y = solve($prob1, $alg())


### PR DESCRIPTION
TODO

- [ ] interoperability `solve(prob::ODEProblem,Rodas5(linsolve=alg::SciMLLinearSolveAlgorithm))`
- [ ] wrap and test a KSP libraries - `Krylov.jl`, `IterativeSolvers.jl`, `KrylovKit.jl`. handle in-place, and out-of-place algs separately? save KSP solver cache in `LinearCache.cacheval`
- [ ] add present solution, iteration count, other functionality to `LinearCache`

ref https://github.com/SciML/LinearSolve.jl/issues/3