### PR TITLE
prevent precompilation warning for upcoming versions of Julia

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -140,6 +140,8 @@ end
 
 const BLASELTYPES = Union{Float32, Float64, ComplexF32, ComplexF64}
 
+function defaultalg_symbol end
+
 include("generic_lufact.jl")
 include("common.jl")
 include("extension_algs.jl")


### PR DESCRIPTION
Fixes this precompilation warning:

```julia-repl
julia> using LinearSolve
Info Given LinearSolve was explicitly requested, output will be shown live
WARNING: Detected access to binding `LinearSolve.defaultalg_symbol` in a world prior to its definition world.
  Julia 1.12 has introduced more strict world age semantics for global bindings.
  !!! This code may malfunction under Revise.
  !!! This code will error in future versions of Julia.
Hint: Add an appropriate `invokelatest` around the access to this binding.
To make this warning an error, and hence obtain a stack trace, use `julia --depwarn=error`.
Precompiling LinearSolve finished.
  77 dependencies successfully precompiled in 85 seconds. 32 already precompiled.
  1 dependency had output during precompilation:
┌ LinearSolve
│  [Output was shown above]
└
```

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
