### PR TITLE
Import CpuId only on x86_64 or i686

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 authors = ["SciML"]
-version = "2.31.0"
+version = "2.31.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -41,13 +41,16 @@ import PrecompileTools
  import Krylov
  using SciMLBase
  import Preferences
- import CpuId
-
 const CRC = ChainRulesCore
 
-if Preferences.@load_preference("LoadMKL_JLL", !occursin("EPYC", CpuId.cpubrand()))
-    using MKL_jll
-    const usemkl = MKL_jll.is_available()
+@static if Sys.ARCH === :x86_64 || Sys.ARCH === :i686
+    import CpuId
+    if Preferences.@load_preference("LoadMKL_JLL", !occursin("EPYC", CpuId.cpubrand()))
+        using MKL_jll
+        const usemkl = MKL_jll.is_available()
+    else
+        const usemkl = false
+    end
 else
     const usemkl = false
 end

--- a/test/qa.jl
+++ b/test/qa.jl
@@ -6,7 +6,7 @@ using LinearSolve, Aqua
     Aqua.test_piracies(LinearSolve,
         treat_as_own = [LinearProblem])
     Aqua.test_project_extras(LinearSolve)
-    Aqua.test_stale_deps(LinearSolve, ignore = [:MKL_jll])
+    Aqua.test_stale_deps(LinearSolve, ignore = [:MKL_jll, :CpuId])
     Aqua.test_unbound_args(LinearSolve)
     Aqua.test_undefined_exports(LinearSolve)
 end


### PR DESCRIPTION
This fixes LinearSolve on AArch64, for example.