### PR TITLE
Fix 2 typos across multiple files

### DIFF
--- a/benchmarks/sparselu.jl
+++ b/benchmarks/sparselu.jl
@@ -38,7 +38,7 @@ algs = [
     MKLPardisoFactorize(),
     SparspakFactorization()
 ]
-cols = [:red, :blue, :green, :magenta, :turqoise] # one color per alg
+cols = [:red, :blue, :green, :magenta, :turquoise] # one color per alg
 lst = [:dash, :solid, :dashdot] # one line style per dim
 
 __parameterless_type(T) = Base.typename(T).wrapper

--- a/docs/src/tutorials/accelerating_choices.md
+++ b/docs/src/tutorials/accelerating_choices.md
@@ -34,7 +34,7 @@ there are a few major tips to note when fine tuning the results to your system:
     v7 it's no longer loaded by default! Thus if your matrices are in this range and you would
     value better run times at the cost of compile and load times, it is recommended you add
     `using RecursiveFactorization`. The defaulting algorithm will then consider it in its list
-    and will automatically (in an architecture-specific way) insert it as it feels necesssary.
+    and will automatically (in an architecture-specific way) insert it as it feels necessary.
  2. One of the major factors that can inhibit BLAS performance on LU factorization is multithreading.
     In many of these plots you can see a giant dip in GFLOPs (higher is better) when a certain size
     threshold is hit. This is because, for the number of chosen threads, there was not enough work


### PR DESCRIPTION
## Summary\n\nThis PR fixes legitimate typos found by the typos-cli tool.\n\n## Changes\n\nFixed 2 different typos with 2 total corrections:\n\n- `turqoise` → `turquoise` (1 occurrences)\n- `necesssary` → `necessary` (1 occurrences)\n\n## Files Modified\n\n- benchmarks/sparselu.jl\n- docs/src/tutorials/accelerating_choices.md\n\n🤖 Generated automatically by typos-cli analysis