### PR TITLE
strict links

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ include("pages.jl")
 makedocs(sitename = "LinearSolve.jl",
          authors = "Chris Rackauckas",
          modules = [LinearSolve, LinearSolve.SciMLBase],
-         clean = true, doctest = false,
+         clean = true, doctest = false, linkcheck = true,
          strict = [
              :doctest,
              :linkcheck,

--- a/docs/src/advanced/custom.md
+++ b/docs/src/advanced/custom.md
@@ -1,4 +1,4 @@
-# Passing in a Custom Linear Solver
+# [Passing in a Custom Linear Solver](@id custom)
 
 Julia users are building a wide variety of applications in the SciML ecosystem,
 often requiring problem-specific handling of their linear solves. As existing solvers in `LinearSolve.jl` may not

--- a/docs/src/basics/FAQ.md
+++ b/docs/src/basics/FAQ.md
@@ -11,7 +11,7 @@ efficiency and ability to choose solvers.
 
 ## Python's NumPy/SciPy just calls fast Fortran/C code, why would LinearSolve.jl be any better?
 
-This is addressed in the [JuliaCon 2022 video](https://youtu.be/JWI34_w-yYw?t=182). This happens in
+This is addressed in the [JuliaCon 2022 video](https://www.youtube.com/watch?v=JWI34_w-yYw&t=182s). This happens in
 a few ways:
 
  1. The Fortran/C code that NumPy/SciPy uses is actually slow. It's [OpenBLAS](https://github.com/xianyi/OpenBLAS),

--- a/docs/src/basics/Preconditioners.md
+++ b/docs/src/basics/Preconditioners.md
@@ -80,7 +80,7 @@ The following preconditioners match the interface of LinearSolve.jl.
   - [IncompleteLU.ilu](https://github.com/haampie/IncompleteLU.jl): an implementation
     of the incomplete LU-factorization preconditioner. This requires `A` as a
     `SparseMatrixCSC`.
-  - [Preconditioners.CholeskyPreconditioner(A, i)](https://github.com/mohamed82008/Preconditioners.jl):
+  - [Preconditioners.CholeskyPreconditioner(A, i)](https://github.com/JuliaLinearAlgebra/Preconditioners.jl):
     An incomplete Cholesky preconditioner with cut-off level `i`. Requires `A` as
     a `AbstractMatrix` and positive semi-definite.
   - [AlgebraicMultiGrid](https://github.com/JuliaLinearAlgebra/AlgebraicMultigrid.jl):

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -35,7 +35,7 @@ with CPUs and GPUs, and thus is the generally preferred form for Krylov methods.
 
 Finally, a user can pass a custom function for handling the linear solve using
 `LinearSolveFunction()` if existing solvers are not optimally suited for their application.
-The interface is detailed [here](#passing-in-a-custom-linear-solver).
+The interface is detailed [here](@ref custom).
 
 ## Full List of Methods
 


### PR DESCRIPTION
Without `linkcheck=true` the strict doc build will never fail.