### PR TITLE
Fix handling of AbstractSparseMatrixCSC

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -158,8 +158,10 @@ function SciMLBase.init(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm,
 
     A = if alias_A || A isa SMatrix
         A
-    elseif A isa Array || A isa SparseMatrixCSC
+    elseif A isa Array
         copy(A)
+    elseif A isa AbstractSparseMatrixCSC
+        SparseMatrixCSC(size(A)..., getcolptr(A), rowvals(A), nonzeros(A))
     else
         deepcopy(A)
     end
@@ -168,8 +170,10 @@ function SciMLBase.init(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm,
         Array(b) # the solution to a linear solve will always be dense!
     elseif alias_b || b isa SVector
         b
-    elseif b isa Array || b isa SparseMatrixCSC
+    elseif b isa Array
         copy(b)
+    elseif b isa AbstractSparseMatrixCSC
+        SparseMatrixCSC(size(b)..., getcolptr(b), rowvals(b), nonzeros(b))
     else
         deepcopy(b)
     end


### PR DESCRIPTION
* `SciMLBase.init` did check only for `SparseMatrixCSC`, thus leading to  dispatches for AbstractSparseMatrixCSC with awful timings.
* Now, if A (resp. b) is an `AbstractSparseMatrixCSC`, instead of making a `copy` (or even `deepcopy`), a `SparseMatrixCSC` is constructed using `size`, `getcolptr`, `rowvals` and `nonzeros`.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
