### PR TITLE
Fix linked image in accelerating_choices.md

### DIFF
--- a/docs/src/tutorials/accelerating_choices.md
+++ b/docs/src/tutorials/accelerating_choices.md
@@ -64,7 +64,7 @@ Sparse linear solvers are not as dependent on the CPU but highly dependent on th
 is being solved. For example, this is for a 1D laplacian vs a 3D laplacian, changing N to make
 smaller and bigger versions:
 
-![Sparse Linear Solve Benchmarks](../assets/dense_linear_solves.png)
+![Sparse Linear Solve Benchmarks](../assets/sparse_linear_solves.png)
 
 Notice that the optimal linear solver changes based on problem (i.e. sparsity pattern) and size.
 LinearSolve.jl just uses a very simple "if small then use KLU and if large use UMFPACK", which


### PR DESCRIPTION
Pure documentation change: The link to the performance comparison in the "sparse solvers" section showed the same image from the "dense solvers" section.

The plot titles are a bit cropped, but I think it's still more informative to show the data that is referenced in the text on the page.

(If understood the guidelines for contributing correctly, none of the points on the checklist below apply here.)

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
