### PR TITLE
Avoid singular A during precompilation

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -61,7 +61,7 @@ SnoopPrecompile.@precompile_all_calls begin
     sol = solve(prob, RFLUFactorization())
     sol = solve(prob, KrylovJL_GMRES())
 
-    A = sprand(4, 4, 0.9)
+    A = sprand(4, 4, 0.3) + I
     prob = LinearProblem(A, b)
     sol = solve(prob)
     sol = solve(prob, KLUFactorization())


### PR DESCRIPTION
There is a small probability that the current choice is singular which causes a precompilation error.