### PR TITLE
[EnzymeExt] Prefix AbstractKrylovSubspaceMethod to avoid undefvarerror

### DIFF
--- a/ext/LinearSolveEnzymeExt.jl
+++ b/ext/LinearSolveEnzymeExt.jl
@@ -144,7 +144,7 @@ function EnzymeCore.EnzymeRules.reverse(config, func::Const{typeof(LinearSolve.s
             _linsolve.cacheval' \ dy
         elseif _linsolve.cacheval isa Tuple && _linsolve.cacheval[1] isa Factorization
             _linsolve.cacheval[1]' \ dy
-        elseif _linsolve.alg isa AbstractKrylovSubspaceMethod
+        elseif _linsolve.alg isa LinearSolve.AbstractKrylovSubspaceMethod
             # Doesn't modify `A`, so it's safe to just reuse it
             invprob = LinearSolve.LinearProblem(transpose(_linsolve.A), dy)
             solve(invprob;


### PR DESCRIPTION
Fixes bug when using LinearSolve (cc @wsmoses)
```julia

ERROR: LoadError: UndefVarError: `AbstractKrylovSubspaceMethod` not defined
Stacktrace:
  [1] #reverse#22
    @ ~/.julia/packages/LinearSolve/sUzK0/ext/LinearSolveEnzymeExt.jl:147
  [2] reverse
    @ ~/.julia/packages/LinearSolve/sUzK0/ext/LinearSolveEnzymeExt.jl:132 [inlined]
  [3] #solve#83
    @ ./deprecated.jl:105
  [4] solve
    @ ./deprecated.jl:103
  [5] Solverx
    @ ~/Dartmouth/dJUICE/src/core/toolkits.jl:212
  [6] Solverx
    @ ~/Dartmouth/dJUICE/src/core/toolkits.jl:199 [inlined]
  [7] solutionsequence_nonlinear
    @ ~/Dartmouth/dJUICE/src/core/solutionsequences.jl:53
  [8] Core
    @ ~/Dartmouth/dJUICE/src/core/analyses/stressbalanceanalysis.jl:114
  [9] costfunction
    @ ~/Dartmouth/dJUICE/src/core/solve.jl:70 [inlined]
 [10] diffejulia_costfunction_3853wrap
    @ ~/Dartmouth/dJUICE/src/core/solve.jl:0
 [11] macro expansion
    @ dJUICE ~/.julia/dev/Enzyme/src/compiler.jl:9875 [inlined]
 [12] enzyme_call
    @ dJUICE ~/.julia/dev/Enzyme/src/compiler.jl:9553 [inlined]
 [13] CombinedAdjointThunk
    @ dJUICE ~/.julia/dev/Enzyme/src/compiler.jl:9516 [inlined]
 [14] autodiff
    @ dJUICE ~/.julia/dev/Enzyme/src/Enzyme.jl:213 [inlined]
 [15] autodiff
    @ dJUICE ~/.julia/dev/Enzyme/src/Enzyme.jl:236 [inlined]
 [16] autodiff
 ```
