### PR TITLE
Add missing LinearVerbosity imports to extensions

### DIFF
--- a/ext/LinearSolveFastLapackInterfaceExt.jl
+++ b/ext/LinearSolveFastLapackInterfaceExt.jl
@@ -1,6 +1,7 @@
 module LinearSolveFastLapackInterfaceExt
 
 using LinearSolve, LinearAlgebra
+using LinearSolve: LinearVerbosity
 using FastLapackInterface
 
 struct WorkspaceAndFactors{W, F}

--- a/ext/LinearSolveIterativeSolversExt.jl
+++ b/ext/LinearSolveIterativeSolversExt.jl
@@ -1,7 +1,7 @@
 module LinearSolveIterativeSolversExt
 
 using LinearSolve, LinearAlgebra
-using LinearSolve: LinearCache, DEFAULT_PRECS
+using LinearSolve: LinearCache, DEFAULT_PRECS, LinearVerbosity
 import LinearSolve: IterativeSolversJL
 using SciMLLogging: @SciMLMessage, Verbosity
 

--- a/ext/LinearSolvePardisoExt.jl
+++ b/ext/LinearSolvePardisoExt.jl
@@ -3,7 +3,7 @@ module LinearSolvePardisoExt
 using Pardiso, LinearSolve
 using SparseArrays
 using SparseArrays: nonzeros, rowvals, getcolptr
-using LinearSolve: PardisoJL, @unpack
+using LinearSolve: PardisoJL, @unpack, LinearVerbosity
 using SciMLLogging: @SciMLMessage, verbosity_to_bool
 using LinearSolve.SciMLBase
 

--- a/ext/LinearSolveSparspakExt.jl
+++ b/ext/LinearSolveSparspakExt.jl
@@ -1,6 +1,7 @@
 module LinearSolveSparspakExt
 
 using LinearSolve, LinearAlgebra
+using LinearSolve: LinearVerbosity
 using Sparspak
 using Sparspak.SparseCSCInterface.SparseArrays
 using SparseArrays: AbstractSparseMatrixCSC, nonzeros, rowvals, getcolptr


### PR DESCRIPTION
## Summary

This PR adds missing `LinearVerbosity` imports to several extensions that were using it in their function signatures but not explicitly importing it.

## Changes

The following extensions now properly import `LinearVerbosity`:
- **LinearSolveIterativeSolversExt.jl** - Added `LinearVerbosity` to the existing `using LinearSolve:` statement
- **LinearSolveFastLapackInterfaceExt.jl** - Added a new `using LinearSolve: LinearVerbosity` line
- **LinearSolvePardisoExt.jl** - Added `LinearVerbosity` to the existing `using LinearSolve:` statement
- **LinearSolveSparspakExt.jl** - Added a new `using LinearSolve: LinearVerbosity` line

## Context

These imports are necessary as `LinearVerbosity` is used as a type annotation in the `init_cacheval` functions of these extensions. While the code may have worked due to Julia's module system, explicit imports ensure better code clarity and prevent potential issues.

## Test Plan

- [x] Package loads successfully with `using LinearSolve`
- [x] Package precompiles without errors
- [x] `LinearVerbosity()` can be created and used

🤖 Generated with [Claude Code](https://claude.ai/code)