### PR TITLE
Add compat entry for MKL_jll

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 authors = ["SciML"]
-version = "3.40.0"
+version = "3.40.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -108,6 +108,7 @@ LAPACK_jll = "3"
 LazyArrays = "2.3"
 Libdl = "1.10"
 LinearAlgebra = "1.10"
+MKL_jll = "2022.2, 2023, 2024, 2025"
 MPI = "0.20"
 Markdown = "1.10"
 Metal = "1.4"


### PR DESCRIPTION
Fixes #779 for new releases of LinearSolve.

Old versions (LinearSolve >= 2.5.0) would have to be fixed in the registry.