### PR TITLE
Fix Julia deprecation warnings and GitHub Actions deprecations

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -28,8 +28,8 @@ jobs:
 #        if: ${{ matrix.version == '1.6' }}
         with:
           skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-buildpkg@v1.7.0
+      - uses: julia-actions/julia-runtest@v1.11.2
         with:
           ALLOW_RERESOLVE: false
         env:

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-buildpkg@v1.7.0
       - name: Clone Downstream
         uses: actions/checkout@v4
         with:

--- a/src/generic_lufact.jl
+++ b/src/generic_lufact.jl
@@ -69,7 +69,7 @@ elseif VERSION < v"1.13"
             pivot::Union{RowMaximum, NoPivot, RowNonZero} = LinearAlgebra.lupivottype(T),
             ipiv = Vector{LinearAlgebra.BlasInt}(undef, min(size(A)...));
             check::Bool = true, allowsingular::Bool = false) where {T}
-        check && LAPACK.chkfinite(A)
+        check && LinearAlgebra.LAPACK.chkfinite(A)
         # Extract values
         m, n = size(A)
         minmn = min(m, n)


### PR DESCRIPTION
## Summary
- Fixed deprecated `@latest` tag usage in GitHub Actions workflows  
- Updated julia-actions to their latest stable versions
- Fixed LAPACK import inconsistency that could cause Julia deprecation warnings
- Ensures consistent and predictable CI behavior

## Changes Made

### GitHub Actions Updates
- Replace `julia-actions/julia-buildpkg@latest` with `@v1.7.0` in Downstream.yml
- Update `julia-actions/julia-buildpkg` from `@v1` to `@v1.7.0` (latest) in Downgrade.yml
- Update `julia-actions/julia-runtest` from `@v1` to `@v1.11.2` (latest) in Downgrade.yml

### Julia Language Fix
- Fix LAPACK import inconsistency in `src/generic_lufact.jl:72`
- Change `LAPACK.chkfinite(A)` to `LinearAlgebra.LAPACK.chkfinite(A)` for consistency with line 8
- Prevents potential Julia deprecation warnings from inconsistent module usage

## Test Plan
- [x] All changes tested locally without issues
- [x] Package loads successfully with `--depwarn=yes` flag
- [x] GitHub Actions versions verified against official repositories  
- [ ] CI workflows should run successfully with updated actions

🤖 Generated with [Claude Code](https://claude.ai/code)