### PR TITLE
Enable "WIP: Wrap BLIS" with reference LAPACK

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,13 +39,14 @@ HYPRE = "b5ffcf37-a2bd-41ab-a3da-4bd9bc8ad771"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
+LAPACK_jll = "51474c39-65e3-53ba-86ba-03b1b862ec14"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
 [extensions]
 LinearSolveBandedMatricesExt = "BandedMatrices"
-LinearSolveBLISExt = "blis_jll"
+LinearSolveBLISExt = ["blis_jll", "LAPACK_jll"]
 LinearSolveBlockDiagonalsExt = "BlockDiagonals"
 LinearSolveCUDAExt = "CUDA"
 LinearSolveEnzymeExt = "Enzyme"


### PR DESCRIPTION
Based on #431, this demonstrates how to get the BLIS extension working using `libblastrampoline` combined with `LAPACK_jll` (based on Reference LAPACK 3.11 https://github.com/Reference-LAPACK/lapack/releases/tag/v3.11)

Note that `suffix_hint="64_",` in `BLAS.lbt_forward` enables ILP versions.
