### PR TITLE
Update documentation regarding alias behavior

### DIFF
--- a/docs/src/basics/common_solver_opts.md
+++ b/docs/src/basics/common_solver_opts.md
@@ -7,12 +7,14 @@ The following are the options these algorithms take, along with their defaults.
 
 ## General Controls
 
-  - `alias_A`: Whether to alias the matrix `A` or use a copy by default. When true,
+  - `alias_A::Bool`: Whether to alias the matrix `A` or use a copy by default. When `true`,
     algorithms like LU-factorization can be faster by reusing the memory via `lu!`,
-    but care must be taken as the original input will be modified. Default is `false`.
-  - `alias_b`: Whether to alias the matrix `b` or use a copy by default. When true,
+    but care must be taken as the original input will be modified. Default is `true` if the
+    algorithm is known not to modify `A`, otherwise is `false`.
+  - `alias_b::Bool`: Whether to alias the matrix `b` or use a copy by default. When `true`,
     algorithms can write and change `b` upon usage. Care must be taken as the
-    original input will be modified. Default is `false`.
+    original input will be modified. Default is `true` if the algorithm is known not to
+    modify `b`, otherwise `false`.
   - `verbose`: Whether to print extra information. Defaults to `false`.
   - `assumptions`: Sets the assumptions of the operator in order to effect the default
     choice algorithm. See the [Operator Assumptions page for more details](@ref assumptions).

--- a/src/common.jl
+++ b/src/common.jl
@@ -107,6 +107,10 @@ default_tol(::Type{Any}) = 0
 default_alias_A(::Any, ::Any, ::Any) = false
 default_alias_b(::Any, ::Any, ::Any) = false
 
+# Non-destructive algorithms default to true
+default_alias_A(::AbstractKrylovSubspaceMethod, ::Any, ::Any) = true
+default_alias_b(::AbstractKrylovSubspaceMethod, ::Any, ::Any) = true
+
 function SciMLBase.init(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm,
                         args...;
                         alias_A = default_alias_A(alg, prob.A, prob.b),


### PR DESCRIPTION
This patch documents that `alias_A` and `alias_b` may depend on whether
the algorithm is known not to modify `A` or `b`. As a minimal first
change, this patch updates the default value for
`alg::AbstractKrylovSubspaceMethod` from `false` to `true`.