### PR TITLE
Auto-reset GMRES u to zero

### DIFF
--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -221,6 +221,7 @@ purge_history!(iter, x, b) = nothing
 function purge_history!(iter::IterativeSolvers.GMRESIterable, x, b)
   iter.k = 1
   iter.x  = x
+  fill!(x,false)
   iter.b  = b
 
   iter.residual.current = IterativeSolvers.init!(iter.arnoldi, iter.x, iter.b, iter.Pl, iter.Ax, initially_zero = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,22 +16,18 @@ function test_interface(alg, prob1, prob2)
     A1 = prob1.A; b1 = prob1.b; x1 = prob1.u0
     A2 = prob2.A; b2 = prob2.b; x2 = prob2.u0
 
-    x1 .= false
     y = solve(prob1, alg; cache_kwargs...)
     @test A1 *  y  ≈ b1
 
     cache = SciMLBase.init(prob1,alg; cache_kwargs...) # initialize cache
-    cache.u .= false
     y = solve(cache)
     @test A1 *  y  ≈ b1
 
     cache = LinearSolve.set_A(cache,copy(A2))
-    cache.u .= false
     y = solve(cache)
     @test A2 *  y  ≈ b1
 
     cache = LinearSolve.set_b(cache,b2)
-    cache.u .= false
     y = solve(cache)
     @test A2 *  y  ≈ b2
 


### PR DESCRIPTION
https://github.com/SciML/LinearSolve.jl/issues/70 shows that setting the initial condition in GMRES is a minefield. Currently it's pretty much impossible for any user to guess correctly so pretty much any case would do better with resetting to zero. The papers suggest doing that even if the rescaling is done in many cases, and the tests require it. So for the sanity of everyone, I think it's best to reset to zero, and if the rescaling is implemented this can be removed, but until then keeping it hardcoded is a good idea.