### PR TITLE
Deprecate the extra libs

### DIFF
--- a/lib/LinearSolveCUDA/Project.toml
+++ b/lib/LinearSolveCUDA/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearSolveCUDA"
 uuid = "0d26bed2-170e-468a-8415-1cfcbba6e180"
 authors = ["SciML"]
-version = "0.1"
+version = "0.1.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/lib/LinearSolveCUDA/src/LinearSolveCUDA.jl
+++ b/lib/LinearSolveCUDA/src/LinearSolveCUDA.jl
@@ -1,5 +1,7 @@
 module LinearSolveCUDA
 
+@warn "LinearSolveCUDA.jl is deprecated and made into an extension package in LinearSolve 2.0. Instead, simply `using CUDA`. Please see the documentation for more details."
+
 using CUDA, LinearAlgebra, LinearSolve, SciMLBase
 using SciMLBase: AbstractSciMLOperator
 

--- a/lib/LinearSolvePardiso/Project.toml
+++ b/lib/LinearSolvePardiso/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearSolvePardiso"
 uuid = "a6722589-28b8-4472-944e-bde9ee6da670"
 authors = ["SciML"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/lib/LinearSolvePardiso/src/LinearSolvePardiso.jl
+++ b/lib/LinearSolvePardiso/src/LinearSolvePardiso.jl
@@ -1,5 +1,7 @@
 module LinearSolvePardiso
 
+@warn "LinearSolvePardiso.jl is deprecated and made into an extension package in LinearSolve 2.0. Instead, simply `using Pardiso`. Please see the documentation for more details."
+
 using Pardiso, LinearSolve, SciMLBase
 using SparseArrays
 using SparseArrays: nonzeros, rowvals, getcolptr


### PR DESCRIPTION
There isn't a perfectly nice way to do this, but this seems reasonable to add after the release is out.