### PR TITLE
Revert "avoid ldiv of invpreconditioner"

### DIFF
--- a/src/preconditioners.jl
+++ b/src/preconditioners.jl
@@ -26,5 +26,6 @@ struct InvPreconditioner{T}
 end
 
 Base.eltype(A::InvPreconditioner) = Base.eltype(A.P)
+LinearAlgebra.ldiv!(A::InvPreconditioner, x) = mul!(x, A.P, x)
 LinearAlgebra.ldiv!(y, A::InvPreconditioner, x) = mul!(y, A.P, x)
 LinearAlgebra.mul!(y, A::InvPreconditioner, x) = ldiv!(y, A.P, x)

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -208,6 +208,9 @@ end
         mul!(y, Pl, x); @test y ≈ s .* x
         mul!(y, Pr, x); @test y ≈ s .\ x
 
+        y .= x; ldiv!(Pl, x); @test x ≈ s .\ y
+        y .= x; ldiv!(Pr, x); @test x ≈ s .* y
+
         ldiv!(y, Pl, x); @test y ≈ s .\ x
         ldiv!(y, Pr, x); @test y ≈ s .* x
     end


### PR DESCRIPTION
Reverts SciML/LinearSolve.jl#100

Apparently this is used in the Arnoldi implementation of IterativeSolvers.

https://buildkite.com/julialang/ordinarydiffeq-dot-jl/builds/894#02c3fa19-ab47-4ee0-9207-cbdde9fd3bb7/398-852
https://github.com/SciML/OrdinaryDiffEq.jl/runs/5034980953?check_suite_focus=true#step:6:461

@ranocha @vpuri3