### PR TITLE
Remove recompile_invalidations

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -5,45 +5,42 @@ if isdefined(Base, :Experimental) &&
 end
 
 import PrecompileTools
+ using ArrayInterface
+ using RecursiveFactorization
+ using Base: cache_dependencies, Bool
+ using LinearAlgebra
+ using SparseArrays
+ using SparseArrays: AbstractSparseMatrixCSC, nonzeros, rowvals, getcolptr
+ using LazyArrays: @~, BroadcastArray
+ using SciMLBase: AbstractLinearAlgorithm
+ using SciMLOperators
+ using SciMLOperators: AbstractSciMLOperator, IdentityOperator
+ using Setfield
+ using UnPack
+ using KLU
+ using Sparspak
+ using FastLapackInterface
+ using DocStringExtensions
+ using EnumX
+ using Markdown
+ using ChainRulesCore
+ import InteractiveUtils
 
-PrecompileTools.@recompile_invalidations begin
-    using ArrayInterface
-    using RecursiveFactorization
-    using Base: cache_dependencies, Bool
-    using LinearAlgebra
-    using SparseArrays
-    using SparseArrays: AbstractSparseMatrixCSC, nonzeros, rowvals, getcolptr
-    using LazyArrays: @~, BroadcastArray
-    using SciMLBase: AbstractLinearAlgorithm
-    using SciMLOperators
-    using SciMLOperators: AbstractSciMLOperator, IdentityOperator
-    using Setfield
-    using UnPack
-    using KLU
-    using Sparspak
-    using FastLapackInterface
-    using DocStringExtensions
-    using EnumX
-    using Markdown
-    using ChainRulesCore
-    import InteractiveUtils
+ import StaticArraysCore: StaticArray, SVector, MVector, SMatrix, MMatrix
 
-    import StaticArraysCore: StaticArray, SVector, MVector, SMatrix, MMatrix
+ using LinearAlgebra: BlasInt, LU
+ using LinearAlgebra.LAPACK: require_one_based_indexing,
+                             chkfinite, chkstride1,
+                             @blasfunc, chkargsok
 
-    using LinearAlgebra: BlasInt, LU
-    using LinearAlgebra.LAPACK: require_one_based_indexing,
-                                chkfinite, chkstride1,
-                                @blasfunc, chkargsok
+ import GPUArraysCore
+ import Preferences
+ import ConcreteStructs: @concrete
 
-    import GPUArraysCore
-    import Preferences
-    import ConcreteStructs: @concrete
-
-    # wrap
-    import Krylov
-    using SciMLBase
-    import Preferences
-end
+ # wrap
+ import Krylov
+ using SciMLBase
+ import Preferences
 
 const CRC = ChainRulesCore
 


### PR DESCRIPTION
`@recompile_invalidations` should only be used in very specific scenarios, and this is not one of those scenarios. Also, there are big changes being done with https://github.com/SciML/CommonWorldInvalidations.jl. With that, we only need to `@recompile_invalidations` on a few entry points. In particular, Static.jl, Symbolics.jl, and preferably ForwardDiff.jl and StaticArrays.jl would adopt it too. But this means that in order to handle all of this effectively, in SciML we only need to apply it on Static.jl, Symbolics.jl, and SciMLBase.jl and the whole ecosystem should be fine.

In any case, this library doesn't need it. It shouldn't make a tangible difference in compile times, while it increases precompile times by a lot.