### PR TITLE
Add warning messages when algorithms are skipped in autotune benchmarking

### DIFF
--- a/lib/LinearSolveAutotune/src/benchmarking.jl
+++ b/lib/LinearSolveAutotune/src/benchmarking.jl
@@ -148,6 +148,7 @@ function benchmark_algorithms(matrix_sizes, algorithms, alg_names, eltypes;
                     if haskey(blocked_algorithms[string(eltype)], name)
                         max_allowed_size = blocked_algorithms[string(eltype)][name]
                         if n > max_allowed_size
+                            @warn "Algorithm $name skipped for size $n (exceeded maxtime on size $max_allowed_size matrix)"
                             # Still need to update progress bar
                             ProgressMeter.next!(progress)
                             # Record as skipped due to exceeding maxtime on smaller matrix


### PR DESCRIPTION
## Summary
- Adds explicit warning messages when algorithms are skipped for larger matrix sizes during autotune benchmarking
- Improves user visibility into the autotuning process by showing when and why algorithms are being skipped

## Problem
When algorithms exceed `maxtime` during benchmarking, they are correctly skipped for larger matrix sizes. However, users only saw the initial "exceeded maxtime" warning but not when algorithms were subsequently skipped. This made it unclear why some algorithms weren't being tested on larger matrices.

Users would see logs like:
```
┌ Warning: Algorithm GenericLUFactorization exceeded maxtime (130.29s > 100.0s) for size 9000, eltype Float64. Will skip for larger matrices.
┌ Warning: Algorithm SimpleLUFactorization exceeded maxtime (134.76s > 100.0s) for size 9000, eltype Float64. Will skip for larger matrices.
```

But then would not see any indication that these algorithms were actually being skipped on the larger 15000×15000 matrices, leading to confusion about whether the skipping logic was working.

## Solution
Added a warning message in `benchmarking.jl:151` when algorithms are skipped:

```julia
@warn "Algorithm $name skipped for size $n (exceeded maxtime on size $max_allowed_size matrix)"
```

Now users see both:
1. **Initial maxtime exceeded warning**: `Algorithm X exceeded maxtime (Y.Zs > maxtime) for size N`  
2. **Skip warnings for larger sizes**: `Algorithm X skipped for size M (exceeded maxtime on size N matrix)`

## Test Plan
- [x] Verified the fix works by creating test scenarios with very small maxtime values
- [x] Confirmed warning messages appear in console output when algorithms are skipped
- [x] Ensured the skipping logic continues to work correctly (algorithms that exceed maxtime are properly excluded from larger matrix tests)
- [x] Verified no regression in existing functionality

The fix is a simple one-line addition that improves user experience without changing any algorithmic behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)