### PR TITLE
Fix returncodes and stats for iterative solvers

### DIFF
--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -306,5 +306,5 @@ function SciMLBase.solve!(cache::LinearCache, alg::KrylovJL; kwargs...)
     end
 
     return SciMLBase.build_linear_solution(alg, cache.u, resid, cache;
-        iters = stats.niter)
+        iters = stats.niter, retcode, stats)
 end

--- a/test/retcodes.jl
+++ b/test/retcodes.jl
@@ -1,0 +1,46 @@
+@testset "Return codes" begin
+    alglist = (
+        LUFactorization,
+        QRFactorization,
+        DiagonalFactorization,
+        DirectLdiv!,
+        SparspakFactorization,
+        KLUFactorization,
+        UMFPACKFactorization,
+        KrylovJL_GMRES,
+        GenericLUFactorization,
+        RFLUFactorization,
+        LDLtFactorization,
+        BunchKaufmanFactorization,
+        CHOLMODFactorization,
+        SVDFactorization,
+        CholeskyFactorization,
+        NormalCholeskyFactorization,
+        AppleAccelerateLUFactorization,
+        MKLLUFactorization,
+        KrylovJL_CRAIGMR,
+        KrylovJL_LSMR,
+    )
+
+    @testset "Success" begin
+        for alg in alglist
+            A = [2.0 1.0; -1.0 1.0]
+            b = [-1.0, 1.0]
+            prob = LinearProblem(A, b)
+            linsolve = init(prob, alg)
+            sol = solve!(linsolve)
+            @test SciMLBase.successful_retcode(sol.retcode) || sol.retcode == ReturnCode.Default # The latter seems off...
+        end
+    end
+
+    @testset "Failure" begin
+        for alg in alglist
+            A = [1.0 1.0; 1.0 1.0]
+            b = [-1.0, 1.0]
+            prob = LinearProblem(A, b)
+            linsolve = init(prob, alg)
+            sol = solve!(linsolve)
+            @test !SciMLBase.successful_retcode(sol.retcode)
+        end
+    end
+end

--- a/test/retcodes.jl
+++ b/test/retcodes.jl
@@ -1,46 +1,46 @@
-@testset "Return codes" begin
-    alglist = (
-        LUFactorization,
-        QRFactorization,
-        DiagonalFactorization,
-        DirectLdiv!,
-        SparspakFactorization,
-        KLUFactorization,
-        UMFPACKFactorization,
-        KrylovJL_GMRES,
-        GenericLUFactorization,
-        RFLUFactorization,
-        LDLtFactorization,
-        BunchKaufmanFactorization,
-        CHOLMODFactorization,
-        SVDFactorization,
-        CholeskyFactorization,
-        NormalCholeskyFactorization,
-        AppleAccelerateLUFactorization,
-        MKLLUFactorization,
-        KrylovJL_CRAIGMR,
-        KrylovJL_LSMR,
-    )
+using LinearSolve
 
-    @testset "Success" begin
-        for alg in alglist
-            A = [2.0 1.0; -1.0 1.0]
-            b = [-1.0, 1.0]
-            prob = LinearProblem(A, b)
-            linsolve = init(prob, alg)
-            sol = solve!(linsolve)
-            @test SciMLBase.successful_retcode(sol.retcode) || sol.retcode == ReturnCode.Default # The latter seems off...
-        end
+alglist = (
+    LUFactorization,
+    QRFactorization,
+    DiagonalFactorization,
+    DirectLdiv!,
+    SparspakFactorization,
+    KLUFactorization,
+    UMFPACKFactorization,
+    KrylovJL_GMRES,
+    GenericLUFactorization,
+    RFLUFactorization,
+    LDLtFactorization,
+    BunchKaufmanFactorization,
+    CHOLMODFactorization,
+    SVDFactorization,
+    CholeskyFactorization,
+    NormalCholeskyFactorization,
+    AppleAccelerateLUFactorization,
+    MKLLUFactorization,
+    KrylovJL_CRAIGMR,
+    KrylovJL_LSMR,
+)
+
+@testset "Success" begin
+    for alg in alglist
+        A = [2.0 1.0; -1.0 1.0]
+        b = [-1.0, 1.0]
+        prob = LinearProblem(A, b)
+        linsolve = init(prob, alg)
+        sol = solve!(linsolve)
+        @test SciMLBase.successful_retcode(sol.retcode) || sol.retcode == ReturnCode.Default # The latter seems off...
     end
+end
 
-    @testset "Failure" begin
-        for alg in alglist
-            A = [1.0 1.0; 1.0 1.0]
-            b = [-1.0, 1.0]
-            prob = LinearProblem(A, b)
-            linsolve = init(prob, alg)
-            sol = solve!(linsolve)
-            @test !SciMLBase.successful_retcode(sol.retcode)
-        end
+@testset "Failure" begin
+    for alg in alglist
+        A = [1.0 1.0; 1.0 1.0]
+        b = [-1.0, 1.0]
+        prob = LinearProblem(A, b)
+        linsolve = init(prob, alg)
+        sol = solve!(linsolve)
+        @test !SciMLBase.successful_retcode(sol.retcode)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ const HAS_EXTENSIONS = isdefined(Base, :get_extension)
 if GROUP == "All" || GROUP == "Core"
     @time @safetestset "Quality Assurance" include("qa.jl")
     @time @safetestset "Basic Tests" include("basictests.jl")
+    @time @safetestset "Return codes" include("retcodes.jl")
     @time @safetestset "Re-solve" include("resolve.jl")
     @time @safetestset "Zero Initialization Tests" include("zeroinittests.jl")
     @time @safetestset "Non-Square Tests" include("nonsquare.jl")


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Trying to resolve #507 . However, this is technically a breaking change.

Also, the factorization solvers should set their retcode to Success and not to Default, or am I missing something? Because `SciMLBase.successful_retcode(ReturnCode.Default) == false` .
