### PR TITLE
Improve timeout handling: skip timed-out algorithms and cap big benchmarks at 15000

### DIFF
--- a/docs/src/tutorials/autotune.md
+++ b/docs/src/tutorials/autotune.md
@@ -73,7 +73,7 @@ Control which matrix size ranges to test:
 # :small  - 20×20 to 100×100 (small problems)  
 # :medium - 100×100 to 300×300 (typical problems)
 # :large  - 300×300 to 1000×1000 (larger problems)
-# :big    - 10000×1000 to 20000x20000 (GPU/HPC scale)
+# :big    - 1000×1000 to 15000×15000 (GPU/HPC scale, capped at 15000 for stability)
 
 # Default: test tiny through large
 results = autotune_setup()  # uses [:tiny, :small, :medium, :large]
@@ -161,7 +161,10 @@ When an algorithm exceeds the `maxtime` limit:
 - The test is skipped to prevent hanging
 - The result is recorded as `NaN` in the benchmark data
 - A warning is displayed indicating the timeout
+- **The algorithm is automatically excluded from all larger matrix sizes** to save time
 - The benchmark continues with the next algorithm
+
+This intelligent timeout handling ensures that slow algorithms don't waste time on progressively larger matrices once they've proven too slow on smaller ones.
 
 ### Missing Algorithm Handling
 


### PR DESCRIPTION
## Summary
This PR improves the efficiency of the autotuning process by:
1. Automatically skipping algorithms that have timed out for all subsequent (larger) matrix sizes
2. Capping the :big benchmark category at 15000×15000 matrices instead of 20000×20000

## Changes

### 1. Smart Algorithm Exclusion
- When an algorithm times out on a matrix size, it's automatically excluded from all larger sizes
- Tracked per element type (Float64, ComplexF64, etc.)
- Prevents wasting time repeatedly testing slow algorithms
- Records skipped tests with message "Skipped: timed out on smaller matrix"

### 2. Reduced Maximum Matrix Size
- Changed :big category from `vcat(1000:2000:10000, 10000:5000:20000)` to `vcat(1000:2000:10000, 10000:5000:15000)`
- 20000×20000 matrices (3.2GB for Float64) often cause issues even on powerful computers
- 15000×15000 (1.8GB for Float64) is more reasonable while still testing large-scale performance

### 3. Improved Reporting
- Reports number of algorithms that timed out
- Reports number of algorithms skipped due to previous timeouts
- Helps users understand what happened during benchmarking

## Benefits
- **Faster benchmarking**: No time wasted on algorithms that are already too slow
- **More stable**: Avoids memory issues with 20000×20000 matrices
- **Better UX**: Clear reporting of what was skipped and why

## Example Output
```
[ Info: 2 tests timed out (exceeded 100.0s limit)
[ Info: 2 algorithms skipped for larger matrices after timing out
```

## Testing
The improved logic ensures that:
- Algorithms timeout once and are then skipped
- Progress bar still updates correctly for skipped tests
- Results are properly recorded as NaN with appropriate error messages

This builds on #716 and #717 to make the autotuning system more robust and efficient.