### PR TITLE
Add GPU type detection to system information

### DIFF
--- a/lib/LinearSolveAutotune/src/telemetry.jl
+++ b/lib/LinearSolveAutotune/src/telemetry.jl
@@ -236,6 +236,23 @@ function format_system_info_markdown(system_info::Dict)
     # Handle both "has_metal" and "metal_available" keys
     push!(lines, "- **Metal Available**: $(get(system_info, "metal_available", get(system_info, "has_metal", false)))")
     
+    # GPU Information
+    if haskey(system_info, "gpu_type")
+        push!(lines, "- **GPU Type**: $(system_info["gpu_type"])")
+        if haskey(system_info, "gpu_count")
+            push!(lines, "- **GPU Count**: $(system_info["gpu_count"])")
+        end
+        if haskey(system_info, "gpu_memory_gb")
+            push!(lines, "- **GPU Memory**: $(system_info["gpu_memory_gb"]) GB")
+        end
+        if haskey(system_info, "gpu_capability")
+            push!(lines, "- **CUDA Capability**: $(system_info["gpu_capability"])")
+        end
+        if haskey(system_info, "gpu_types")
+            push!(lines, "- **All GPU Types**: $(join(system_info["gpu_types"], ", "))")
+        end
+    end
+    
     # Add package versions section
     if haskey(system_info, "package_versions")
         push!(lines, "")


### PR DESCRIPTION
## Summary
- Adds GPU type detection for CUDA and Metal devices to LinearSolveAutotune's system information collection
- Enhances telemetry reporting with detailed GPU specifications including name, memory, and compute capability
- Improves debugging and performance analysis by providing complete hardware context

## Changes

### New Functions in `gpu_detection.jl`

1. **`get_cuda_gpu_info()`** - Retrieves CUDA GPU information:
   - GPU name/type using `CUDA.name(device)` 
   - Number of GPUs available
   - GPU memory in GB using `CUDA.totalmem(device)`
   - CUDA compute capability using `CUDA.capability(device)`
   - Lists all GPU types for multi-GPU systems

2. **`get_metal_gpu_info()`** - Detects Metal GPU information:
   - Identifies Apple Silicon GPU type (M1/M2/M3/M4) based on CPU model
   - Reports GPU count

### Updated Functions

- **`get_system_info()`** - Now includes GPU fields when GPUs are detected
- **`get_detailed_system_info()`** - Includes GPU information in detailed system data export
- **`format_system_info_markdown()`** in `telemetry.jl` - Formats GPU information for display

## Implementation Details

The implementation uses the CUDA.jl API to query device properties when CUDA is available. For Metal GPUs on Apple Silicon, it infers the GPU type from the CPU model since Metal.jl doesn't expose detailed device names.

The code gracefully handles:
- Missing GPU hardware
- Unloaded GPU packages (CUDA.jl/Metal.jl)
- Extension loading failures

When GPUs are not available, the functions return empty dictionaries and no GPU information is added to the system info.

## Testing

Created a test script that verifies:
- System information collection works correctly
- GPU fields are populated when GPUs are available
- No errors occur when GPUs are absent
- Both `get_system_info()` and `get_detailed_system_info()` include GPU data

The test successfully runs on systems with and without GPUs.

## Example Output

When a CUDA GPU is available:
```
gpu_type: NVIDIA GeForce RTX 3090
gpu_count: 1
gpu_memory_gb: 24.0
gpu_capability: 8.6
```

When on Apple Silicon with Metal:
```
gpu_type: Apple M2 GPU
gpu_count: 1
```

🤖 Generated with [Claude Code](https://claude.ai/code)