### PR TITLE
Disable use of older MKL_jll versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 authors = ["SciML"]
-version = "3.40.0"
+version = "3.40.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -108,6 +108,7 @@ LAPACK_jll = "3"
 LazyArrays = "2.3"
 Libdl = "1.10"
 LinearAlgebra = "1.10"
+MKL_jll = "2019, 2020, 2021, 2022, 2023, 2024, 2025"
 MPI = "0.20"
 Markdown = "1.10"
 Metal = "1.4"

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -49,8 +49,11 @@ const CRC = ChainRulesCore
 @static if Sys.ARCH === :x86_64 || Sys.ARCH === :i686
     if Preferences.@load_preference("LoadMKL_JLL",
         !occursin("EPYC", Sys.cpu_info()[1].model))
+        # MKL_jll < 2022.2 doesn't support the mixed LP64 and ILP64 interfaces that we make use of in LinearSolve
+        # In particular, the `_64` APIs do not exist
+        # https://www.intel.com/content/www/us/en/developer/articles/release-notes/onemkl-release-notes-2022.html
         using MKL_jll
-        const usemkl = MKL_jll.is_available()
+        const usemkl = MKL_jll.is_available() && pkgversion(MKL_jll) >= v"2022.2"
     else
         const usemkl = false
     end

--- a/src/mkl.jl
+++ b/src/mkl.jl
@@ -12,7 +12,10 @@ struct MKLLUFactorization <: AbstractFactorization end
 @static if !@isdefined(MKL_jll)
     __mkl_isavailable() = false
 else
-    __mkl_isavailable() = MKL_jll.is_available()
+    # MKL_jll < 2022.2 doesn't support the mixed LP64 and ILP64 interfaces that we make use of in LinearSolve
+    # In particular, the `_64` APIs do not exist
+    # https://www.intel.com/content/www/us/en/developer/articles/release-notes/onemkl-release-notes-2022.html
+    __mkl_isavailable() = MKL_jll.is_available() && pkgversion(MKL_jll) >= v"2022.2"
 end
 
 function getrf!(A::AbstractMatrix{<:ComplexF64};


### PR DESCRIPTION
Alternative to #780 that would still allow installing MKL_jll < 2022.2 together with recent versions of LinearSolve.

I didn't change anything in LinearSolveAutotune as based on its Project.toml it only supports MKL_jll 2025 anyway.

---

I also briefly tried to fix support of older MKL_jll versions but it seems to me one would basically have to duplicate the version-specific handling that MKL.jl is/was doing. 