### PR TITLE
Fix KLUFactorization for AbstractSparseMatrixCSC subtypes

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -259,6 +259,13 @@ function SciMLBase.solve!(cache::LinearSolve.LinearCache, alg::KLUFactorization;
                     SparseMatrixCSC(size(A)..., getcolptr(A), rowvals(A),
                         nonzeros(A)),
                     check = false)
+            elseif cacheval === nothing || cacheval === PREALLOCATED_KLU ||
+                   length(nonzeros(A)) != length(cacheval.nzval)
+                # Create new factorization if cacheval is uninitialized or size mismatch
+                fact = KLU.klu(
+                    SparseMatrixCSC(size(A)..., getcolptr(A), rowvals(A),
+                        nonzeros(A)),
+                    check = false)
             else
                 fact = KLU.klu!(cacheval, nonzeros(A), check = false)
             end


### PR DESCRIPTION
## Summary
- Fixes #737 by properly handling AbstractSparseMatrixCSC subtypes in KLUFactorization
- Adds check for uninitialized or dimension-mismatched cached values before attempting reuse
- Ensures compatibility with custom sparse matrix types that implement the AbstractSparseMatrixCSC interface

## Problem
KLUFactorization was failing with AbstractSparseMatrixCSC subtypes while UMFPACK, Sparspak, and Pardiso worked correctly. The issue occurred when:
1. The cached value was PREALLOCATED_KLU (a 0x0 matrix)  
2. pattern_changed returned false for this case
3. klu! was called with mismatched dimensions, causing a DimensionMismatch error

## Solution
Added a check before calling klu! to verify:
- The cacheval is not `nothing` or `PREALLOCATED_KLU`
- The dimensions match between the cached value and the input matrix

If either condition fails, a new factorization is created instead of attempting to reuse the incompatible cached value.

## Test plan
- [x] Verified the minimal reproducible example from issue #737 now works
- [x] Tested with both `reuse_symbolic=true` and `reuse_symbolic=false` 
- [x] Confirmed UMFPACK still works as expected
- [x] Formatted code with JuliaFormatter using SciMLStyle

🤖 Generated with [Claude Code](https://claude.ai/code)