### PR TITLE
Simplify mixed precision: compute types on demand instead of caching

### DIFF
--- a/src/mkl.jl
+++ b/src/mkl.jl
@@ -283,13 +283,12 @@ function LinearSolve.init_cacheval(alg::MKL32MixedLUFactorization, A, b, u, Pl, 
     # Pre-allocate appropriate 32-bit arrays based on input type
     m, n = size(A)
     T32 = eltype(A) <: Complex ? ComplexF32 : Float32
-    Torig = eltype(u)
     A_32 = similar(A, T32)
     b_32 = similar(b, T32)
     u_32 = similar(u, T32)
     luinst = ArrayInterface.lu_instance(rand(T32, 0, 0))
-    # Return tuple with pre-allocated arrays and cached types
-    (luinst, Ref{BlasInt}(), A_32, b_32, u_32, T32, Torig)
+    # Return tuple with pre-allocated arrays
+    (luinst, Ref{BlasInt}(), A_32, b_32, u_32)
 end
 
 function SciMLBase.solve!(cache::LinearCache, alg::MKL32MixedLUFactorization;
@@ -301,11 +300,12 @@ function SciMLBase.solve!(cache::LinearCache, alg::MKL32MixedLUFactorization;
 
     if cache.isfresh
         # Get pre-allocated arrays from cacheval
-        luinst, info, A_32, b_32, u_32, T32, Torig = @get_cacheval(cache, :MKL32MixedLUFactorization)
-        # Copy A to pre-allocated 32-bit array using cached type
+        luinst, info, A_32, b_32, u_32 = @get_cacheval(cache, :MKL32MixedLUFactorization)
+        # Compute 32-bit type on demand and copy A
+        T32 = eltype(A) <: Complex ? ComplexF32 : Float32
         A_32 .= T32.(A)
         res = getrf!(A_32; ipiv = luinst.ipiv, info = info)
-        fact = (LU(res[1:3]...), res[4], A_32, b_32, u_32, T32, Torig)
+        fact = (LU(res[1:3]...), res[4], A_32, b_32, u_32)
         cache.cacheval = fact
 
         if !LinearAlgebra.issuccess(fact[1])
@@ -315,21 +315,25 @@ function SciMLBase.solve!(cache::LinearCache, alg::MKL32MixedLUFactorization;
         cache.isfresh = false
     end
 
-    A_lu, info, A_32, b_32, u_32, T32, Torig = @get_cacheval(cache, :MKL32MixedLUFactorization)
+    A_lu, info, A_32, b_32, u_32 = @get_cacheval(cache, :MKL32MixedLUFactorization)
     require_one_based_indexing(cache.u, cache.b)
     m, n = size(A_lu, 1), size(A_lu, 2)
 
-    # Copy b to pre-allocated 32-bit array using cached type
+    # Compute types on demand for conversions
+    T32 = eltype(A) <: Complex ? ComplexF32 : Float32
+    Torig = eltype(cache.u)
+    
+    # Copy b to pre-allocated 32-bit array
     b_32 .= T32.(cache.b)
 
     if m > n
         getrs!('N', A_lu.factors, A_lu.ipiv, b_32; info)
-        # Convert back to original precision using cached type
+        # Convert back to original precision
         cache.u[1:n] .= Torig.(b_32[1:n])
     else
         copyto!(u_32, b_32)
         getrs!('N', A_lu.factors, A_lu.ipiv, u_32; info)
-        # Convert back to original precision using cached type
+        # Convert back to original precision
         cache.u .= Torig.(u_32)
     end
 

--- a/src/openblas.jl
+++ b/src/openblas.jl
@@ -308,13 +308,12 @@ function LinearSolve.init_cacheval(alg::OpenBLAS32MixedLUFactorization, A, b, u,
     # Pre-allocate appropriate 32-bit arrays based on input type
     m, n = size(A)
     T32 = eltype(A) <: Complex ? ComplexF32 : Float32
-    Torig = eltype(u)
     A_32 = similar(A, T32)
     b_32 = similar(b, T32)
     u_32 = similar(u, T32)
     luinst = ArrayInterface.lu_instance(rand(T32, 0, 0))
-    # Return tuple with pre-allocated arrays and cached types
-    (luinst, Ref{BlasInt}(), A_32, b_32, u_32, T32, Torig)
+    # Return tuple with pre-allocated arrays
+    (luinst, Ref{BlasInt}(), A_32, b_32, u_32)
 end
 
 function SciMLBase.solve!(cache::LinearCache, alg::OpenBLAS32MixedLUFactorization;
@@ -326,11 +325,12 @@ function SciMLBase.solve!(cache::LinearCache, alg::OpenBLAS32MixedLUFactorizatio
 
     if cache.isfresh
         # Get pre-allocated arrays from cacheval
-        luinst, info, A_32, b_32, u_32, T32, Torig = @get_cacheval(cache, :OpenBLAS32MixedLUFactorization)
-        # Copy A to pre-allocated 32-bit array using cached type
+        luinst, info, A_32, b_32, u_32 = @get_cacheval(cache, :OpenBLAS32MixedLUFactorization)
+        # Compute 32-bit type on demand and copy A
+        T32 = eltype(A) <: Complex ? ComplexF32 : Float32
         A_32 .= T32.(A)
         res = openblas_getrf!(A_32; ipiv = luinst.ipiv, info = info)
-        fact = (LU(res[1:3]...), res[4], A_32, b_32, u_32, T32, Torig)
+        fact = (LU(res[1:3]...), res[4], A_32, b_32, u_32)
         cache.cacheval = fact
 
         if !LinearAlgebra.issuccess(fact[1])
@@ -340,21 +340,25 @@ function SciMLBase.solve!(cache::LinearCache, alg::OpenBLAS32MixedLUFactorizatio
         cache.isfresh = false
     end
 
-    A_lu, info, A_32, b_32, u_32, T32, Torig = @get_cacheval(cache, :OpenBLAS32MixedLUFactorization)
+    A_lu, info, A_32, b_32, u_32 = @get_cacheval(cache, :OpenBLAS32MixedLUFactorization)
     require_one_based_indexing(cache.u, cache.b)
     m, n = size(A_lu, 1), size(A_lu, 2)
 
-    # Copy b to pre-allocated 32-bit array using cached type
+    # Compute types on demand for conversions
+    T32 = eltype(A) <: Complex ? ComplexF32 : Float32
+    Torig = eltype(cache.u)
+    
+    # Copy b to pre-allocated 32-bit array
     b_32 .= T32.(cache.b)
 
     if m > n
         openblas_getrs!('N', A_lu.factors, A_lu.ipiv, b_32; info)
-        # Convert back to original precision using cached type
+        # Convert back to original precision
         cache.u[1:n] .= Torig.(b_32[1:n])
     else
         copyto!(u_32, b_32)
         openblas_getrs!('N', A_lu.factors, A_lu.ipiv, u_32; info)
-        # Convert back to original precision using cached type
+        # Convert back to original precision
         cache.u .= Torig.(u_32)
     end
 


### PR DESCRIPTION
## Summary
- Simplified mixed precision implementations by computing types on demand rather than caching them
- Reduces complexity while maintaining zero allocations for subsequent solves
- Cleaner implementation as requested in review feedback

## Changes
Modified all 6 mixed precision implementations to compute `T32` and `Torig` types on demand in `solve!` functions instead of storing them in the cache:
- `MKL32MixedLUFactorization` 
- `OpenBLAS32MixedLUFactorization`
- `AppleAccelerate32MixedLUFactorization`
- `RF32MixedLUFactorization`
- `CUDAOffload32MixedLUFactorization`
- `MetalOffload32MixedLUFactorization`

### Before
```julia
# In init_cacheval:
T32 = eltype(A) <: Complex ? ComplexF32 : Float32
Torig = eltype(u)
return (luinst, ipiv, A_32, b_32, u_32, T32, Torig)

# In solve!:
fact, ipiv, A_32, b_32, u_32, T32, Torig = @get_cacheval(cache, :MKL32MixedLUFactorization)
```

### After
```julia
# In init_cacheval:
return (luinst, ipiv, A_32, b_32, u_32)

# In solve!:
fact, ipiv, A_32, b_32, u_32 = @get_cacheval(cache, :MKL32MixedLUFactorization)
# Compute types on demand
T32 = eltype(A) <: Complex ? ComplexF32 : Float32
Torig = eltype(cache.u)
```

## Performance
The type computations (`eltype(A) <: Complex` and `eltype(cache.u)`) are simple operations that don't allocate, so computing them on demand has negligible performance impact while making the code cleaner and easier to understand.

## Related
This is a cleaner reimplementation of #758 based on review feedback.

🤖 Generated with [Claude Code](https://claude.ai/code)