### PR TITLE
correct mistake in constructor of KrylovKitJL

### DIFF
--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -297,6 +297,7 @@ end
 function KrylovKitJL_CG(args...; kwargs...)
     KrylovKitJL(args...; KrylovAlg = KrylovKit.CG, kwargs..., isposdef = true)
 end
+
 function KrylovKitJL_GMRES(args...; kwargs...)
     KrylovKitJL(args...; KrylovAlg = KrylovKit.GMRES, kwargs...)
 end

--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -301,7 +301,7 @@ function KrylovKitJL_GMRES(args...; kwargs...)
     KrylovKitJL(args...; KrylovAlg = KrylovKit.GMRES, kwargs...)
 end
 
-function SciMLBase.solve(cache::LinearCache, alg::KrylovKitJL, kwargs...)
+function SciMLBase.solve(cache::LinearCache, alg::KrylovKitJL; kwargs...)
     atol = float(cache.abstol)
     rtol = float(cache.reltol)
     maxiter = cache.maxiters

--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -291,11 +291,11 @@ end
 function KrylovKitJL(args...;
                      KrylovAlg = KrylovKit.GMRES, gmres_restart = 0,
                      kwargs...)
-    return KrylovJL(KrylovAlg, gmres_restart, args, kwargs)
+    return KrylovKitJL(KrylovAlg, gmres_restart, args, kwargs)
 end
 
 function KrylovKitJL_CG(args...; kwargs...)
-    KrylovKitJL(args...; KrylovAlg = KrylovKit.CG, kwargs...)
+    KrylovKitJL(args...; KrylovAlg = KrylovKit.CG, kwargs..., isposdef = true)
 end
 function KrylovKitJL_GMRES(args...; kwargs...)
     KrylovKitJL(args...; KrylovAlg = KrylovKit.GMRES, kwargs...)
@@ -306,12 +306,12 @@ function SciMLBase.solve(cache::LinearCache, alg::KrylovKitJL, kwargs...)
     rtol = float(cache.reltol)
     maxiter = cache.maxiters
     verbosity = cache.verbose ? 1 : 0
-    krylovdim = (alg.gmres_restart == 0) ? min(20, size(A, 1)) : alg.gmres_restart
+    krylovdim = (alg.gmres_restart == 0) ? min(20, size(cache.A, 1)) : alg.gmres_restart
 
     kwargs = (atol = atol, rtol = rtol, maxiter = maxiter, verbosity = verbosity,
               krylovdim = krylovdim, alg.kwargs...)
 
-    x, info = KrylovKit.linsolve(cache.A, cache.b, cache.u, alg.KrylovAlg)
+    x, info = KrylovKit.linsolve(cache.A, cache.b, cache.u; kwargs...)
 
     copy!(cache.u, x)
     resid = info.normres

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -193,6 +193,7 @@ end
                     ("CG", KrylovKitJL_CG(kwargs...)),
                     ("GMRES", KrylovKitJL_GMRES(kwargs...)))
             @testset "$(alg[1])" begin test_interface(alg[2], prob1, prob2) end
+			@test alg[2] isa KrylovKitJL
         end
     end
 

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -193,7 +193,7 @@ end
                     ("CG", KrylovKitJL_CG(kwargs...)),
                     ("GMRES", KrylovKitJL_GMRES(kwargs...)))
             @testset "$(alg[1])" begin test_interface(alg[2], prob1, prob2) end
-			@test alg[2] isa KrylovKitJL
+            @test alg[2] isa KrylovKitJL
         end
     end
 


### PR DESCRIPTION
This tries to remove the error on KrylovKit iterative solver. 

I am not sure why but this does not work because of a Rosetta issue on my computer.

Basically, the way to trigger CG is to pass `isposdef = true` to KrylovKit.