### PR TITLE
Better safeguard on unloadable MKL

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -54,19 +54,17 @@ const CRC = ChainRulesCore
         # https://www.intel.com/content/www/us/en/developer/articles/release-notes/onemkl-release-notes-2022.html
         using MKL_jll: MKL_jll
         const usemkl = MKL_jll.is_available() && pkgversion(MKL_jll) >= v"2022.2"
-
-        @static if usemkl
-            using MKL_jll: libmkl_rt
-        else
-            global libmkl_rt
-        end
     else
-        global libmkl_rt
         const usemkl = false
     end
 else
-    global libmkl_rt
     const usemkl = false
+end
+
+@static if usemkl
+   using MKL_jll: libmkl_rt
+else
+   global libmkl_rt
 end
 
 # OpenBLAS_jll is a standard library, but allow users to disable it via preferences

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -52,8 +52,14 @@ const CRC = ChainRulesCore
         # MKL_jll < 2022.2 doesn't support the mixed LP64 and ILP64 interfaces that we make use of in LinearSolve
         # In particular, the `_64` APIs do not exist
         # https://www.intel.com/content/www/us/en/developer/articles/release-notes/onemkl-release-notes-2022.html
-        using MKL_jll: MKL_jll, libmkl_rt
+        using MKL_jll: MKL_jll
         const usemkl = MKL_jll.is_available() && pkgversion(MKL_jll) >= v"2022.2"
+
+        @static if usemkl
+            using MKL_jll: libmkl_rt
+        else
+            global libmkl_rt
+        end
     else
         global libmkl_rt
         const usemkl = false


### PR DESCRIPTION
Tries to safeguard https://github.com/julia-actions/setup-julia/pull/300 https://github.com/JuliaLang/julia/issues/55878 where the user has requested an incorrect architecture and thus we may believe we can load MKL until we check `MKL_jll.is_available() == false`. The reason is because we're being lied to about `@static if Sys.ARCH === :x86_64 || Sys.ARCH === :i686` which then makes it take this branch and then MKL does not exist. We could instead check `isapple` another type of workaround here and 99% of users would be perfectly fine, but if this is safe this is slightly better for the 1 remaining Intel Apple user that exists in the wild somewhere.
