### PR TITLE
Fix broken note admonitions

### DIFF
--- a/docs/src/tutorials/linear.md
+++ b/docs/src/tutorials/linear.md
@@ -159,7 +159,6 @@ mfopA * sol.u - b
 
 !!! note
     
-
-Note that not all methods can use a matrix-free operator. For example, `LS.LUFactorization()` requires a matrix. If you use an
-invalid method, you will get an error. The methods particularly from KrylovJL are the ones preferred for these cases
-(and are defaulted to).
+    Note that not all methods can use a matrix-free operator. For example, `LS.LUFactorization()` requires a matrix. If you use an
+    invalid method, you will get an error. The methods particularly from KrylovJL are the ones preferred for these cases
+    (and are defaulted to).


### PR DESCRIPTION
## Checklist

- [N/A] Appropriate tests were added
- [N/A] Any code changes were done in a way that does not break public API
- [N/A] All documentation related to code changes were updated
- [N/A] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [N/A] Any new documentation only uses public API
  
## Additional context

This PR only modifies documentation formatting, fixing [note admonition format](https://docs.sciml.ai/LinearSolve/stable/tutorials/linear/#Note-d580e91f1d7518fc) on the getting started page. Currently live version:
<img width="860" height="219" alt="Screenshot 2025-08-10 at 12 17 09 PM" src="https://github.com/user-attachments/assets/445b72ac-b4da-4114-952f-e618cb9708fe" />
