### PR TITLE
prototype canonify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # LinearSolve.jl
 
 [![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](http://linearsolve.sciml.ai/stable)
-[![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/dev/modules/LinearSolve/)
+[![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/LinearSolve/stable/)
 
 [![codecov](https://codecov.io/gh/SciML/LinearSolvers.jl/branch/master/graph/badge.svg)](https://app.codecov.io/gh/SciML/LinearSolve.jl)
 [![Build Status](https://github.com/SciML/LinearSolvers.jl/workflows/CI/badge.svg)](https://github.com/SciML/LinearSolvers.jl/actions?query=workflow%3ACI)
@@ -28,8 +27,8 @@ maximum efficiency. Specifically, LinearSolve.jl includes:
   as optimally as possible
 
 For information on using the package,
-[see the stable documentation](https://linearsolve.sciml.ai/stable/). Use the
-[in-development documentation](https://linearsolve.sciml.ai/dev/) for the version of
+[see the stable documentation](https://docs.sciml.ai/LinearSolve/stable/). Use the
+[in-development documentation](https://docs.sciml.ai/LinearSolve/dev/) for the version of
 the documentation which contains the unreleased features.
 
 ## High Level Examples

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,7 +19,7 @@ makedocs(sitename = "LinearSolve.jl",
          ],
          format = Documenter.HTML(analytics = "UA-90474609-3",
                                   assets = ["assets/favicon.ico"],
-                                  canonical = "https://linearsolve.sciml.ai/stable/"),
+                                  canonical = "https://docs.sciml.ai/LinearSolve/stable/"),
          pages = pages)
 
 deploydocs(;

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ LinearSolve.jl is a unified interface for the linear solving packages of
 Julia. It interfaces with other packages of the Julia ecosystem
 to make it easy to test alternative solver packages and pass small types to
 control algorithm swapping. It also interfaces with the
-[ModelingToolkit.jl](https://mtk.sciml.ai/dev/) world of symbolic modeling to
+[ModelingToolkit.jl](https://docs.sciml.ai/ModelingToolkit/stable/) world of symbolic modeling to
 allow for automatically generating high-performance code.
 
 Performance is key: the current methods are made to be highly performant on


### PR DESCRIPTION
Contains 3/4 points of https://github.com/SciML/SciMLDocs/issues/53 .

I have only updated links between different sciml.ai documentation, but there are also quite a few github links.
Should a link to e.g. catalyst github just link to to catalyst docs?

I think the within package links are smart enough by themselves, e.g.
https://docs.sciml.ai/ModelingToolkit/stable/tutorials/ode_modeling/#Notes-and-pointers-how-to-go-on
 