### PR TITLE
Setup retcode for Krylov.jl

### DIFF
--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -270,6 +270,18 @@ function SciMLBase.solve!(cache::LinearCache, alg::KrylovJL; kwargs...)
     stats = @get_cacheval(cache, :KrylovJL_GMRES).stats
     resid = stats.residuals |> last
 
+    retcode = if !stats.solved
+        if stats.status == "maximum number of iterations exceeded"
+            ReturnCode.MaxIters
+        elseif stats.status == "solution good enough given atol and rtol"
+            ReturnCode.ConvergenceFailure
+        else
+            ReturnCode.Failure
+        end
+    else
+        ReturnCode.Success
+    end
+
     return SciMLBase.build_linear_solution(alg, cache.u, resid, cache;
         iters = stats.niter)
 end


### PR DESCRIPTION
This solves https://github.com/SciML/LinearSolve.jl/issues/297. KrylovKit.jl already throws `ReturnCode.Failure` if it doesn't converge, IterativeSolvers.jl doesn't have it possible, and now Krylov.jl is using retcodes. So now nothing is silent on non-convergence when it's possible to be known from the solver. This also fixes https://github.com/SciML/LinearSolve.jl/issues/298