### PR TITLE
Don't use AppleAccelerate on number types that are not floats

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -162,7 +162,9 @@ function defaultalg(A, b, assump::OperatorAssumptions)
                 __conditioning(assump) === OperatorCondition.WellConditioned)
                 if length(b) <= 10
                     DefaultAlgorithmChoice.GenericLUFactorization
-                elseif VERSION >= v"1.8" && appleaccelerate_isavailable()
+                elseif VERSION >= v"1.8" && appleaccelerate_isavailable() &&
+                       (A === nothing ? eltype(b) <: Union{Float32, Float64} :
+                           eltype(A) <: Union{Float32, Float64})
                     DefaultAlgorithmChoice.AppleAccelerateLUFactorization
                 elseif (length(b) <= 100 || (isopenblas() && length(b) <= 500) ||
                        (usemkl && length(b) <= 200)) &&


### PR DESCRIPTION
@ChrisRackauckas I saw that this was done for MKL in #390, but it seems to be missing for AppleAccelerate. Is this the correct way to handle it?