### PR TITLE
Added the posibility to modify the control paramteres of UMFPACK alg

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -750,10 +750,6 @@ patterns with “more structure”.
     `A` has the same sparsity pattern as the previous `A`. If this algorithm is to
     be used in a context where that assumption does not hold, set `reuse_symbolic=false`.
 
-    There is also the possibility to set your own control array for the factorization that will be  
-    passed at the SparseArrays package. To do so u have to pass a Vector{Float64} with 20 elements.
-    If no vecetor is passed the default control array is used.
-    More details on the UMFPACK doc
 """
 
 Base.@kwdef struct UMFPACKFactorization{T <: Union{Nothing, Vector{Float64}}} <: AbstractFactorization

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -735,6 +735,14 @@ const default_control=[1.0, 0.2, 0.2, 0.1, 32.0, 0.0, 0.7, 0.0, 1.0, 0.3, 1.0, 1
 A fast sparse multithreaded LU-factorization which specializes on sparsity
 patterns with “more structure”.
 
+## Fields
+
+* `reuse_symbolic`: Whether the symbolic factorization is reused between calls. This requires that the sparsity pattern is
+  preserved. Defaults to true.
+* `check_pattern`: Whether the sparsity pattern is checked for changes to allow for symbolic factorization caching. 
+  The default is true.
+* `control`: A control vector for more options to pass to UMFPACK. See the UMFPACK documentation for more details.
+
 !!! note
 
     By default, the SparseArrays.jl are implemented for efficiency by caching the

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -727,7 +727,7 @@ end
 
 #!!!ATTENTION
 #These array could change and whenever there will be a change in the SparseArrays package this array must be changed
-const default_control=[1.0, 0.2, 0.2, 0.1, 32.0, 0.0, 0.7, 0.0, 1.0, 0.3, 1.0, 1.0, 0.9, 0.0, 10.0, 0.001, 1.0, 0.5, 0.0, 1.0]
+const default_control=SparseArrays.UMFPACK.get_umfpack_control(Float64,Int64)
 
 """
 `UMFPACKFactorization(;reuse_symbolic=true, check_pattern=true, control=Vector{Float64}(20))`

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -738,10 +738,10 @@ patterns with “more structure”.
 """
 const default_control::Array{FLoat64}=[1.0, 0.2, 0.2, 0.1, 32.0, 0.0, 0.7, 0.0, 1.0, 0.3, 1.0, 1.0, 0.9, 0.0, 10.0, 0.001, 1.0, 0.5, 0.0, 1.0]
 
-Base.@kwdef struct UMFPACKFactorization <: AbstractFactorization
+Base.@kwdef struct UMFPACKFactorization{T <: Union{Nothing, Vector{Float64}} <: AbstractFactorization
     reuse_symbolic::Bool = true
     check_pattern::Bool = true # Check factorization re-use
-    control::Vector{Float64}=nothing
+    control::T=nothing
 end
 
 const PREALLOCATED_UMFPACK = SparseArrays.UMFPACK.UmfpackLU(SparseMatrixCSC(0, 0, [1],

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -736,7 +736,7 @@ patterns with “more structure”.
     `A` has the same sparsity pattern as the previous `A`. If this algorithm is to
     be used in a context where that assumption does not hold, set `reuse_symbolic=false`.
 """
-const default_control::Array{FLoat64}=[1.0, 0.2, 0.2, 0.1, 32.0, 0.0, 0.7, 0.0, 1.0, 0.3, 1.0, 1.0, 0.9, 0.0, 10.0, 0.001, 1.0, 0.5, 0.0, 1.0]
+const default_control=[1.0, 0.2, 0.2, 0.1, 32.0, 0.0, 0.7, 0.0, 1.0, 0.3, 1.0, 1.0, 0.9, 0.0, 10.0, 0.001, 1.0, 0.5, 0.0, 1.0]
 
 Base.@kwdef struct UMFPACKFactorization{T <: Union{Nothing, Vector{Float64}} <: AbstractFactorization
     reuse_symbolic::Bool = true

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -723,8 +723,14 @@ end
 
 ################################## Factorizations which require solve! overloads
 
+# Default control array of 20 elements from Umfpack
+
+#!!!ATTENTION
+#These array could change and whenever there will be a change in the SparseArrays package this array must be changed
+const default_control=[1.0, 0.2, 0.2, 0.1, 32.0, 0.0, 0.7, 0.0, 1.0, 0.3, 1.0, 1.0, 0.9, 0.0, 10.0, 0.001, 1.0, 0.5, 0.0, 1.0]
+
 """
-`UMFPACKFactorization(;reuse_symbolic=true, check_pattern=true)`
+`UMFPACKFactorization(;reuse_symbolic=true, check_pattern=true, control=Vector{Float64}(20))`
 
 A fast sparse multithreaded LU-factorization which specializes on sparsity
 patterns with “more structure”.
@@ -735,10 +741,14 @@ patterns with “more structure”.
     symbolic factorization. I.e., if `set_A` is used, it is expected that the new
     `A` has the same sparsity pattern as the previous `A`. If this algorithm is to
     be used in a context where that assumption does not hold, set `reuse_symbolic=false`.
-"""
-const default_control=[1.0, 0.2, 0.2, 0.1, 32.0, 0.0, 0.7, 0.0, 1.0, 0.3, 1.0, 1.0, 0.9, 0.0, 10.0, 0.001, 1.0, 0.5, 0.0, 1.0]
 
-Base.@kwdef struct UMFPACKFactorization{T <: Union{Nothing, Vector{Float64}} <: AbstractFactorization
+    There is also the possibility to set your own control array for the factorization that will be  
+    passed at the SparseArrays package. To do so u have to pass a Vector{Float64} with 20 elements.
+    If no vecetor is passed the default control array is used.
+    More details on the UMFPACK doc
+"""
+
+Base.@kwdef struct UMFPACKFactorization{T <: Union{Nothing, Vector{Float64}}} <: AbstractFactorization
     reuse_symbolic::Bool = true
     check_pattern::Bool = true # Check factorization re-use
     control::T=nothing

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -739,6 +739,7 @@ patterns with “more structure”.
 Base.@kwdef struct UMFPACKFactorization <: AbstractFactorization
     reuse_symbolic::Bool = true
     check_pattern::Bool = true # Check factorization re-use
+    control::Vector{Float64}=SparseArrays.UMFPACK.get_umfpack_control(Float64,Int64) # Control Parameters of UMFPACK 
 end
 
 const PREALLOCATED_UMFPACK = SparseArrays.UMFPACK.UmfpackLU(SparseMatrixCSC(0, 0, [1],
@@ -782,15 +783,15 @@ function SciMLBase.solve!(cache::LinearCache, alg::UMFPACKFactorization; kwargs.
                 fact = lu(
                     SparseMatrixCSC(size(A)..., getcolptr(A), rowvals(A),
                         nonzeros(A)),
-                    check = false)
+                    check = false, control=alg.control)
             else
                 fact = lu!(cacheval,
                     SparseMatrixCSC(size(A)..., getcolptr(A), rowvals(A),
-                        nonzeros(A)), check = false)
+                        nonzeros(A)), check = false, control=alg.control)
             end
         else
             fact = lu(SparseMatrixCSC(size(A)..., getcolptr(A), rowvals(A), nonzeros(A)),
-                check = false)
+                check = false, control=alg.control)
         end
         cache.cacheval = fact
         cache.isfresh = false

--- a/test/controlvectortest.jl
+++ b/test/controlvectortest.jl
@@ -4,7 +4,7 @@ A = sparse(rand(3,3));
 b=rand(3);
 prob = LinearProblem(A, b);
 
-#check without contro Vector
+#check without control Vector
 u=solve(prob,UMFPACKFactorization()).u
 
 #check plugging in a control vector

--- a/test/controlvectortest.jl
+++ b/test/controlvectortest.jl
@@ -1,0 +1,12 @@
+using SparseArrays, LinearSolve
+
+A = sparse(rand(3,3));
+b=rand(3);
+prob = LinearProblem(A, b);
+
+#check without contro Vector
+u=solve(prob,UMFPACKFactorization()).u
+
+#check plugging in a control vector
+controlv=SparseArrays.UMFPACK.get_umfpack_control(Float64,Int64)
+u=solve(prob,UMFPACKFactorization(control=controlv)).u


### PR DESCRIPTION
#383 
I have added a vector of type Float 64 in the UMFPACKFactorization structure in order to give the possibility to the user to plug in their customized control vector int the UMFPACK algorithm; 
This control vector is used in the solve function and is passed to SparseArrays through the lu function.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

For a deeper understing on the control vector i sugest to read subsection 5.10 at page 23 in the following pdf
https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/dev/UMFPACK/Doc/UMFPACK_UserGuide.pdf
