### PR TITLE
Setup 64-bit AppleAccelerate 64-bit version

### DIFF
--- a/src/appleaccelerate.jl
+++ b/src/appleaccelerate.jl
@@ -12,7 +12,9 @@ AppleAccelerateLUFactorization()
 A wrapper over Apple's Accelerate Library. Direct calls to Acceelrate in a way that pre-allocates workspace
 to avoid allocations and does not require libblastrampoline.
 """
-struct AppleAccelerateLUFactorization <: AbstractFactorization end
+struct AppleAccelerateLUFactorization{use64} <: AbstractFactorization 
+    AppleAccelerateLUFactorization(use64 = false) = new{use64}()
+end
 
 function appleaccelerate_isavailable()
     libacc_hdl = Libdl.dlopen_e(libacc)
@@ -64,23 +66,65 @@ function aa_getrs!(trans::AbstractChar, A::AbstractMatrix{<:Float64}, ipiv::Abst
     B
 end
 
+function aa_getrf64!(A::AbstractMatrix{<:Float64}; ipiv = similar(A, BlasInt, min(size(A,1),size(A,2))), info = Ref{BlasInt}(), check = false)
+    require_one_based_indexing(A)
+    check && chkfinite(A)
+    chkstride1(A)
+    m, n = size(A)
+    lda  = max(1,stride(A, 2))
+    if isempty(ipiv)
+        ipiv = similar(A, BlasInt, min(size(A,1),size(A,2)))
+    end
+    ccall("dgetrf\$NEWLAPACK\$ILP64", Cvoid,
+            (Ref{BlasInt}, Ref{BlasInt}, Ptr{Float64},
+            Ref{BlasInt}, Ptr{BlasInt}, Ptr{BlasInt}),
+            m, n, A, lda, ipiv, info)
+    info[] < 0 && throw(ArgumentError("Invalid arguments sent to LAPACK dgetrf_"))
+    A, ipiv, BlasInt(info[]), info #Error code is stored in LU factorization type
+end
+
+function aa_getrs64!(trans::AbstractChar, A::AbstractMatrix{<:Float64}, ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{<:Float64}; info = Ref{BlasInt}())
+    require_one_based_indexing(A, ipiv, B)
+    LinearAlgebra.LAPACK.chktrans(trans)
+    chkstride1(A, B, ipiv)
+    n = LinearAlgebra.checksquare(A)
+    if n != size(B, 1)
+        throw(DimensionMismatch("B has leading dimension $(size(B,1)), but needs $n"))
+    end
+    if n != length(ipiv)
+        throw(DimensionMismatch("ipiv has length $(length(ipiv)), but needs to be $n"))
+    end
+    nrhs = size(B, 2)
+    ccall(("dgetrs\$NEWLAPACK\$ILP64", libacc), Cvoid,
+          (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ptr{Float64}, Ref{BlasInt},
+           Ptr{BlasInt}, Ptr{Float64}, Ref{BlasInt}, Ptr{BlasInt}, Clong),
+          trans, n, size(B,2), A, max(1,stride(A,2)), ipiv, B, max(1,stride(B,2)), info, 1)
+    LinearAlgebra.LAPACK.chklapackerror(BlasInt(info[]))
+    B
+end
+
 default_alias_A(::AppleAccelerateLUFactorization, ::Any, ::Any) = false
 default_alias_b(::AppleAccelerateLUFactorization, ::Any, ::Any) = false
 
-function LinearSolve.init_cacheval(alg::AppleAccelerateLUFactorization, A, b, u, Pl, Pr,
+function LinearSolve.init_cacheval(alg::AppleAccelerateLUFactorization{use64}, A, b, u, Pl, Pr,
     maxiters::Int, abstol, reltol, verbose::Bool,
-    assumptions::OperatorAssumptions)
+    assumptions::OperatorAssumptions) where {use64}
+    T = use64 ? BlasInt : Cint
     luinst = ArrayInterface.lu_instance(convert(AbstractMatrix, A))
-    LU(luinst.factors,similar(A, Cint, 0), luinst.info), Ref{Cint}()
+    LU(luinst.factors,similar(A, T, 0), luinst.info), Ref{T}()
 end
 
-function SciMLBase.solve!(cache::LinearCache, alg::AppleAccelerateLUFactorization;
-    kwargs...)
+function SciMLBase.solve!(cache::LinearCache, alg::AppleAccelerateLUFactorization{use64};
+    kwargs...) where {use64}
     A = cache.A
     A = convert(AbstractMatrix, A)
     if cache.isfresh
         cacheval = @get_cacheval(cache, :AppleAccelerateLUFactorization)
-        res = aa_getrf!(A; ipiv = cacheval[1].ipiv, info = cacheval[2])
+        if use64
+            res = aa_getrf64!(A; ipiv = cacheval[1].ipiv, info = cacheval[2])
+        else
+            res = aa_getrf!(A; ipiv = cacheval[1].ipiv, info = cacheval[2])
+        end
         fact = LU(res[1:3]...), res[4]
         cache.cacheval = fact
         cache.isfresh = false
@@ -91,11 +135,19 @@ function SciMLBase.solve!(cache::LinearCache, alg::AppleAccelerateLUFactorizatio
     m, n = size(A, 1), size(A, 2)
     if m > n
         Bc = copy(cache.b)
-        aa_getrs!('N', A.factors, A.ipiv, Bc; info)
+        if use64
+            aa_getrs64!('N', A.factors, A.ipiv, Bc; info)
+        else
+            aa_getrs!('N', A.factors, A.ipiv, Bc; info)
+        end
         return copyto!(cache.u, 1, Bc, 1, n)
     else
         copyto!(cache.u, cache.b)
-        aa_getrs!('N', A.factors, A.ipiv, cache.u; info)
+        if use64
+            aa_getrs64!('N', A.factors, A.ipiv, cache.u; info)
+        else
+            aa_getrs!('N', A.factors, A.ipiv, cache.u; info)
+        end
     end
 
     SciMLBase.build_linear_solution(alg, cache.u, nothing, cache)


### PR DESCRIPTION
It may not be very useful though. Test script:

```julia
using BenchmarkTools, Random, VectorizationBase
using LinearAlgebra, LinearSolve
nc = min(Int(VectorizationBase.num_cores()), Threads.nthreads())
BLAS.set_num_threads(nc)
BenchmarkTools.DEFAULT_PARAMETERS.seconds = 0.5

function luflop(m, n = m; innerflop = 2)
    sum(1:min(m, n)) do k
        invflop = 1
        scaleflop = isempty((k + 1):m) ? 0 : sum((k + 1):m)
        updateflop = isempty((k + 1):n) ? 0 :
                     sum((k + 1):n) do j
            isempty((k + 1):m) ? 0 : sum((k + 1):m) do i
                innerflop
            end
        end
        invflop + scaleflop + updateflop
    end
end

algs = [LUFactorization(), GenericLUFactorization(), RFLUFactorization(), AppleAccelerateLUFactorization(), AppleAccelerateLUFactorization(true), FastLUFactorization(), SimpleLUFactorization()]
res = [Float64[] for i in 1:length(algs)]

ns = 4:8:500
for i in 1:length(ns)
    n = ns[i]
    @info "$n × $n"
    rng = MersenneTwister(123)
    global A = rand(rng, n, n)
    global b = rand(rng, n)
    global u0= rand(rng, n)

    for j in 1:length(algs)
        bt = @belapsed solve(prob, $(algs[j])).u setup=(prob = LinearProblem(copy(A), copy(b); u0 = copy(u0), alias_A=true, alias_b=true))
        push!(res[j], luflop(n) / bt / 1e9)
    end
end

using Plots
__parameterless_type(T) = Base.typename(T).wrapper
parameterless_type(x) = __parameterless_type(typeof(x))
parameterless_type(::Type{T}) where {T} = __parameterless_type(T)

p = plot(ns, res[1]; ylabel = "GFLOPs", xlabel = "N", title = "GFLOPs for NxN LU Factorization", label = string(Symbol(parameterless_type(algs[1]))), legend=:outertopright)
for i in 2:length(res)
    if algs[i] isa AppleAccelerateLUFactorization{true}
        plot!(p, ns, res[i]; label = "AppleAccelerateLUFactorization 64-bit")
    else
        plot!(p, ns, res[i]; label = string(Symbol(parameterless_type(algs[i]))))
    end
end
p

savefig("lubench.png")
savefig("lubench.pdf")
```
