### PR TITLE
Set a sparsity threshold for KLU

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -79,7 +79,9 @@ end
     function defaultalg(A::AbstractSparseMatrixCSC{<:Union{Float64, ComplexF64}, Ti}, b,
         assump::OperatorAssumptions) where {Ti}
         if assump.issq
-            if length(b) <= 10_000 && length(nonzeros(A)) / length(A) < 1e-4
+            @show length(b) <= 10_000
+            @show length(nonzeros(A)) / length(A)
+            if length(b) <= 10_000 && length(nonzeros(A)) / length(A) < 2e-4
                 DefaultLinearSolver(DefaultAlgorithmChoice.KLUFactorization)
             else
                 DefaultLinearSolver(DefaultAlgorithmChoice.UMFPACKFactorization)

--- a/src/default.jl
+++ b/src/default.jl
@@ -79,7 +79,7 @@ end
     function defaultalg(A::AbstractSparseMatrixCSC{<:Union{Float64, ComplexF64}, Ti}, b,
         assump::OperatorAssumptions) where {Ti}
         if assump.issq
-            if length(b) <= 10_000
+            if length(b) <= 10_000 && length(nonzeros(A)) / length(A) < 1e-4
                 DefaultLinearSolver(DefaultAlgorithmChoice.KLUFactorization)
             else
                 DefaultLinearSolver(DefaultAlgorithmChoice.UMFPACKFactorization)

--- a/test/default_algs.jl
+++ b/test/default_algs.jl
@@ -21,7 +21,7 @@ solve(prob)
     LinearSolve.OperatorAssumptions(false)).alg ===
       LinearSolve.DefaultAlgorithmChoice.QRFactorization
 
-@test LinearSolve.defaultalg(sprand(1000, 1000, 0.5), zeros(1000)).alg ===
+@test LinearSolve.defaultalg(sprand(1000, 1000, 1e-5) + I, zeros(1000)).alg ===
       LinearSolve.DefaultAlgorithmChoice.KLUFactorization
 prob = LinearProblem(sprand(1000, 1000, 0.5), zeros(1000))
 solve(prob)

--- a/test/default_algs.jl
+++ b/test/default_algs.jl
@@ -21,7 +21,7 @@ solve(prob)
     LinearSolve.OperatorAssumptions(false)).alg ===
       LinearSolve.DefaultAlgorithmChoice.QRFactorization
 
-@test LinearSolve.defaultalg(sprand(1000, 1000, 1e-5) + I, zeros(1000)).alg ===
+@test LinearSolve.defaultalg(sprand(1000, 1000, 1e-6) + I, zeros(1000)).alg ===
       LinearSolve.DefaultAlgorithmChoice.KLUFactorization
 prob = LinearProblem(sprand(1000, 1000, 0.5), zeros(1000))
 solve(prob)

--- a/test/default_algs.jl
+++ b/test/default_algs.jl
@@ -21,7 +21,7 @@ solve(prob)
     LinearSolve.OperatorAssumptions(false)).alg ===
       LinearSolve.DefaultAlgorithmChoice.QRFactorization
 
-@test LinearSolve.defaultalg(sprand(1000, 1000, 1e-6) + I, zeros(1000)).alg ===
+@test LinearSolve.defaultalg(sprand(10^4, 10^4, 1e-5) + I, zeros(1000)).alg ===
       LinearSolve.DefaultAlgorithmChoice.KLUFactorization
 prob = LinearProblem(sprand(1000, 1000, 0.5), zeros(1000))
 solve(prob)


### PR DESCRIPTION
Closes https://github.com/SciML/LinearSolve.jl/issues/340. While many results are very much based on more details about the sparsity pattern, it's at least clear that if the matrix is not very sparse then it should probably use UMFPACK, so this is a conservative bound. When mixed with the length bound, I find that this seems to work rather well, though is not always optimal, is at least better than always choosing UMFPACK