### PR TITLE
Fix LinearSolveAutotune printout to use correct benchmark size ranges

### DIFF
--- a/lib/LinearSolveAutotune/src/benchmarking.jl
+++ b/lib/LinearSolveAutotune/src/benchmarking.jl
@@ -229,12 +229,14 @@ function categorize_results(df::DataFrame)
 
     categories = Dict{String, String}()
 
-    # Define size ranges
+    # Define size ranges based on actual benchmark categories
+    # These align with the sizes defined in get_benchmark_sizes()
     ranges = [
-        ("0-128", 1:128),
-        ("128-256", 129:256),
-        ("256-512", 257:512),
-        ("512+", 513:10000)
+        ("tiny (5-20)", 5:20),
+        ("small (20-100)", 21:100),
+        ("medium (100-300)", 101:300),
+        ("large (300-1000)", 301:1000),
+        ("big (10000+)", 10000:typemax(Int))
     ]
 
     # Get unique element types


### PR DESCRIPTION
## Summary
- Fixed the printout in LinearSolveAutotune.jl to use the actual benchmark size categories instead of hardcoded ranges
- The issue summary now correctly shows results organized by the same sizing used in the benchmark

## Problem
The autotune printout was using hardcoded ranges (0-128, 128-256, 256-512, 512+) that didn't align with the actual benchmark size categories defined in `get_benchmark_sizes()`:
- `:tiny` - 5:5:20
- `:small` - 20:20:100  
- `:medium` - 100:50:300
- `:large` - 300:100:1000
- `:big` - 10000:1000:100000

## Solution
Updated `categorize_results()` in `benchmarking.jl` to use the proper size ranges with descriptive labels:
- "tiny (5-20)"
- "small (20-100)"
- "medium (100-300)"
- "large (300-1000)"
- "big (10000+)"

Also updated the telemetry formatting in `telemetry.jl` to:
- Handle the new range format when parsing categories
- Sort ranges in logical order (tiny → small → medium → large → big) instead of alphabetically

## Test Plan
Created a test script that verifies the categorization now works correctly with the proper size ranges.

Example output now shows:
```
#### Recommendations for Float64

| Size Range | Best Algorithm |
|------------|----------------|
| tiny (5-20) | TestAlg |
| small (20-100) | TestAlg |
| medium (100-300) | AlgB |
| large (300-1000) | AlgB |
| big (10000+) | TestAlg |
```

🤖 Generated with [Claude Code](https://claude.ai/code)