### PR TITLE
Add MinAres solver to iterative wrappers

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -251,7 +251,7 @@ export KrylovJL, KrylovJL_CG, KrylovJL_MINRES, KrylovJL_GMRES,
        KrylovJL_BICGSTAB, KrylovJL_LSMR, KrylovJL_CRAIGMR,
        IterativeSolversJL, IterativeSolversJL_CG, IterativeSolversJL_GMRES,
        IterativeSolversJL_BICGSTAB, IterativeSolversJL_MINRES, IterativeSolversJL_IDRS,
-       KrylovKitJL, KrylovKitJL_CG, KrylovKitJL_GMRES
+       KrylovKitJL, KrylovKitJL_CG, KrylovKitJL_GMRES, KrylovJL_MINARES
 
 export SimpleGMRES
 

--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -96,6 +96,17 @@ function KrylovJL_CRAIGMR(args...; kwargs...)
     KrylovJL(args...; KrylovAlg = Krylov.craigmr!, kwargs...)
 end
 
+"""
+```julia
+KrylovJL_MINARES(args...; kwargs...)
+```
+
+A generic MINARES implementation for Hermitian linear systems
+"""
+function KrylovJL_MINARES(args...; kwargs...)
+    KrylovJL(args...; KrylovAlg = Krylov.minares!, kwargs...)
+end
+
 function get_KrylovJL_solver(KrylovAlg)
     KS = if (KrylovAlg === Krylov.lsmr!)
         Krylov.LsmrSolver
@@ -163,6 +174,8 @@ function get_KrylovJL_solver(KrylovAlg)
         Krylov.GpmrSolver
     elseif (KrylovAlg === Krylov.fom!)
         Krylov.FomSolver
+    elseif (KrylovAlg === Krylov.minares!)
+        Krylov.MinaresSolver
     else
         error("Invalid Krylov method detected")
     end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -274,7 +274,8 @@ end
             ("GMRES", KrylovJL_GMRES(kwargs...)),
             ("GMRES_prec", KrylovJL_GMRES(; precs, ldiv = false, kwargs...)),
             # ("BICGSTAB",KrylovJL_BICGSTAB(kwargs...)),
-            ("MINRES", KrylovJL_MINRES(kwargs...))
+            ("MINRES", KrylovJL_MINRES(kwargs...)),
+            ("MINARES", KrylovJL_MINARES(kwards...))
         )
         for (name, algorithm) in algorithms
             @testset "$name" begin

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -275,7 +275,7 @@ end
             ("GMRES_prec", KrylovJL_GMRES(; precs, ldiv = false, kwargs...)),
             # ("BICGSTAB",KrylovJL_BICGSTAB(kwargs...)),
             ("MINRES", KrylovJL_MINRES(kwargs...)),
-            ("MINARES", KrylovJL_MINARES(kwards...))
+            ("MINARES", KrylovJL_MINARES(kwargs...))
         )
         for (name, algorithm) in algorithms
             @testset "$name" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

A very minor change to add the minares solver from `Krylov.jl` to the iterative wrappers. The paper can be found [here](https://arxiv.org/abs/2310.01757)
