### PR TITLE
Fix QR pivot bit width error on LP64 platform when precompile

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -311,7 +311,7 @@ function init_cacheval(alg::QRFactorization, A::Symmetric{<:Number, <:Array}, b,
     return qr(convert(AbstractMatrix, A), alg.pivot)
 end
 
-const PREALLOCATED_QR_ColumnNorm = ArrayInterface.qr_instance(rand(1, 1), ColumnNorm())
+const PREALLOCATED_QR_ColumnNorm = qr(rand(1, 1), ColumnNorm())
 
 function init_cacheval(alg::QRFactorization{ColumnNorm}, A::Matrix{Float64}, b, u, Pl, Pr,
         maxiters::Int, abstol, reltol, verbose::Bool, assumptions::OperatorAssumptions)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

### What changed

```julia
const PREALLOCATED_QR_ColumnNorm = ArrayInterface.qr_instance(rand(1, 1), ColumnNorm())
```

This preallocated QR value is infered as Int64 instead of BlasInt. However, it is predicted to be Int32 on LP64 platform.

So I use the real LAPACK QR to generate this preallocated value to keep the type match.

```julia
const PREALLOCATED_QR_ColumnNorm = qr(rand(1, 1), ColumnNorm())
```

### Impact

Before this, I cant install Pkg "NonlinearSolve" on my m1 macbookpro, which throws error:

<details>
NonlinearSolve precompile error 
<summary>Details</summary>
ERROR: The following 2 direct dependencies failed to precompile:

NonlinearSolve 

Failed to precompile NonlinearSolve [8913a72c-1f9b-4ce2-8d82-65094dcecaec] to "/Users/chiyizi/.julia/compiled/v1.11/NonlinearSolve/jl_HCZZPa".
ERROR: LoadError: TaskFailedException

    nested task error: TypeError: in setfield!, expected LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, got a value of type LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int32}}
    Stacktrace:
      [1] __setfield!(cache::LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, alg::LinearSolve.DefaultLinearSolver, v::LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int32}})
        @ LinearSolve ~/.julia/packages/LinearSolve/kU6c0/src/default.jl:50
      [2] setproperty!(cache::LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, name::Symbol, x::LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int32}})
        @ LinearSolve ~/.julia/packages/LinearSolve/kU6c0/src/common.jl:138
      [3] macro expansion
        @ ~/.julia/packages/LinearSolve/kU6c0/src/factorization.jl:6 [inlined]
      [4] solve!(cache::LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, alg::LinearSolve.QRFactorization{LinearAlgebra.ColumnNorm}; kwargs::@Kwargs{})
        @ LinearSolve ~/.julia/packages/LinearSolve/kU6c0/src/factorization.jl:1
      [5] solve!
        @ ~/.julia/packages/LinearSolve/kU6c0/src/factorization.jl:1 [inlined]
      [6] macro expansion
        @ ~/.julia/packages/LinearSolve/kU6c0/src/default.jl:610 [inlined]
      [7] solve!(::LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, ::LinearSolve.DefaultLinearSolver; assump::LinearSolve.OperatorAssumptions{Nothing}, kwargs::@Kwargs{})
        @ LinearSolve ~/.julia/packages/LinearSolve/kU6c0/src/default.jl:503
      [8] solve!
        @ ~/.julia/packages/LinearSolve/kU6c0/src/default.jl:503 [inlined]
      [9] #solve!#12
        @ ~/.julia/packages/LinearSolve/kU6c0/src/common.jl:424 [inlined]
     [10] solve!
        @ ~/.julia/packages/LinearSolve/kU6c0/src/common.jl:423 [inlined]
     [11] #_#1
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl:23 [inlined]
     [12] LinearSolveJLCache
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl:13 [inlined]
     [13] solve!(cache::NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, Nothing}, Nothing, Nothing, Nothing, Val{false}, Val{false}}, J::Matrix{Float64}, fu::Vector{Float64}, u::Vector{Float64}, idx::Val{1}; skip_solve::Bool, new_jacobian::Bool, kwargs::@Kwargs{verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/descent/newton.jl:111
     [14] solve! (repeats 2 times)
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/descent/newton.jl:85 [inlined]
     [15] step!(cache::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Float64, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, ADTypes.AutoForwardDiff{nothing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, Nothing, Bool}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, Val{:None}, NonlinearSolveBase.JacobianCache{Matrix{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Vector{Float64}, Float64, ADTypes.AutoForwardDiff{nothing, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.JacobianConfig{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Float64}, Float64, 2, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Float64}, Float64, 2}}}, Tuple{Nothing}}}, NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, Nothing}, Nothing, Nothing, Nothing, Val{false}, Val{false}}, Nothing, Nothing, Nothing, Nothing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(NonlinearSolveBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64}, NonlinearSolveBase.NonlinearSolveTrace{Val{false}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}}, @Kwargs{verbose::Bool}, NonlinearSolveBase.NonlinearSolveDefaultInit}; recompute_jacobian::Nothing)
        @ NonlinearSolveFirstOrder ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/solve.jl:254
     [16] step!
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/solve.jl:232 [inlined]
     [17] #step!#163
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:500 [inlined]
     [18] step!
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:494 [inlined]
     [19] solve!(cache::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Float64, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, ADTypes.AutoForwardDiff{nothing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, Nothing, Bool}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, Val{:None}, NonlinearSolveBase.JacobianCache{Matrix{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Vector{Float64}, Float64, ADTypes.AutoForwardDiff{nothing, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.JacobianConfig{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Float64}, Float64, 2, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Float64}, Float64, 2}}}, Tuple{Nothing}}}, NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, Nothing}, Nothing, Nothing, Nothing, Val{false}, Val{false}}, Nothing, Nothing, Nothing, Nothing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(NonlinearSolveBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64}, NonlinearSolveBase.NonlinearSolveTrace{Val{false}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}}, @Kwargs{verbose::Bool}, NonlinearSolveBase.NonlinearSolveDefaultInit})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:240
     [20] __solve(::SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}; kwargs::@Kwargs{alias_u0::Bool, abstol::Float64, verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:228
     [21] __solve
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:223 [inlined]
     [22] solve_call(_prob::SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, args::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}; merge_callbacks::Bool, kwargshandle::Nothing, kwargs::@Kwargs{alias_u0::Bool, abstol::Float64, verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:154
     [23] solve_up(prob::SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, sensealg::Nothing, u0::Vector{Float64}, p::Float64, args::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}; originator::SciMLBase.ChainRulesOriginator, kwargs::@Kwargs{alias_u0::Bool, abstol::Float64, verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:115
     [24] solve_up
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:101 [inlined]
     [25] solve(prob::SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, args::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}; sensealg::Nothing, u0::Nothing, p::Nothing, wrap::Val{true}, kwargs::@Kwargs{abstol::Float64, verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:81
     [26] solve
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:47 [inlined]
     [27] (::NonlinearSolveFirstOrder.var"#34#43"{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}})()
        @ NonlinearSolveFirstOrder ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:92

...and 3 more exceptions.

Stacktrace:
 [1] macro expansion
   @ ./task.jl:499 [inlined]
 [2] macro expansion
   @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:84 [inlined]
 [3] macro expansion
   @ ~/.julia/packages/PrecompileTools/L8A3n/src/workloads.jl:78 [inlined]
 [4] macro expansion
   @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:83 [inlined]
 [5] macro expansion
   @ ~/.julia/packages/PrecompileTools/L8A3n/src/workloads.jl:140 [inlined]
 [6] top-level scope
   @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:42
 [7] top-level scope
   @ stdin:6
in expression starting at /Users/chiyizi/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:1
in expression starting at stdin:6
ERROR: LoadError: Failed to precompile NonlinearSolveFirstOrder [5959db7a-ea39-4486-b5fe-2dd0bf03d60d] to "/Users/chiyizi/.julia/compiled/v1.11/NonlinearSolveFirstOrder/jl_XHZTG2".
Stacktrace:
 [1] mkpidlock(f::Base.var"#1110#1111"{Base.PkgId}, at::String, pid::Int32; kwopts::@Kwargs{stale_age::Int64, wait::Bool})
   @ FileWatching.Pidfile /opt/homebrew/Cellar/julia/1.11.7/share/julia/stdlib/v1.11/FileWatching/src/pidfile.jl:95
 [2] top-level scope
   @ stdin:6
in expression starting at /Users/chiyizi/code/projs/sciml/NonlinearSolve.jl/src/NonlinearSolve.jl:1
in expression starting at stdin:6
NonlinearSolveFirstOrder 

Failed to precompile NonlinearSolveFirstOrder [5959db7a-ea39-4486-b5fe-2dd0bf03d60d] to "/Users/chiyizi/.julia/compiled/v1.11/NonlinearSolveFirstOrder/jl_nnotZz".
ERROR: LoadError: TaskFailedException

    nested task error: TypeError: in setfield!, expected LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, got a value of type LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int32}}
    Stacktrace:
      [1] __setfield!(cache::LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, alg::LinearSolve.DefaultLinearSolver, v::LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int32}})
        @ LinearSolve ~/.julia/packages/LinearSolve/kU6c0/src/default.jl:50
      [2] setproperty!(cache::LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, name::Symbol, x::LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int32}})
        @ LinearSolve ~/.julia/packages/LinearSolve/kU6c0/src/common.jl:138
      [3] macro expansion
        @ ~/.julia/packages/LinearSolve/kU6c0/src/factorization.jl:6 [inlined]
      [4] solve!(cache::LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, alg::LinearSolve.QRFactorization{LinearAlgebra.ColumnNorm}; kwargs::@Kwargs{})
        @ LinearSolve ~/.julia/packages/LinearSolve/kU6c0/src/factorization.jl:1
      [5] solve!
        @ ~/.julia/packages/LinearSolve/kU6c0/src/factorization.jl:1 [inlined]
      [6] macro expansion
        @ ~/.julia/packages/LinearSolve/kU6c0/src/default.jl:610 [inlined]
      [7] solve!(::LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, ::LinearSolve.DefaultLinearSolver; assump::LinearSolve.OperatorAssumptions{Nothing}, kwargs::@Kwargs{})
        @ LinearSolve ~/.julia/packages/LinearSolve/kU6c0/src/default.jl:503
      [8] solve!
        @ ~/.julia/packages/LinearSolve/kU6c0/src/default.jl:503 [inlined]
      [9] #solve!#12
        @ ~/.julia/packages/LinearSolve/kU6c0/src/common.jl:424 [inlined]
     [10] solve!
        @ ~/.julia/packages/LinearSolve/kU6c0/src/common.jl:423 [inlined]
     [11] #_#1
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl:23 [inlined]
     [12] LinearSolveJLCache
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl:13 [inlined]
     [13] solve!(cache::NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, Nothing}, Nothing, Nothing, Nothing, Val{false}, Val{false}}, J::Matrix{Float64}, fu::Vector{Float64}, u::Vector{Float64}, idx::Val{1}; skip_solve::Bool, new_jacobian::Bool, kwargs::@Kwargs{verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/descent/newton.jl:111
     [14] solve! (repeats 2 times)
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/descent/newton.jl:85 [inlined]
     [15] step!(cache::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Float64, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, ADTypes.AutoForwardDiff{nothing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, Nothing, Bool}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, Val{:None}, NonlinearSolveBase.JacobianCache{Matrix{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Vector{Float64}, Float64, ADTypes.AutoForwardDiff{nothing, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.JacobianConfig{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Float64}, Float64, 2, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Float64}, Float64, 2}}}, Tuple{Nothing}}}, NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, Nothing}, Nothing, Nothing, Nothing, Val{false}, Val{false}}, Nothing, Nothing, Nothing, Nothing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(NonlinearSolveBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64}, NonlinearSolveBase.NonlinearSolveTrace{Val{false}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}}, @Kwargs{verbose::Bool}, NonlinearSolveBase.NonlinearSolveDefaultInit}; recompute_jacobian::Nothing)
        @ NonlinearSolveFirstOrder ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/solve.jl:254
     [16] step!
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/solve.jl:232 [inlined]
     [17] #step!#163
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:500 [inlined]
     [18] step!
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:494 [inlined]
     [19] solve!(cache::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Float64, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, ADTypes.AutoForwardDiff{nothing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, Nothing, Bool}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, Val{:None}, NonlinearSolveBase.JacobianCache{Matrix{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Vector{Float64}, Float64, ADTypes.AutoForwardDiff{nothing, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.JacobianConfig{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Float64}, Float64, 2, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, Float64}, Float64, 2}}}, Tuple{Nothing}}}, NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Vector{Int32}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int32}}, Base.RefValue{Int32}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, Bool, LinearSolve.LinearSolveAdjoint{Missing}}, Nothing}, Nothing, Nothing, Nothing, Val{false}, Val{false}}, Nothing, Nothing, Nothing, Nothing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(NonlinearSolveBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64}, NonlinearSolveBase.NonlinearSolveTrace{Val{false}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}}, @Kwargs{verbose::Bool}, NonlinearSolveBase.NonlinearSolveDefaultInit})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:240
     [20] __solve(::SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}; kwargs::@Kwargs{alias_u0::Bool, abstol::Float64, verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:228
     [21] __solve
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:223 [inlined]
     [22] solve_call(_prob::SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, args::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}; merge_callbacks::Bool, kwargshandle::Nothing, kwargs::@Kwargs{alias_u0::Bool, abstol::Float64, verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:154
     [23] solve_up(prob::SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, sensealg::Nothing, u0::Vector{Float64}, p::Float64, args::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}; originator::SciMLBase.ChainRulesOriginator, kwargs::@Kwargs{alias_u0::Bool, abstol::Float64, verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:115
     [24] solve_up
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:101 [inlined]
     [25] solve(prob::SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}, args::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}; sensealg::Nothing, u0::Nothing, p::Nothing, wrap::Val{true}, kwargs::@Kwargs{abstol::Float64, verbose::Bool})
        @ NonlinearSolveBase ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:81
     [26] solve
        @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveBase/src/solve.jl:47 [inlined]
     [27] (::NonlinearSolveFirstOrder.var"#34#43"{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Float64, SciMLBase.NonlinearFunction{false, SciMLBase.NoSpecialize, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Nothing, Any, Any, Any}, @Kwargs{}}})()
        @ NonlinearSolveFirstOrder ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:92

...and 3 more exceptions.

Stacktrace:
 [1] macro expansion
   @ ./task.jl:499 [inlined]
 [2] macro expansion
   @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:84 [inlined]
 [3] macro expansion
   @ ~/.julia/packages/PrecompileTools/L8A3n/src/workloads.jl:78 [inlined]
 [4] macro expansion
   @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:83 [inlined]
 [5] macro expansion
   @ ~/.julia/packages/PrecompileTools/L8A3n/src/workloads.jl:140 [inlined]
 [6] top-level scope
   @ ~/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:42
 [7] top-level scope
   @ stdin:6
in expression starting at /Users/chiyizi/code/projs/sciml/NonlinearSolve.jl/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl:1
in expression starting at stdin:6
</details>

This is caused by mismatch type according to the above. After this commit, I can install this Pkg.
