### PR TITLE
Add AMDGPU methods to documentation

### DIFF
--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -238,6 +238,19 @@ The following are non-standard GPU factorization routines.
 CudaOffloadFactorization
 ```
 
+### AMDGPU.jl
+
+The following are GPU factorization routines for AMD GPUs using the ROCm stack.
+
+!!! note
+    
+    Using these solvers requires adding the package AMDGPU.jl, i.e. `using AMDGPU`
+
+```@docs
+AMDGPUOffloadLUFactorization
+AMDGPUOffloadQRFactorization
+```
+
 ### CUSOLVERRF.jl
 
 !!! note

--- a/docs/src/tutorials/gpu.md
+++ b/docs/src/tutorials/gpu.md
@@ -39,8 +39,18 @@ sol.u
 This computation can be moved to the GPU by the following:
 
 ```julia
-using CUDA # Add the GPU library
+using CUDA # Add the GPU library for NVIDIA GPUs
 sol = LS.solve(prob, LS.CudaOffloadFactorization())
+sol.u
+```
+
+For AMD GPUs, you can use the AMDGPU.jl package:
+
+```julia
+using AMDGPU # Add the GPU library for AMD GPUs
+sol = LS.solve(prob, LS.AMDGPUOffloadLUFactorization())  # LU factorization
+# or
+sol = LS.solve(prob, LS.AMDGPUOffloadQRFactorization())  # QR factorization
 sol.u
 ```
 

--- a/docs/src/tutorials/gpu.md
+++ b/docs/src/tutorials/gpu.md
@@ -40,7 +40,7 @@ This computation can be moved to the GPU by the following:
 
 ```julia
 using CUDA # Add the GPU library for NVIDIA GPUs
-sol = LS.solve(prob, LS.CudaOffloadFactorization())
+sol = LS.solve(prob, LS.CudaOffloadLUFactorization())
 sol.u
 ```
 


### PR DESCRIPTION
## Summary
This PR adds documentation for the recently merged AMDGPU offload factorization methods.

## Changes
- Added `AMDGPUOffloadLUFactorization` and `AMDGPUOffloadQRFactorization` to the solver documentation section
- Added example usage in the GPU tutorial showing how to use AMDGPU methods alongside the existing CUDA examples
- Documented the requirement for `using AMDGPU` when using these solvers

## Notes
These methods are documented but not recommended as primary choices - they're listed after the CUDA methods to indicate they're available for users with AMD GPUs. The documentation includes their docstrings and usage requirements.

🤖 Generated with Claude Code