### PR TITLE
Update adjoint of Linear Solve for complex matrices

### DIFF
--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -62,21 +62,21 @@ function CRC.rrule(::typeof(SciMLBase.solve), prob::LinearProblem,
             elseif cache.cacheval isa Tuple && cache.cacheval[1] isa Factorization
                 first(cache.cacheval)' \ ∂u
             elseif alg isa AbstractKrylovSubspaceMethod
-                invprob = LinearProblem(transpose(cache.A), ∂u)
+                invprob = LinearProblem(adjoint(cache.A), ∂u)
                 solve(invprob, alg; cache.abstol, cache.reltol, cache.verbose).u
             elseif alg isa DefaultLinearSolver
                 LinearSolve.defaultalg_adjoint_eval(cache, ∂u)
             else
-                invprob = LinearProblem(transpose(A_), ∂u) # We cached `A`
+                invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
                 solve(invprob, alg; cache.abstol, cache.reltol, cache.verbose).u
             end
         else
-            invprob = LinearProblem(transpose(A_), ∂u) # We cached `A`
+            invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
             λ = solve(
                 invprob, sensealg.linsolve; cache.abstol, cache.reltol, cache.verbose).u
         end
 
-        tu = transpose(sol.u)
+        tu = adjoint(sol.u)
         ∂A = BroadcastArray(@~ .-(λ .* tu))
         ∂b = λ
         ∂prob = LinearProblem(∂A, ∂b, ∂∅)

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -7,8 +7,8 @@ Given a Linear Problem ``A x = b`` computes the sensitivities for ``A`` and ``b`
 
 ```math
 \begin{align}
-A^T \lambda &= \partial x   \\
-\partial A  &= -\lambda x^T \\
+A' \lambda &= \partial x   \\
+\partial A  &= -\lambda x' \\
 \partial b  &= \lambda
 \end{align}
 ```
@@ -20,7 +20,7 @@ For more details, check [these notes](https://math.mit.edu/~stevenj/18.336/adjoi
 Note that in most cases, it makes sense to use the same linear solver for the adjoint as the
 forward solve (this is done by keeping the linsolve as `missing`). For example, if the
 forward solve was performed via a Factorization, then we can reuse the factorization for the
-adjoint solve. However, for specific structured matrices if ``A^T`` is known to have a
+adjoint solve. However, for specific structured matrices if ``A'`` is known to have a
 specific structure distinct from ``A`` then passing in a `linsolve` will be more efficient.
 """
 @kwdef struct LinearSolveAdjoint{L} <:

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -4,8 +4,8 @@ using FiniteDiff, RecursiveFactorization
 using LazyArrays: BroadcastArray
 
 n = 4
-A = rand(n, n);
-b1 = rand(n);
+A = rand(n, n) + 1im * rand(n, n);
+b1 = rand(n) + 1im * rand(n, n);
 
 function f(A, b1; alg = LUFactorization())
     prob = LinearProblem(A, b1)

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -5,7 +5,7 @@ using LazyArrays: BroadcastArray
 
 n = 4
 A = rand(n, n) + 1im * rand(n, n);
-b1 = rand(n) + 1im * rand(n, n);
+b1 = rand(n) + 1im * rand(n);
 
 function f(A, b1; alg = LUFactorization())
     prob = LinearProblem(A, b1)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

For complex matrices, `A \ b` and `LinearProblem(A, b)` give different gradients via Zygote. The issue is that Zygote uses `adjoint` 
while LinearSolve uses `transpose`. This should only affect behavior for complex matrices and this PR changes LinearSolve behavior to match Zygote.
