### PR TITLE
Add MIT license to LinearSolveAutotune and update auth docs

### DIFF
--- a/docs/src/tutorials/autotune.md
+++ b/docs/src/tutorials/autotune.md
@@ -177,16 +177,43 @@ GPU algorithms tested (when available):
 
 The autotuner includes a telemetry feature that allows you to share your benchmark results with the LinearSolve.jl community. This helps improve algorithm selection across different hardware configurations.
 
-### Setting Up GitHub Authentication
+### Automatic Authentication
 
-To share results, you need to authenticate with GitHub. There are two methods:
+**New in v2.0+**: LinearSolveAutotune now includes automatic authentication support! If you're not already authenticated, the system will offer to help you set up GitHub authentication when you run `share_results()`.
+
+```julia
+# Run benchmarks
+results = autotune_setup()
+
+# Share with the community - will prompt for authentication if needed
+share_results(results)
+```
+
+If you're not authenticated, you'll see:
+```
+🔐 GitHub authentication not found.
+   To share results with the community, authentication is required.
+
+Would you like to authenticate with GitHub now? (y/n)
+> 
+```
+
+Simply type `y` and follow the prompts to authenticate directly from Julia!
+
+### Manual Authentication Setup
+
+You can also set up authentication manually before sharing:
 
 #### Method 1: GitHub CLI (Recommended)
 
-1. **Install GitHub CLI**
+The GitHub CLI is the easiest way to authenticate. LinearSolveAutotune will automatically use the GitHub CLI if it's installed, or fall back to a bundled version if not.
+
+1. **Install GitHub CLI (Optional)**
    - macOS: `brew install gh`
    - Windows: `winget install --id GitHub.cli`
    - Linux: See [cli.github.com](https://cli.github.com/manual/installation)
+   
+   Note: If you don't have gh installed, LinearSolveAutotune includes a bundled version via `gh_cli_jll` that will be used automatically!
 
 2. **Authenticate**
    ```bash
@@ -212,28 +239,39 @@ To share results, you need to authenticate with GitHub. There are two methods:
 
 ### Sharing Your Results
 
-Once authenticated, sharing is simple:
+Once authenticated (either automatically or manually), sharing is simple:
 
 ```julia
 # Run benchmarks
 results = autotune_setup()
 
-# Share with the community
+# Share with the community (with automatic authentication prompt)
 share_results(results)
+
+# Or skip the authentication prompt if not authenticated
+share_results(results; auto_login = false)
 ```
 
 This will:
-1. Format your benchmark results as a markdown report
-2. Create performance plots if enabled
-3. Post the results as a comment to the [community benchmark collection issue](https://github.com/SciML/LinearSolve.jl/issues/669)
-4. Upload plots as GitHub Gists for easy viewing
+1. Check for existing GitHub authentication
+2. Offer to set up authentication if needed (unless `auto_login = false`)
+3. Format your benchmark results as a markdown report
+4. Post the results as a comment to the [community benchmark collection issue](https://github.com/SciML/LinearSolve.jl/issues/669)
+5. Save results locally if authentication is unavailable
+
+### No GitHub CLI Required!
+
+LinearSolveAutotune now includes `gh_cli_jll`, which provides a bundled version of the GitHub CLI. This means:
+- You don't need to install gh separately
+- Authentication works on all platforms
+- The system automatically uses your existing gh installation if available, or falls back to the bundled version
 
 !!! info "Privacy Note"
     - Sharing is completely optional
     - Only benchmark performance data and system specifications are shared
     - No personal information is collected
     - All shared data is publicly visible on GitHub
-    - If authentication fails, results are saved locally for manual sharing
+    - If authentication fails or is skipped, results are saved locally for manual sharing
 
 ## Working with Results
 

--- a/lib/LinearSolveAutotune/LICENSE
+++ b/lib/LinearSolveAutotune/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Chris Rackauckas and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- Added MIT LICENSE file to the LinearSolveAutotune sublibrary
- Updated documentation to reflect new authentication features introduced in recent PRs
- Improved user experience documentation for the automatic authentication flow

## Changes

### License Addition
- Added standard MIT LICENSE file to `lib/LinearSolveAutotune/` directory
- Ensures the sublibrary has proper licensing information

### Documentation Updates in `docs/src/tutorials/autotune.md`
- **New "Automatic Authentication" section**: Documents the new automatic authentication prompt feature that helps users set up GitHub authentication interactively
- **Updated authentication instructions**: Clarifies that gh CLI is now optional since LinearSolveAutotune includes gh_cli_jll as a fallback
- **Added usage examples**: Shows how to use the `auto_login` parameter in `share_results()`
- **Improved clarity**: Explains the authentication flow is now more user-friendly with automatic prompts

## Context
This PR complements the recent authentication improvements:
- PR #687: Added gh_cli_jll as a fallback for systems without gh installed
- PR #689: Added automatic authentication prompts when sharing results

The documentation now accurately reflects these improvements, making it clear that users no longer need to manually install gh CLI or set up authentication before using the telemetry features.

## Test plan
- [x] Documentation builds successfully
- [x] LICENSE file is properly formatted
- [x] Documentation accurately reflects the current authentication behavior

🤖 Generated with [Claude Code](https://claude.ai/code)