### PR TITLE
Remove type variable T

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -249,8 +249,7 @@ function LinearSolve.init_cacheval(alg::CHOLMODFactorization,
         A::AbstractArray, b, u,
         Pl, Pr,
         maxiters::Int, abstol, reltol,
-        verbose::Bool, assumptions::OperatorAssumptions) where {T <:
-                                                                BLASELTYPES}
+        verbose::Bool, assumptions::OperatorAssumptions)
     nothing
 end
 


### PR DESCRIPTION
Type variable T not used in `init_cacheval` method, so removed

## Checklist

- [x ] Appropriate tests were added
- [x ] Any code changes were done in a way that does not break public API
- [x ] All documentation related to code changes were updated
- [x ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
