### PR TITLE
Many tweaks to the default algorithm choice

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -17,8 +17,8 @@ function defaultalg(A, b)
             elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
-            #elseif A === nothing || A isa Matrix
-            #    alg = FastLUFactorization()
+                #elseif A === nothing || A isa Matrix
+                #    alg = FastLUFactorization()
             else
                 alg = LUFactorization()
             end
@@ -75,9 +75,9 @@ function SciMLBase.solve(cache::LinearCache, alg::Nothing,
                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
-            #elseif A isa Matrix
-            #    alg = FastLUFactorization()
-            #    SciMLBase.solve(cache, alg, args...; kwargs...)
+                #elseif A isa Matrix
+                #    alg = FastLUFactorization()
+                #    SciMLBase.solve(cache, alg, args...; kwargs...)
             else
                 alg = LUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
@@ -137,9 +137,9 @@ function init_cacheval(alg::Nothing, A, b, u, Pl, Pr, maxiters, abstol, reltol, 
                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
-            #elseif A isa Matrix
-            #    alg = FastLUFactorization()
-            #    init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
+                #elseif A isa Matrix
+                #    alg = FastLUFactorization()
+                #    init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
             else
                 alg = LUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)

--- a/src/default.jl
+++ b/src/default.jl
@@ -15,7 +15,7 @@ function defaultalg(A, b)
             if length(b) <= 10
                 alg = GenericLUFactorization()
             elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
-                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
+                   eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
             elseif A === nothing || A isa Matrix
                 alg = FastLUFactorization()
@@ -72,7 +72,7 @@ function SciMLBase.solve(cache::LinearCache, alg::Nothing,
                 alg = GenericLUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
             elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
-                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
+                   eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
             elseif A isa Matrix
@@ -134,7 +134,7 @@ function init_cacheval(alg::Nothing, A, b, u, Pl, Pr, maxiters, abstol, reltol, 
                 alg = GenericLUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
             elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
-                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
+                   eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
             elseif A isa Matrix

--- a/src/default.jl
+++ b/src/default.jl
@@ -14,8 +14,11 @@ function defaultalg(A, b)
            ArrayInterfaceCore.can_setindex(b)
             if length(b) <= 10
                 alg = GenericLUFactorization()
-            elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500))
+            elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
+                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
+            elseif A === nothing || A isa Matrix
+                alg = FastLUFactorization()
             else
                 alg = LUFactorization()
             end
@@ -30,7 +33,7 @@ function defaultalg(A, b)
     elseif A isa SymTridiagonal
         alg = GenericFactorization(; fact_alg = ldlt!)
     elseif A isa SparseMatrixCSC
-        alg = UMFPACKFactorization()
+        alg = KLUFactorization()
 
         # This catches the cases where a factorization overload could exist
         # For example, BlockBandedMatrix
@@ -40,7 +43,7 @@ function defaultalg(A, b)
         # This catches the case where A is a CuMatrix
         # Which does not have LU fully defined
     elseif A isa GPUArraysCore.AbstractGPUArray || b isa GPUArraysCore.AbstractGPUArray
-        alg = QRFactorization(false)
+        alg = LUFactorization()
 
         # Not factorizable operator, default to only using A*x
     else
@@ -68,8 +71,12 @@ function SciMLBase.solve(cache::LinearCache, alg::Nothing,
             if length(b) <= 10
                 alg = GenericLUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
-            elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500))
+            elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
+                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
+                SciMLBase.solve(cache, alg, args...; kwargs...)
+            elseif A isa Matrix
+                alg = FastLUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
             else
                 alg = LUFactorization()
@@ -89,7 +96,7 @@ function SciMLBase.solve(cache::LinearCache, alg::Nothing,
         alg = GenericFactorization(; fact_alg = ldlt!)
         SciMLBase.solve(cache, alg, args...; kwargs...)
     elseif A isa SparseMatrixCSC
-        alg = UMFPACKFactorization()
+        alg = KLUFactorization()
         SciMLBase.solve(cache, alg, args...; kwargs...)
 
         # This catches the cases where a factorization overload could exist
@@ -101,7 +108,7 @@ function SciMLBase.solve(cache::LinearCache, alg::Nothing,
         # This catches the case where A is a CuMatrix
         # Which does not have LU fully defined
     elseif A isa GPUArraysCore.AbstractGPUArray
-        alg = QRFactorization(false)
+        alg = LUFactorization()
         SciMLBase.solve(cache, alg, args...; kwargs...)
 
         # Not factorizable operator, default to only using A*x
@@ -126,8 +133,12 @@ function init_cacheval(alg::Nothing, A, b, u, Pl, Pr, maxiters, abstol, reltol, 
             if length(b) <= 10
                 alg = GenericLUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
-            elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500))
+            elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
+                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
+                init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
+            elseif A isa Matrix
+                alg = FastLUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
             else
                 alg = LUFactorization()
@@ -147,7 +158,7 @@ function init_cacheval(alg::Nothing, A, b, u, Pl, Pr, maxiters, abstol, reltol, 
         alg = GenericFactorization(; fact_alg = ldlt!)
         init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
     elseif A isa SparseMatrixCSC
-        alg = UMFPACKFactorization()
+        alg = KLUFactorization()
         init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
 
         # This catches the cases where a factorization overload could exist
@@ -159,7 +170,7 @@ function init_cacheval(alg::Nothing, A, b, u, Pl, Pr, maxiters, abstol, reltol, 
         # This catches the case where A is a CuMatrix
         # Which does not have LU fully defined
     elseif A isa GPUArraysCore.AbstractGPUArray
-        alg = QRFactorization(false)
+        alg = LUFactorization()
         init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
 
         # Not factorizable operator, default to only using A*x

--- a/src/default.jl
+++ b/src/default.jl
@@ -15,7 +15,7 @@ function defaultalg(A, b)
             if length(b) <= 10
                 alg = GenericLUFactorization()
             elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
-                   eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
+                   eltype(A) <: Union{Float32, Float64}
                 alg = RFLUFactorization()
                 #elseif A === nothing || A isa Matrix
                 #    alg = FastLUFactorization()
@@ -72,7 +72,7 @@ function SciMLBase.solve(cache::LinearCache, alg::Nothing,
                 alg = GenericLUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
             elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
-                   eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
+                   eltype(A) <: Union{Float32, Float64}
                 alg = RFLUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
                 #elseif A isa Matrix
@@ -134,7 +134,7 @@ function init_cacheval(alg::Nothing, A, b, u, Pl, Pr, maxiters, abstol, reltol, 
                 alg = GenericLUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
             elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
-                   eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
+                   eltype(A) <: Union{Float32, Float64}
                 alg = RFLUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
                 #elseif A isa Matrix

--- a/src/default.jl
+++ b/src/default.jl
@@ -17,8 +17,8 @@ function defaultalg(A, b)
             elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
-            elseif A === nothing || A isa Matrix
-                alg = FastLUFactorization()
+            #elseif A === nothing || A isa Matrix
+            #    alg = FastLUFactorization()
             else
                 alg = LUFactorization()
             end
@@ -75,9 +75,9 @@ function SciMLBase.solve(cache::LinearCache, alg::Nothing,
                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
-            elseif A isa Matrix
-                alg = FastLUFactorization()
-                SciMLBase.solve(cache, alg, args...; kwargs...)
+            #elseif A isa Matrix
+            #    alg = FastLUFactorization()
+            #    SciMLBase.solve(cache, alg, args...; kwargs...)
             else
                 alg = LUFactorization()
                 SciMLBase.solve(cache, alg, args...; kwargs...)
@@ -137,9 +137,9 @@ function init_cacheval(alg::Nothing, A, b, u, Pl, Pr, maxiters, abstol, reltol, 
                    eltype(A) <: Union{Float32, Float64} && Base.Threads.nthreads() > 1
                 alg = RFLUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
-            elseif A isa Matrix
-                alg = FastLUFactorization()
-                init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
+            #elseif A isa Matrix
+            #    alg = FastLUFactorization()
+            #    init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)
             else
                 alg = LUFactorization()
                 init_cacheval(alg, A, b, u, Pl, Pr, maxiters, abstol, reltol, verbose)


### PR DESCRIPTION
Summary:

- RecrusiveFactorization choice looks for Flaot32|Float64 and Julia threads. This should fix the main issue in https://github.com/SciML/LinearSolve.jl/issues/159 that RFLUFactorization is not optimized on complex matrices
- CuArrays now supports LU factorizations
- If a standard matrix, then use FastLUFactorization

That last bit still has a question mark (https://github.com/SciML/LinearSolve.jl/issues/159#issuecomment-1186526040)