### PR TITLE
Make `GenericLUFactorization` bypass overloads when used on DualLinear Problems

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -8,6 +8,25 @@ using ForwardDiff: Dual, Partials
 using SciMLBase
 using RecursiveArrayTools
 
+using LinearSolve: LUFactorization,
+                   QRFactorization,
+                   DiagonalFactorization,
+                   DirectLdiv!,
+                   SparspakFactorization,
+                   KLUFactorization,
+                   UMFPACKFactorization,
+                   KrylovJL,
+                   RFLUFactorization,
+                   LDLtFactorization,
+                   BunchKaufmanFactorization,
+                   CHOLMODFactorization,
+                   SVDFactorization,
+                   CholeskyFactorization,
+                   NormalCholeskyFactorization,
+                   AppleAccelerateLUFactorization,
+                   MKLLUFactorization,
+                   DefaultLinearSolver
+
 const DualLinearProblem = LinearProblem{
     <:Union{Number, <:AbstractArray, Nothing}, iip,
     <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
@@ -41,7 +60,7 @@ DirectLdiv!,
 SparspakFactorization,
 KLUFactorization,
 UMFPACKFactorization,
-KrylovJL_GMRES,
+KrylovJL,
 RFLUFactorization,
 LDLtFactorization,
 BunchKaufmanFactorization,
@@ -51,9 +70,7 @@ CholeskyFactorization,
 NormalCholeskyFactorization,
 AppleAccelerateLUFactorization,
 MKLLUFactorization,
-QRFactorizationPivoted,
-KrylovJL_CRAIGMR,
-KrylovJL_LSMR}
+DefaultLinearSolver}
 
 LinearSolve.@concrete mutable struct DualLinearCache
     linear_cache

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -127,7 +127,7 @@ end
 
 # Opt out for GenericLUFactorization
 function SciMLBase.init(prob::DualAbstractLinearProblem, alg::GenericLUFactorization, args...; kwargs...)
-    return LinearSolve.__init(prob,alg, args...; kwargs...)
+    return __init(prob,alg, args...; kwargs...)
 end
 
 function __dual_init(

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -53,7 +53,7 @@ const DualBLinearProblem = LinearProblem{
 const DualAbstractLinearProblem = Union{
     DualLinearProblem, DualALinearProblem, DualBLinearProblem}
 
-Acceptable_algs = Union{LUFactorization,
+const acceptable_algs = Union{LUFactorization,
 QRFactorization,
 DiagonalFactorization,
 DirectLdiv!,
@@ -160,7 +160,7 @@ function linearsolve_dual_solution(u::AbstractArray, partials,
 end
 
 function SciMLBase.init(
-        prob::DualAbstractLinearProblem, alg::Acceptable_algs,
+        prob::DualAbstractLinearProblem, alg::acceptable_algs,
         args...;
         alias = LinearAliasSpecifier(),
         abstol = LinearSolve.default_tol(real(eltype(prob.b))),

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -34,6 +34,27 @@ const DualBLinearProblem = LinearProblem{
 const DualAbstractLinearProblem = Union{
     DualLinearProblem, DualALinearProblem, DualBLinearProblem}
 
+Acceptable_algs = Union{LUFactorization,
+QRFactorization,
+DiagonalFactorization,
+DirectLdiv!,
+SparspakFactorization,
+KLUFactorization,
+UMFPACKFactorization,
+KrylovJL_GMRES,
+RFLUFactorization,
+LDLtFactorization,
+BunchKaufmanFactorization,
+CHOLMODFactorization,
+SVDFactorization,
+CholeskyFactorization,
+NormalCholeskyFactorization,
+AppleAccelerateLUFactorization,
+MKLLUFactorization,
+QRFactorizationPivoted,
+KrylovJL_CRAIGMR,
+KrylovJL_LSMR}
+
 LinearSolve.@concrete mutable struct DualLinearCache
     linear_cache
     dual_type
@@ -122,7 +143,7 @@ function linearsolve_dual_solution(u::AbstractArray, partials,
 end
 
 function SciMLBase.init(
-        prob::DualAbstractLinearProblem, alg::LinearSolve.SciMLLinearSolveAlgorithm,
+        prob::DualAbstractLinearProblem, alg::Acceptable_algs,
         args...;
         alias = LinearAliasSpecifier(),
         abstol = LinearSolve.default_tol(real(eltype(prob.b))),

--- a/src/common.jl
+++ b/src/common.jl
@@ -138,7 +138,7 @@ end
 __init_u0_from_Ab(::SMatrix{S1, S2}, b) where {S1, S2} = zeros(SVector{S2, eltype(b)})
 
 function SciMLBase.init(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm, args...; kwargs...)
-    __init(prob, alg, args..., kwargs...)
+    __init(prob, alg, args...; kwargs...)
 end
 
 function __init(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm,

--- a/src/common.jl
+++ b/src/common.jl
@@ -137,7 +137,11 @@ function __init_u0_from_Ab(A, b)
 end
 __init_u0_from_Ab(::SMatrix{S1, S2}, b) where {S1, S2} = zeros(SVector{S2, eltype(b)})
 
-function SciMLBase.init(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm,
+function SciMLBase.init(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm, args...; kwargs...)
+    __init(prob, alg, args..., kwargs...)
+end
+
+function __init(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm,
         args...;
         alias = LinearAliasSpecifier(),
         abstol = default_tol(real(eltype(prob.b))),

--- a/test/forwarddiff_overloads.jl
+++ b/test/forwarddiff_overloads.jl
@@ -192,4 +192,4 @@ backslash_x_p = A \ b
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
 prob = LinearProblem(A, b)
-@test init(prob, GenericLUFactorization()) isa LinearCache
+@test init(prob, GenericLUFactorization()) isa LinearSolve.LinearCache

--- a/test/forwarddiff_overloads.jl
+++ b/test/forwarddiff_overloads.jl
@@ -87,13 +87,6 @@ backslash_x_p = A \ new_b
 @test ≈(x_p, backslash_x_p, rtol = 1e-9)
 
 # Nested Duals
-function h(p)
-    (A = [p[1] p[2]+1 p[2]^3;
-          3*p[1] p[1]+5 p[2] * p[1]-4;
-          p[2]^2 9*p[1] p[2]],
-        b = [p[1] + 1, p[2] * 2, p[1]^2])
-end
-
 A,
 b = h([ForwardDiff.Dual(ForwardDiff.Dual(5.0, 1.0, 0.0), 1.0, 0.0),
     ForwardDiff.Dual(ForwardDiff.Dual(5.0, 1.0, 0.0), 0.0, 1.0)])
@@ -193,3 +186,10 @@ overload_x_p = solve(prob, UMFPACKFactorization())
 backslash_x_p = A \ b
 
 @test ≈(overload_x_p, backslash_x_p, rtol = 1e-9)
+
+
+# Test that GenericLU doesn't create a DualLinearCache
+A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
+
+prob = LinearProblem(A, b)
+@test init(prob, GenericLUFactorization()) isa LinearCache


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Needed so that GenericalLUFactorization on DualLinearProblems can go through the normal init. 
It's a little bit clunky but I don't think there's another way to exclude specific algorithms from going through the Dual version of `init`. Plus this way is explicit about exactly which algorithms will go through the Dual overloads. 