### PR TITLE
Move `use_*` extension functions to their respective extensions

### DIFF
--- a/ext/LinearSolveBLISExt.jl
+++ b/ext/LinearSolveBLISExt.jl
@@ -15,6 +15,8 @@ using SciMLBase: ReturnCode
 const global libblis = blis_jll.blis
 const global liblapack = LAPACK_jll.liblapack
 
+LinearSolve.useblis() = true
+
 function getrf!(A::AbstractMatrix{<:ComplexF64};
     ipiv = similar(A, BlasInt, min(size(A, 1), size(A, 2))),
     info = Ref{BlasInt}(),

--- a/ext/LinearSolveCUDAExt.jl
+++ b/ext/LinearSolveCUDAExt.jl
@@ -11,6 +11,8 @@ using LinearSolve: LinearSolve, is_cusparse, defaultalg, cudss_loaded, DefaultLi
 using LinearSolve.LinearAlgebra, LinearSolve.SciMLBase, LinearSolve.ArrayInterface
 using SciMLBase: AbstractSciMLOperator
 
+LinearSolve.usecuda() = CUDA.functional()
+
 function LinearSolve.is_cusparse(A::Union{
         CUDA.CUSPARSE.CuSparseMatrixCSR, CUDA.CUSPARSE.CuSparseMatrixCSC})
     true

--- a/ext/LinearSolveMetalExt.jl
+++ b/ext/LinearSolveMetalExt.jl
@@ -6,6 +6,12 @@ using SciMLBase: AbstractSciMLOperator
 using LinearSolve: ArrayInterface, MKLLUFactorization, MetalOffload32MixedLUFactorization, 
                    @get_cacheval, LinearCache, SciMLBase, OperatorAssumptions
 
+@static if Sys.isapple()
+
+LinearSolve.usemetal() = true
+
+end
+
 default_alias_A(::MetalLUFactorization, ::Any, ::Any) = false
 default_alias_b(::MetalLUFactorization, ::Any, ::Any) = false
 

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -433,18 +433,9 @@ const HAS_APPLE_ACCELERATE = Ref(false)
 appleaccelerate_isavailable() = HAS_APPLE_ACCELERATE[]
 
 # Extension availability checking functions
-useblis() = Base.get_extension(@__MODULE__, :LinearSolveBLISExt) !== nothing
-function usecuda()
-   ext = Base.get_extension(@__MODULE__, :LinearSolveCUDAExt)
-   !isnothing(ext) && ext.CUDA.functional()
-end
-
-# Metal is only available on Apple platforms
-@static if !Sys.isapple()
-    usemetal() = false
-else
-    usemetal() = Base.get_extension(@__MODULE__, :LinearSolveMetalExt) !== nothing
-end
+useblis() = false
+usecuda() = false
+usemetal() = false
 
 PrecompileTools.@compile_workload begin
     A = rand(4, 4)


### PR DESCRIPTION
This will technically invalidate when loading this extensions.

However, most of the extension implementations already invalidate by design so this at least resolves SciML/LinearSolve.jl#778.

