### PR TITLE
fix `pattern_changed`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 authors = ["SciML"]
-version = "3.7.0"
+version = "3.7.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -3,7 +3,7 @@ module LinearSolveSparseArraysExt
 using LinearSolve, LinearAlgebra
 using SparseArrays
 using SparseArrays: AbstractSparseMatrixCSC, nonzeros, rowvals, getcolptr
-using LinearSolve: BLASELTYPES
+using LinearSolve: BLASELTYPES, pattern_changed
 
 # Can't `using KLU` because cannot have a dependency in there without
 # requiring the user does `using KLU`

--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -229,7 +229,7 @@ function LinearSolve._ldiv!(::LinearSolve.SVector,
     (A \ b)
 end
 
-function pattern_changed(fact, A::SparseArrays.SparseMatrixCSC)
+function LinearSolve.pattern_changed(fact, A::SparseArrays.SparseMatrixCSC)
     !(SparseArrays.decrement(SparseArrays.getcolptr(A)) ==
       fact.colptr && SparseArrays.decrement(SparseArrays.getrowval(A)) ==
       fact.rowval)

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -523,6 +523,16 @@ end
             test_interface(nothing, prob3, prob4)
         end
     end
+
+    @testset "Sparse matrix (check pattern_changed)" begin
+        n = 4
+        A = spdiagm(1 => ones(n - 1), 0 => fill(2.0, n), -1 => ones(n - 1))
+        b = rand(n)
+        linprob = @inferred LinearProblem(A, b)
+        alg = @inferred LUFactorization()
+        linsolve = @inferred init(linprob, alg)
+        linres = @inferred solve!(linsolve)
+    end
 end # testset
 
 # https://github.com/SciML/LinearSolve.jl/issues/347


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The test

```julia
@testset "Sparse matrix (check pattern_changed)" begin
    n = 4
    A = spdiagm(1 => ones(n - 1), 0 => fill(2.0, n), -1 => ones(n - 1))
    b = rand(n)
    linprob = @inferred LinearProblem(A, b)
    alg = @inferred LUFactorization()
    linsolve = @inferred init(linprob, alg)
    linres = @inferred solve!(linsolve)
end
```

I added failed before with the error

```
Error During Test at REPL[52]:1
  Got exception outside of a @test
  ArgumentError: pattern of the matrix changed
  Stacktrace:
    [1] umferror(status::Int32)
      @ SparseArrays.UMFPACK
[...]
```

I already bumped the patch version to make it easier for you to release this bug fix.