### PR TITLE
Make length of Partials known at compile time in ForwardDiff overloads

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -34,7 +34,7 @@ const DualBLinearProblem = LinearProblem{
 const DualAbstractLinearProblem = Union{
     DualLinearProblem, DualALinearProblem, DualBLinearProblem}
 
-LinearSolve.@concrete mutable struct DualLinearCache{DT <: Dual}
+LinearSolve.@concrete mutable struct DualLinearCache{DT}
     linear_cache
 
     partials_A
@@ -113,10 +113,10 @@ function linearsolve_dual_solution(
 end
 
 function linearsolve_dual_solution(u::AbstractArray, partials,
-        cache::DualLinearCache{DT}) where {DT}
+        cache::DualLinearCache{DT}) where {T, V, N, DT <: Dual{T,V,N}}
     # Handle single-level duals for arrays
     partials_list = RecursiveArrayTools.VectorOfArray(partials)
-    return map(((uᵢ, pᵢ),) -> DT(uᵢ, Partials(Tuple(pᵢ))),
+    return map(((uᵢ, pᵢ),) -> DT(uᵢ, Partials{N,V}(NTuple{N,V}(pᵢ))),
         zip(u, partials_list[i, :] for i in 1:length(partials_list.u[1])))
 end
 

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -1,4 +1,4 @@
-using LinearSolve, RecursiveFactorization, LinearAlgebra, SparseArrays, Test
+using LinearSolve, ForwardDiff, RecursiveFactorization, LinearAlgebra, SparseArrays, Test
 using JET
 
 # Dense problem setup
@@ -21,6 +21,18 @@ prob_sparse = LinearProblem(A_sparse, b)
 # Sparse SPD for CHOLMODFactorization
 A_sparse_spd = sparse(A_spd)
 prob_sparse_spd = LinearProblem(A_sparse_spd, b)
+
+# Dual problem set up 
+function h(p)
+    (A = [p[1] p[2]+1 p[2]^3;
+          3*p[1] p[1]+5 p[2] * p[1]-4;
+          p[2]^2 9*p[1] p[2]],
+        b = [p[1] + 1, p[2] * 2, p[1]^2])
+end
+
+A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
+
+dual_prob = LinearProblem(A, b)
 
 @testset "JET Tests for Dense Factorizations" begin
     # Working tests - these pass JET optimization checks
@@ -108,4 +120,12 @@ end
     # Test the default solver selection
     JET.@test_opt solve(prob) broken=true
     JET.@test_opt solve(prob_sparse) broken=true
+end
+
+@testset "JET Tests for creating Dual solutions" begin
+    # Make sure there's no runtime dispatch when making solutions of Dual problems
+    dual_cache = init(prob)
+    ext = Base.get_extension(LinearSolve, :LinearSolveForwardDiffExt)
+    JET.@test_opt ext.linearsolve_dual_solution(
+        [1.0, 1.0, 1.0], [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], cache)
 end

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -124,8 +124,8 @@ end
 
 @testset "JET Tests for creating Dual solutions" begin
     # Make sure there's no runtime dispatch when making solutions of Dual problems
-    dual_cache = init(prob)
+    dual_cache = init(dual_prob)
     ext = Base.get_extension(LinearSolve, :LinearSolveForwardDiffExt)
     JET.@test_opt ext.linearsolve_dual_solution(
-        [1.0, 1.0, 1.0], [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], dual_cache )
+        [1.0, 1.0, 1.0], [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], dual_cache)
 end

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -127,5 +127,5 @@ end
     dual_cache = init(prob)
     ext = Base.get_extension(LinearSolve, :LinearSolveForwardDiffExt)
     JET.@test_opt ext.linearsolve_dual_solution(
-        [1.0, 1.0, 1.0], [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], cache)
+        [1.0, 1.0, 1.0], [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], dual_cache )
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
