### PR TITLE
Fix check of factorisation

### DIFF
--- a/src/appleaccelerate.jl
+++ b/src/appleaccelerate.jl
@@ -244,7 +244,7 @@ function SciMLBase.solve!(cache::LinearCache, alg::AppleAccelerateLUFactorizatio
         fact = LU(res[1:3]...), res[4]
         cache.cacheval = fact
 
-        if !LinearAlgebra.issuccess(fact)
+        if !LinearAlgebra.issuccess(fact[1])
             return SciMLBase.build_linear_solution(
                 alg, cache.u, nothing, cache; retcode = ReturnCode.Failure)
         end

--- a/src/mkl.jl
+++ b/src/mkl.jl
@@ -220,7 +220,7 @@ function SciMLBase.solve!(cache::LinearCache, alg::MKLLUFactorization;
         fact = LU(res[1:3]...), res[4]
         cache.cacheval = fact
 
-        if !LinearAlgebra.issuccess(fact)
+        if !LinearAlgebra.issuccess(fact[1])
             return SciMLBase.build_linear_solution(
                 alg, cache.u, nothing, cache; retcode = ReturnCode.Failure)
         end


### PR DESCRIPTION
For `appleaccelerate` and `mkl`, the `fact` variable is a tuple, only the first element should be checked.

I think these cases must not be covered in your test suite, but I was getting the following error:

```
ERROR: MethodError: no method matching issuccess(::Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Base.RefValue{Int64}})
The function `issuccess` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  issuccess(::LinearAlgebra.BunchKaufman)
   @ LinearAlgebra ~/.julia/juliaup/julia-1.11.5+0.x64.linux.gnu/share/julia/stdlib/v1.11/LinearAlgebra/src/bunchkaufman.jl:321
  issuccess(::StaticArrays.LU)
   @ StaticArrays ~/.julia/packages/StaticArrays/LSPcF/src/lu.jl:71
  issuccess(::SparseArrays.CHOLMOD.Factor)
   @ SparseArrays ~/.julia/juliaup/julia-1.11.5+0.x64.linux.gnu/share/julia/stdlib/v1.11/SparseArrays/src/solvers/cholmod.jl:1958
  ...

Stacktrace:
  [1] solve!(cache::LinearSolve.LinearCache{…}, alg::LinearSolve.MKLLUFactorization; kwargs::@Kwargs{…})
    @ LinearSolve ~/.julia/packages/LinearSolve/cf5tu/src/mkl.jl:223
```

This was only for `mkl`, but I assume the `appleaccelerate` has the same issue