### PR TITLE
Get rid of `deepcopy`, put Dual types in type system 

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -34,19 +34,6 @@ const DualBLinearProblem = LinearProblem{
 const DualAbstractLinearProblem = Union{
     DualLinearProblem, DualALinearProblem, DualBLinearProblem}
 
-# LinearSolve.@concrete mutable struct DualLinearCache
-#     linear_cache
-#     dual_type
-
-#     partials_A
-#     partials_b
-#     partials_u
-
-#     dual_A
-#     dual_b
-#     dual_u
-# end
-
 LinearSolve.@concrete mutable struct DualLinearCache{DT <: Dual}
     linear_cache
 
@@ -124,12 +111,6 @@ function linearsolve_dual_solution(
         u::Number, partials, cache::DualLinearCache{DT}) where {DT}
     return DT(u, partials)
 end
-
-# function linearsolve_dual_solution(u::Number, partials,
-#         dual_type::Type{<:Dual{T, V, P}}) where {T, V, P}
-#     # Handle single-level duals
-#     return dual_type(u, partials)
-# end
 
 function linearsolve_dual_solution(u::AbstractArray, partials,
         cache::DualLinearCache{DT}) where {DT}

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -34,9 +34,21 @@ const DualBLinearProblem = LinearProblem{
 const DualAbstractLinearProblem = Union{
     DualLinearProblem, DualALinearProblem, DualBLinearProblem}
 
-LinearSolve.@concrete mutable struct DualLinearCache
+# LinearSolve.@concrete mutable struct DualLinearCache
+#     linear_cache
+#     dual_type
+
+#     partials_A
+#     partials_b
+#     partials_u
+
+#     dual_A
+#     dual_b
+#     dual_u
+# end
+
+LinearSolve.@concrete mutable struct DualLinearCache{DT <: Dual}
     linear_cache
-    dual_type
 
     partials_A
     partials_b
@@ -109,21 +121,21 @@ function xp_linsolve_rhs(
 end
 
 function linearsolve_dual_solution(
-        u::Number, partials, dual_type)
-    return dual_type(u, partials)
+        u::Number, partials, cache::DualLinearCache{DT}) where {DT}
+    return DT(u, partials)
 end
 
-function linearsolve_dual_solution(u::Number, partials,
-        dual_type::Type{<:Dual{T, V, P}}) where {T, V, P}
-    # Handle single-level duals
-    return dual_type(u, partials)
-end
+# function linearsolve_dual_solution(u::Number, partials,
+#         dual_type::Type{<:Dual{T, V, P}}) where {T, V, P}
+#     # Handle single-level duals
+#     return dual_type(u, partials)
+# end
 
 function linearsolve_dual_solution(u::AbstractArray, partials,
-        dual_type::Type{<:Dual{T, V, P}}) where {T, V, P}
+        cache::DualLinearCache{DT}) where {DT}
     # Handle single-level duals for arrays
     partials_list = RecursiveArrayTools.VectorOfArray(partials)
-    return map(((uᵢ, pᵢ),) -> dual_type(uᵢ, Partials(Tuple(pᵢ))),
+    return map(((uᵢ, pᵢ),) -> DT(uᵢ, Partials(Tuple(pᵢ))),
         zip(u, partials_list[i, :] for i in 1:length(partials_list.u[1])))
 end
 
@@ -173,7 +185,7 @@ function __dual_init(
         alias = alias, abstol = abstol, reltol = reltol,
         maxiters = maxiters, verbose = verbose, Pl = Pl, Pr = Pr, assumptions = assumptions,
         sensealg = sensealg, u0 = new_u0, kwargs...)
-    return DualLinearCache(non_partial_cache, dual_type, ∂_A, ∂_b,
+    return DualLinearCache{dual_type}(non_partial_cache, ∂_A, ∂_b,
         !isnothing(∂_b) ? zero.(∂_b) : ∂_b, A, b, zeros(dual_type, length(b)))
 end
 
@@ -182,11 +194,11 @@ function SciMLBase.solve!(cache::DualLinearCache, args...; kwargs...)
 end
 
 function SciMLBase.solve!(
-        cache::DualLinearCache, alg::SciMLLinearSolveAlgorithm, args...; kwargs...)
+        cache::DualLinearCache{DT}, alg::SciMLLinearSolveAlgorithm, args...; kwargs...) where {DT <: ForwardDiff.Dual}
     sol,
     partials = linearsolve_forwarddiff_solve(
         cache::DualLinearCache, cache.alg, args...; kwargs...)
-    dual_sol = linearsolve_dual_solution(sol.u, partials, cache.dual_type)
+    dual_sol = linearsolve_dual_solution(sol.u, partials, cache)
 
     if cache.dual_u isa AbstractArray
         cache.dual_u[:] = dual_sol

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -54,7 +54,13 @@ function linearsolve_forwarddiff_solve(cache::DualLinearCache, alg, args...; kwa
     primal_b = copy(cache.linear_cache.b)
     uu = sol.u
 
-    primal_sol = deepcopy(sol)
+    primal_sol = (;
+        u = recursivecopy(sol.u),
+        resid = recursivecopy(sol.resid),
+        retcode = recursivecopy(sol.retcode),
+        iters = recursivecopy(sol.iters),
+        stats = recursivecopy(sol.stats)
+    )
 
     # Solves Dual partials separately 
     ∂_A = cache.partials_A


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
Trying to address https://github.com/SciML/OrdinaryDiffEq.jl/issues/2837 and https://github.com/SciML/LinearSolve.jl/issues/648

This gets rid of the call to `deepcopy`.
 
This also puts the type of the dual number that needs to be constructed in to the type system instead of having it be a field in the dual caches. I'm not sure if that will help with trimming but I think in general it's a better way to do this. 

