### PR TITLE
Fix CUDA functional check in init_cacheval functions

### DIFF
--- a/ext/LinearSolveCUDAExt.jl
+++ b/ext/LinearSolveCUDAExt.jl
@@ -53,6 +53,11 @@ end
 function LinearSolve.init_cacheval(alg::CudaOffloadLUFactorization, A::AbstractArray, b, u, Pl, Pr,
         maxiters::Int, abstol, reltol, verbose::Bool,
         assumptions::OperatorAssumptions)
+    # Check if CUDA is functional before creating CUDA arrays
+    if !CUDA.functional()
+        return nothing
+    end
+    
     T = eltype(A)
     noUnitT = typeof(zero(T))
     luT = LinearAlgebra.lutype(noUnitT)
@@ -76,6 +81,11 @@ end
 function LinearSolve.init_cacheval(alg::CudaOffloadQRFactorization, A, b, u, Pl, Pr,
         maxiters::Int, abstol, reltol, verbose::Bool,
         assumptions::OperatorAssumptions)
+    # Check if CUDA is functional before creating CUDA arrays
+    if !CUDA.functional()
+        return nothing
+    end
+    
     qr(CUDA.CuArray(A))
 end
 


### PR DESCRIPTION
## Summary
- Add `CUDA.functional()` check before creating CUDA arrays in `init_cacheval` functions
- Return `nothing` if CUDA is loaded but not functional
- Fixes issue where `CudaOffloadLUFactorization` and `CudaOffloadQRFactorization` would fail during cache initialization when CUDA is in environment but not usable

## Details
The issue occurs when CUDA.jl is loaded in the environment but `CUDA.functional()` returns `false` (e.g., in CI environments without actual CUDA hardware). The `init_cacheval` functions for CUDA algorithms were trying to create `CuVector` and `CuMatrix` objects without checking if CUDA is functional, causing failures during default algorithm initialization.

## Changes
1. **CudaOffloadLUFactorization**: Added `CUDA.functional()` check before creating `CuVector` and `CuMatrix` in `init_cacheval`
2. **CudaOffloadQRFactorization**: Added `CUDA.functional()` check before creating `CUDA.CuArray` in `init_cacheval`  
3. Both functions now return `nothing` when CUDA is not functional, matching the fallback behavior when the extension isn't loaded

## Test plan
- [x] Verified package loads successfully 
- [x] Confirmed `init_cacheval` returns `nothing` when CUDA not functional
- [x] Basic linear algebra operations work correctly
- [x] No errors during cache initialization for default algorithms

Closes #761

🤖 Generated with [Claude Code](https://claude.ai/code)