### PR TITLE
Fix BenchmarkTools.DEFAULT_PARAMETERS const assignment error in Julia 1.12

### DIFF
--- a/lib/LinearSolveAutotune/src/benchmarking.jl
+++ b/lib/LinearSolveAutotune/src/benchmarking.jl
@@ -110,8 +110,7 @@ function benchmark_algorithms(matrix_sizes, algorithms, alg_names, eltypes;
     progress = Progress(total_benchmarks, desc="Benchmarking: ", 
                        barlen=50, showspeed=true)
 
-    try
-        for eltype in eltypes
+    for eltype in eltypes
             # Initialize blocked algorithms dict for this element type
             blocked_algorithms[string(eltype)] = Dict{String, Int}()
             
@@ -233,10 +232,13 @@ function benchmark_algorithms(matrix_sizes, algorithms, alg_names, eltypes;
                                     error_msg = "Insufficient time for benchmarking"
                                 else
                                     # Actual benchmark
-                                    bench = @benchmark solve($prob, $alg) setup=(prob = LinearProblem(
+                                    # Create benchmark with custom parameters
+                                    bench_params = BenchmarkTools.Parameters(;seconds=seconds, samples=samples)
+                                    b = @benchmarkable solve($prob, $alg) setup=(prob = LinearProblem(
                                         copy($A), copy($b);
                                         u0 = copy($u0),
-                                        alias = LinearAliasSpecifier(alias_A = true, alias_b = true))) seconds=$seconds samples=$samples
+                                        alias = LinearAliasSpecifier(alias_A = true, alias_b = true)))
+                                    bench = BenchmarkTools.run(b, bench_params)
 
                                     # Calculate GFLOPs
                                     min_time_sec = minimum(bench.times) / 1e9
@@ -268,8 +270,7 @@ function benchmark_algorithms(matrix_sizes, algorithms, alg_names, eltypes;
                     ProgressMeter.next!(progress)
                 end
             end
-        end
-
+    end
 
     return DataFrame(results_data)
 end

--- a/lib/LinearSolveAutotune/src/benchmarking.jl
+++ b/lib/LinearSolveAutotune/src/benchmarking.jl
@@ -87,10 +87,9 @@ function benchmark_algorithms(matrix_sizes, algorithms, alg_names, eltypes;
         samples = 5, seconds = 0.5, sizes = [:tiny, :small, :medium, :large],
         check_correctness = true, correctness_tol = 1e0, maxtime = 100.0)
 
-    # Set benchmark parameters
-    old_params = BenchmarkTools.DEFAULT_PARAMETERS
-    BenchmarkTools.DEFAULT_PARAMETERS.seconds = seconds
-    BenchmarkTools.DEFAULT_PARAMETERS.samples = samples
+    # Note: We pass benchmark parameters directly to @benchmark instead of 
+    # modifying BenchmarkTools.DEFAULT_PARAMETERS to avoid const assignment 
+    # errors in Julia 1.12+
 
     # Initialize results DataFrame
     results_data = []
@@ -237,7 +236,7 @@ function benchmark_algorithms(matrix_sizes, algorithms, alg_names, eltypes;
                                     bench = @benchmark solve($prob, $alg) setup=(prob = LinearProblem(
                                         copy($A), copy($b);
                                         u0 = copy($u0),
-                                        alias = LinearAliasSpecifier(alias_A = true, alias_b = true)))
+                                        alias = LinearAliasSpecifier(alias_A = true, alias_b = true))) seconds=$seconds samples=$samples
 
                                     # Calculate GFLOPs
                                     min_time_sec = minimum(bench.times) / 1e9
@@ -271,10 +270,6 @@ function benchmark_algorithms(matrix_sizes, algorithms, alg_names, eltypes;
             end
         end
 
-    finally
-        # Restore original benchmark parameters
-        BenchmarkTools.DEFAULT_PARAMETERS = old_params
-    end
 
     return DataFrame(results_data)
 end


### PR DESCRIPTION
## Summary

Fixes #744 - resolves const assignment error when setting `BenchmarkTools.DEFAULT_PARAMETERS` in Julia 1.12+.

In Julia 1.12+, `BenchmarkTools.DEFAULT_PARAMETERS` became a const and cannot be reassigned. The previous code attempted to:
1. Save original parameters: `old_params = BenchmarkTools.DEFAULT_PARAMETERS`
2. Modify global parameters: `BenchmarkTools.DEFAULT_PARAMETERS.seconds = seconds`
3. Restore in finally block: `BenchmarkTools.DEFAULT_PARAMETERS = old_params` ← This fails

## Changes

- **Removed** global modification of `BenchmarkTools.DEFAULT_PARAMETERS`
- **Replaced** with local `BenchmarkTools.Parameters` creation and direct usage via `@benchmarkable` + `BenchmarkTools.run`
- **Removed** try/finally block that was only needed for parameter restoration
- **Maintains** exact same functionality while fixing Julia 1.12+ compatibility

## Files Changed

- `lib/LinearSolveAutotune/src/benchmarking.jl:90-93`: Removed global parameter setting
- `lib/LinearSolveAutotune/src/benchmarking.jl:235-241`: Updated benchmark execution to use local parameters
- `lib/LinearSolveAutotune/src/benchmarking.jl:272-277`: Removed try/finally block

## Testing

- ✅ All LinearSolveAutotune tests pass
- ✅ Benchmarking functionality works correctly with custom parameters
- ✅ No behavior changes - same results as before

## Benefits

- **Fixes** Julia 1.12+ compatibility issue
- **Cleaner** code without global state modification  
- **Thread-safe** approach using local parameters
- **Future-proof** against further BenchmarkTools.jl const restrictions

🤖 Generated with [Claude Code](https://claude.ai/code)