### PR TITLE
Update Preconditioners.md

### DIFF
--- a/docs/src/basics/Preconditioners.md
+++ b/docs/src/basics/Preconditioners.md
@@ -75,5 +75,3 @@ following interface:
 - `Base.eltype(::Preconditioner)`
 - `Base.adjoint(::Preconditioner)`
 - `LinearAlgebra.ldiv!(::AbstractVector,::Preconditioner,::AbstractVector)`
-- `Base.inv(::Preconditioner)` (Dear Jesus Krylov.jl, why?)
-- `LinearAlgebra.mul!(::AbstractVector,::Preconditioner,::AbstractVector)` (Required for Krylov.jl)


### PR DESCRIPTION
Preconditioners don't need Base.inv, and LinearAlgebra.mul! to be defined. For Krylov.jl, we pass in the lazy `InvComposePreconditioner` whose `mul!` just calls the `ldiv!` of the `ComposePreconditioner`.