### PR TITLE
Don't use type-printing from inside a generated function

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -320,7 +320,7 @@ cache.cacheval = NamedTuple(LUFactorization = cache of LUFactorization, ...)
 end
 
 function defaultalg_symbol(::Type{T}) where {T}
-    Symbol(split(string(SciMLBase.parameterless_type(T)), ".")[end])
+    Base.typename(SciMLBase.parameterless_type(T)).name
 end
 defaultalg_symbol(::Type{<:GenericFactorization{typeof(ldlt!)}}) = :LDLtFactorization
 


### PR DESCRIPTION
Base's type printing code uses the REPL's currently active module to determine how to print types. Unfortunately, this means it is illegal to use this in generated functions. Switch to grabbing the symbol directly from the typename, since this now errors on julia master:
```
  Got exception outside of a @test
  LoadError: MethodError: no method matching active_module()
  You may have intended to import Base.active_module
  The applicable method may be too new: running in world age 26446, while current world is 26576.

  Closest candidates are:
    active_module(::REPL.LineEditREPL) (method too new to be called from this world context.)
     @ REPL ~/julia/usr/share/julia/stdlib/v1.11/REPL/src/REPL.jl:590
    active_module() (method too new to be called from this world context.)
     @ REPL ~/julia/usr/share/julia/stdlib/v1.11/REPL/src/REPL.jl:586
    active_module(::REPL.REPLDisplay) (method too new to be called from this world context.)
     @ REPL ~/julia/usr/share/julia/stdlib/v1.11/REPL/src/REPL.jl:592
    ...

  Stacktrace:
    [1] #invokelatest#2
      @ ./essentials.jl:1025 [inlined]
    [2] invokelatest
      @ ./essentials.jl:1022 [inlined]
    [3] active_module
      @ ./show.jl:512 [inlined]
    [4] show_type_name(io::IOBuffer, tn::Core.TypeName)
      @ Base ./show.jl:1051
    [5] _show_type(io::IOBuffer, x::Type)
      @ Base ./show.jl:966
    [6] show(io::IOBuffer, x::Type)
      @ Base ./show.jl:963
    [7] print(io::IOBuffer, x::Type)
      @ Base ./strings/io.jl:35
    [8] print_to_string(xs::Type)
      @ Base ./strings/io.jl:148
    [9] string
      @ ./strings/io.jl:189 [inlined]
   [10] defaultalg_symbol(::Type{LinearSolve.LUFactorization{LinearAlgebra.RowMaximum}})
      @ LinearSolve ~/.julia/packages/LinearSolve/4aydZ/src/default.jl:323
```