### PR TITLE
Fix handling for default algorithms for DualLinearProblems

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -243,9 +243,6 @@ function __dual_init(
         dual_type = get_dual_type(prob.b)
     end
 
-    alg isa LinearSolve.DefaultLinearSolver ?
-    real_alg = LinearSolve.defaultalg(primal_prob.A, primal_prob.b) : real_alg = alg
-
     non_partial_cache = init(
         primal_prob, real_alg, assumptions, args...;
         alias = alias, abstol = abstol, reltol = reltol,

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -244,7 +244,7 @@ function __dual_init(
     end
 
     non_partial_cache = init(
-        primal_prob, real_alg, assumptions, args...;
+        primal_prob, alg, assumptions, args...;
         alias = alias, abstol = abstol, reltol = reltol,
         maxiters = maxiters, verbose = verbose, Pl = Pl, Pr = Pr, assumptions = assumptions,
         sensealg = sensealg, u0 = new_u0, kwargs...)

--- a/test/forwarddiff_overloads.jl
+++ b/test/forwarddiff_overloads.jl
@@ -13,7 +13,7 @@ end
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
 prob = LinearProblem(A, b)
-overload_x_p = solve(prob)
+overload_x_p = solve(prob, LUFactorization())
 backslash_x_p = A \ b
 krylov_overload_x_p = solve(prob, KrylovJL_GMRES())
 @test ≈(overload_x_p, backslash_x_p, rtol = 1e-9)
@@ -42,7 +42,7 @@ prob = LinearProblem(A, b)
 A, b = h([ForwardDiff.Dual(10.0, 1.0, 0.0), ForwardDiff.Dual(10.0, 0.0, 1.0)])
 
 prob = LinearProblem(A, b)
-cache = init(prob)
+cache = init(prob, LUFactorization())
 
 new_A, new_b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 cache.A = new_A
@@ -60,7 +60,7 @@ backslash_x_p = new_A \ new_b
 A, b = h([ForwardDiff.Dual(10.0, 1.0, 0.0), ForwardDiff.Dual(10.0, 0.0, 1.0)])
 
 prob = LinearProblem(A, b)
-cache = init(prob)
+cache = init(prob, LUFactorization())
 
 new_A, _ = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 cache.A = new_A
@@ -75,7 +75,7 @@ backslash_x_p = new_A \ b
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
 prob = LinearProblem(A, b)
-cache = init(prob)
+cache = init(prob, LUFactorization())
 
 _, new_b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 cache.b = new_b
@@ -99,7 +99,7 @@ original_x_p = A \ b
 @test ≈(overload_x_p, original_x_p, rtol = 1e-9)
 
 prob = LinearProblem(A, b)
-cache = init(prob)
+cache = init(prob, LUFactorization())
 
 new_A,
 new_b = h([ForwardDiff.Dual(ForwardDiff.Dual(10.0, 1.0, 0.0), 1.0, 0.0),
@@ -155,7 +155,7 @@ end
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
 prob = LinearProblem(A, b)
-cache = init(prob)
+cache = init(prob, LUFactorization())
 
 new_A, new_b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 cache.A = new_A
@@ -193,3 +193,5 @@ A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
 prob = LinearProblem(A, b)
 @test init(prob, GenericLUFactorization()) isa LinearSolve.LinearCache
+
+@test init(prob) isa LinearSolve.LinearCache

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -136,7 +136,7 @@ end
 
 @testset "JET Tests for creating Dual solutions" begin
     # Make sure there's no runtime dispatch when making solutions of Dual problems
-    dual_cache = init(dual_prob)
+    dual_cache = init(dual_prob, LUFactorization())
     ext = Base.get_extension(LinearSolve, :LinearSolveForwardDiffExt)
     JET.@test_opt ext.linearsolve_dual_solution(
         [1.0, 1.0, 1.0], [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], dual_cache)

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -144,6 +144,7 @@ end
 
 @testset "JET Tests for default algs with DualLinear Problems" begin
     # Test for Default alg choosing for DualLinear Problems
+    # These should both produce a LinearCache
     alg = LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization)
     JET.@test_opt init(dual_prob, alg) broken = true
     JET.@test_opt init(dual_prob) broken = true

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -145,6 +145,6 @@ end
 @testset "JET Tests for default algs with DualLinear Problems" begin
     # Test for Default alg choosing for DualLinear Problems
     alg = LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization)
-    JET.@test_opt init(dual_prob, alg)
-    JET.@test_opt init(dual_prob)
+    JET.@test_opt init(dual_prob, alg) broken = true
+    JET.@test_opt init(dual_prob) broken = true
 end

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -146,6 +146,6 @@ end
     # Test for Default alg choosing for DualLinear Problems
     # These should both produce a LinearCache
     alg = LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization)
-    JET.@test_opt init(dual_prob, alg) broken = true
-    JET.@test_opt init(dual_prob) broken = true
+    JET.@test_opt init(dual_prob, alg) 
+    JET.@test_opt init(dual_prob) 
 end

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -141,3 +141,9 @@ end
     JET.@test_opt ext.linearsolve_dual_solution(
         [1.0, 1.0, 1.0], [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], dual_cache)
 end
+
+@testset "JET Tests for default algs with DualLinear Problems" begin
+    alg = LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization)
+    JET.@test_opt init(dual_prob, alg)
+    JET.@test_opt init(dual_prob)
+end

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -146,6 +146,11 @@ end
     # Test for Default alg choosing for DualLinear Problems
     # These should both produce a LinearCache
     alg = LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization)
-    JET.@test_opt init(dual_prob, alg) 
-    JET.@test_opt init(dual_prob) 
+    if VERSION < v"1.11"
+        JET.@test_opt init(dual_prob, alg) broken=true
+        JET.@test_opt init(dual_prob) broken=true
+    else
+        JET.@test_opt init(dual_prob, alg)
+        JET.@test_opt init(dual_prob)
+    end
 end

--- a/test/nopre/jet.jl
+++ b/test/nopre/jet.jl
@@ -143,6 +143,7 @@ end
 end
 
 @testset "JET Tests for default algs with DualLinear Problems" begin
+    # Test for Default alg choosing for DualLinear Problems
     alg = LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization)
     JET.@test_opt init(dual_prob, alg)
     JET.@test_opt init(dual_prob)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This makes it so that the default alg is chosen based on the primal A and b _before_ going to make the Dual cache. This also means that for small problems GenericLU will be used, and the cache will be a normal LinearCache. 
