### PR TITLE
common arg handling

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -12,7 +12,7 @@ struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tl,Tr,Ttol}
     # common arguments
     abstol::Ttol
     reltol::Ttol
-    maxiters::Ti
+    maxiters::Int
     verbose::Bool
 end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -8,8 +8,6 @@ struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tl,Tr,Ttol}
     isfresh::Bool # false => cacheval is set wrt A, true => update cacheval wrt A
     Pl::Tl        # store final preconditioner here. not being used rn
     Pr::Tr        # wrappers are using preconditioner in cache.alg for now
-
-    # common arguments
     abstol::Ttol
     reltol::Ttol
     maxiters::Int
@@ -52,7 +50,10 @@ SciMLBase.init(prob::LinearProblem, args...; kwargs...) = SciMLBase.init(prob,no
 
 function SciMLBase.init(prob::LinearProblem, alg::Union{SciMLLinearSolveAlgorithm,Nothing}, args...;
                         alias_A = false, alias_b = false,
-                        abstol=0, reltol=0, maxiters=0, verbose=false,
+                        abstol=√eps(eltype(prob.A)),
+                        reltol=√eps(eltype(prob.A)),
+                        maxiters=length(prob.b),
+                        verbose=false,
                         kwargs...,
                        )
     @unpack A, b, u0, p = prob
@@ -69,11 +70,6 @@ function SciMLBase.init(prob::LinearProblem, alg::Union{SciMLLinearSolveAlgorith
     A = alias_A ? A : deepcopy(A)
     b = alias_b ? b : deepcopy(b)
 
-
-    abstol   = (abstol   == 0) ? √eps(eltype(A)) : abstol
-    reltol   = (reltol   == 0) ? √eps(eltype(A)) : reltol
-    maxiters = (maxiters == 0) ? length(b)       : maxiters
-
     cache = LinearCache{
         typeof(A),
         typeof(b),
@@ -84,7 +80,6 @@ function SciMLBase.init(prob::LinearProblem, alg::Union{SciMLLinearSolveAlgorith
         typeof(Pl),
         typeof(Pr),
         typeof(reltol),
-        typeof(maxiters)
     }(
         A,
         b,

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,4 +1,4 @@
-struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tl,Tr,Ttol,Ti}
+struct LinearCache{TA,Tb,Tu,Tp,Talg,Tc,Tl,Tr,Ttol}
     A::TA
     b::Tb
     u::Tu

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,14 +10,16 @@ A2 = A/2; b2 = rand(n); x2 = zero(b)
 prob1 = LinearProblem(A1, b1; u0=x1)
 prob2 = LinearProblem(A2, b2; u0=x2)
 
+cache_kwargs = (;verbose=true, abstol=1e-8, reltol=1e-8, maxiter=30,)
+
 function test_interface(alg, prob1, prob2)
     A1 = prob1.A; b1 = prob1.b; x1 = prob1.u0
     A2 = prob2.A; b2 = prob2.b; x2 = prob2.u0
 
-    y = solve(prob1, alg)
+    y = solve(prob1, alg; cache_kwargs...)
     @test A1 *  y  ≈ b1
 
-    cache = SciMLBase.init(prob1,alg) # initialize cache
+    cache = SciMLBase.init(prob1,alg; cache_kwargs...) # initialize cache
     y = solve(cache)
     @test A1 *  y  ≈ b1
 
@@ -92,8 +94,7 @@ end
 end
 
 @testset "KrylovJL" begin
-    kwargs = (;ifverbose=false, abstol=1e-8, reltol=1e-8, maxiter=30,
-               gmres_restart=5)
+    kwargs = (;gmres_restart=5,)
     for alg in (
                 ("Default",KrylovJL(kwargs...)),
                 ("CG",KrylovJL_CG(kwargs...)),
@@ -108,8 +109,7 @@ end
 end
 
 @testset "IterativeSolversJL" begin
-    kwargs = (;ifverbose=false, abstol=1e-8, reltol=1e-8, maxiter=30,
-               gmres_restart=5)
+    kwargs = (;gmres_restart=5,)
     for alg in (
                 ("Default", IterativeSolversJL(kwargs...)),
                 ("CG", IterativeSolversJL_CG(kwargs...)),


### PR DESCRIPTION
move abstol, reltol, maxiters, vebose to cache from wrappers.

ref https://github.com/SciML/LinearSolve.jl/issues/23