### PR TITLE
Always pivot in RFLUFactorization

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -178,12 +178,7 @@ function defaultalg(A, b, assump::OperatorAssumptions{true})
             elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500)) &&
                    (A === nothing ? eltype(b) <: Union{Float32, Float64} :
                     eltype(A) <: Union{Float32, Float64})
-                pivot = if __conditioning(assump) === OperatorCondition.IllConditioned
-                    Val(true)
-                else
-                    Val(false)
-                end
-                alg = RFLUFactorization(; pivot = pivot)
+                alg = RFLUFactorization()
                 #elseif A === nothing || A isa Matrix
                 #    alg = FastLUFactorization()
             else


### PR DESCRIPTION
This was a mistake introduced when the other factorization option was split