### PR TITLE
Cleanup pardiso test

### DIFF
--- a/test/pardiso/pardiso.jl
+++ b/test/pardiso/pardiso.jl
@@ -60,7 +60,7 @@ linsolve.A = copy(A2)
 sol13 = solve!(linsolve)
 
 for alg in algs
-    linsolve = init(prob, alg)
+    local linsolve = init(prob, alg)
     sol31 = solve!(linsolve)
     linsolve.b = copy(b2)
     sol32 = solve!(linsolve)
@@ -147,11 +147,11 @@ function makeA()
 end
 
 for alg in algs
-    A = makeA()
+    local A = makeA()
     u0 = fill(0.1, size(A, 2))
     linprob = LinearProblem(A, A * u0)
     u = LinearSolve.solve(linprob, alg)
-    @test norm(u - u0) < 1.0e-14
+    @test norm(u - u0) < 5.0e-14
 end
 
 # Testing and demonstrating Pardiso.set_iparm! for MKLPardisoSolver


### PR DESCRIPTION
* prevent soft scope warning in 1.12
* slightly relax accuracy for current panua pardiso
* ran locally with both MKL and Panua
* tested locally with https://github.com/JuliaSparse/Pardiso.jl/pull/117 which introduces finalizers

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
