### PR TITLE
Add JOSS paper for LinearSolve.jl

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -1,0 +1,134 @@
+@article{Bezanson2017,
+  author = {Bezanson, Jeff and Edelman, Alan and Karpinski, Stefan and Shah, Viral B.},
+  title = {{J}ulia: A Fresh Approach to Numerical Computing},
+  journal = {SIAM Review},
+  volume = {59},
+  number = {1},
+  pages = {65-98},
+  year = {2017},
+  doi = {10.1137/141000671},
+  URL = {https://doi.org/10.1137/141000671},
+  eprint = {https://doi.org/10.1137/141000671}
+}
+
+@misc{ma2021modelingtoolkit,
+  title={ModelingToolkit: A Composable Graph Transformation System For Equation-Based Modeling},
+  author={Yingbo Ma and Shashi Gowda and Ranjan Anantharaman and Chris Laughman and Viral Shah and Chris Rackauckas},
+  year={2021},
+  eprint={2103.05244},
+  archivePrefix={arXiv},
+  doi={10.48550/arXiv.2103.05244},
+  url={https://doi.org/10.48550/arXiv.2103.05244},
+  primaryClass={cs.MS}
+}
+
+@article{rackauckas2017differentialequations,
+  title={DifferentialEquations.jl--a performant and feature-rich ecosystem for solving differential equations in Julia},
+  author={Rackauckas, Christopher and Nie, Qing},
+  journal={Journal of Open Research Software},
+  volume={5},
+  number={1},
+  pages={15},
+  year={2017},
+  publisher={Ubiquity Press},
+  doi={10.5334/jors.151},
+  url={https://doi.org/10.5334/jors.151}
+}
+
+@article{Davis2010KLU,
+  title={Algorithm 907: KLU, a direct sparse solver for circuit simulation problems},
+  author={Davis, Timothy A. and Palamadai Natarajan, Ekanathan},
+  journal={ACM Transactions on Mathematical Software (TOMS)},
+  volume={37},
+  number={3},
+  pages={1--17},
+  year={2010},
+  publisher={ACM New York, NY, USA},
+  doi={10.1145/1824801.1824814},
+  url={https://doi.org/10.1145/1824801.1824814}
+}
+
+@article{Davis2004UMFPACK,
+  title={Algorithm 832: UMFPACK V4.3---an unsymmetric-pattern multifrontal method},
+  author={Davis, Timothy A.},
+  journal={ACM Transactions on Mathematical Software (TOMS)},
+  volume={30},
+  number={2},
+  pages={196--199},
+  year={2004},
+  publisher={ACM New York, NY, USA},
+  doi={10.1145/992200.992206},
+  url={https://doi.org/10.1145/992200.992206}
+}
+
+@article{Schenk2004Pardiso,
+  title={Solving unsymmetric sparse systems of linear equations with PARDISO},
+  author={Schenk, Olaf and G{\"a}rtner, Klaus},
+  journal={Future Generation Computer Systems},
+  volume={20},
+  number={3},
+  pages={475--487},
+  year={2004},
+  publisher={Elsevier},
+  doi={10.1016/j.future.2003.07.011},
+  url={https://doi.org/10.1016/j.future.2003.07.011}
+}
+
+@misc{Sparspak,
+  author = {Sherman, Andrew H. and George, Alan and Liu, Joseph W. H.},
+  title = {Sparspak: Waterloo Sparse Matrix Package},
+  howpublished = {Julia implementation: \url{https://github.com/PetrKryslUCSD/Sparspak.jl}},
+  note = {User's Guide for SPARSPAK: Waterloo sparse linear equations package},
+  year = {1978}
+}
+
+@inproceedings{besard2018juliagpu,
+  title={Effective extensible programming: unleashing Julia on GPUs},
+  author={Besard, Tim and Foket, Christophe and De Sutter, Bjorn},
+  booktitle={IEEE Transactions on Parallel and Distributed Systems},
+  volume={30},
+  number={4},
+  pages={827--841},
+  year={2019},
+  organization={IEEE},
+  doi={10.1109/TPDS.2018.2872064},
+  url={https://doi.org/10.1109/TPDS.2018.2872064}
+}
+
+@misc{Krylov,
+  author = {Montoison, Alexis and Orban, Dominique},
+  title = {Krylov.jl: A Julia basket of hand-picked Krylov methods},
+  year = {2020},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/JuliaSmoothOptimizers/Krylov.jl}},
+  doi={10.5281/zenodo.822073},
+  url={https://doi.org/10.5281/zenodo.822073}
+}
+
+@misc{IterativeSolvers,
+  author = {Jutho Haegeman and others},
+  title = {IterativeSolvers.jl: Iterative algorithms for solving linear systems, eigensystems, and singular value problems},
+  year = {2023},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/JuliaLinearAlgebra/IterativeSolvers.jl}}
+}
+
+@misc{KrylovKit,
+  author = {Haegeman, Jutho},
+  title = {KrylovKit.jl: A Julia package collecting a number of Krylov-based algorithms for linear problems, singular value and eigenvalue problems},
+  year = {2023},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/Jutho/KrylovKit.jl}}
+}
+
+@misc{RecursiveFactorization,
+  author = {Rackauckas, Christopher and others},
+  title = {RecursiveFactorization.jl: A Julia package for recursive dense matrix factorizations},
+  year = {2023},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/JuliaLinearAlgebra/RecursiveFactorization.jl}}
+}

--- a/joss/paper.md
+++ b/joss/paper.md
@@ -1,0 +1,102 @@
+---
+title: 'LinearSolve.jl: High-Performance Unified Interface for Linear System Solvers'
+tags:
+  - julia
+  - linear algebra
+  - numerical methods
+  - high-performance computing
+authors:
+  - name: Christopher Rackauckas
+    orcid: 0000-0001-5850-0663
+    corresponding: true
+    affiliation: "1, 2, 3"
+affiliations:
+ - name: JuliaHub
+   index: 1
+ - name: Pumas-AI
+   index: 2
+ - name: Massachusetts Institute of Technology
+   index: 3
+date: 25 October 2025
+bibliography: paper.bib
+---
+
+# Summary
+
+Solving linear systems of the form $Ax = b$ is a fundamental operation in scientific computing, appearing in applications ranging from machine learning to differential equations. LinearSolve.jl is a Julia [@Bezanson2017] package that provides a unified, high-performance interface for linear system solvers across the Julia ecosystem. The package implements the SciML common interface, enabling users to easily swap between different solver algorithms while maintaining maximum efficiency. LinearSolve.jl includes:
+
+  - Fast pure Julia LU factorizations which can outperform standard BLAS implementations
+  - Specialized sparse matrix solvers including KLU [@Davis2010KLU], UMFPACK [@Davis2004UMFPACK], and Pardiso [@Schenk2004Pardiso]
+  - Sparspak.jl [@Sparspak] for pure Julia sparse LU factorization supporting generic number types
+  - GPU-offloading capabilities for large dense and sparse matrices via CUDA.jl [@besard2018juliagpu], Metal.jl, and AMDGPU.jl
+  - Comprehensive wrappers for Krylov methods from Krylov.jl [@Krylov], IterativeSolvers.jl [@IterativeSolvers], and KrylovKit.jl [@KrylovKit]
+  - A polyalgorithm that intelligently selects optimal methods based on problem characteristics
+  - An advanced caching interface that optimizes symbolic and numerical factorizations
+  - Mixed precision solvers for memory-bandwidth-limited problems
+  - Integration with ModelingToolkit.jl [@ma2021modelingtoolkit] for symbolic modeling
+
+# Statement of need
+
+Linear system solving is ubiquitous in scientific computing, yet choosing the right solver for a given problem requires significant expertise. Different algorithms excel in different regimes: direct methods like LU factorization are efficient for small to medium dense systems, sparse factorizations leverage structure in large sparse systems, and iterative Krylov methods scale to very large systems when lower tolerance is acceptable. Furthermore, modern hardware diversity (CPUs with various BLAS implementations, NVIDIA GPUs, AMD GPUs, Apple Silicon) means that optimal performance often requires hardware-specific implementations.
+
+LinearSolve.jl addresses these challenges by providing a unified interface that abstracts away implementation details while maintaining high performance. Users define a `LinearProblem` once and can easily experiment with different solvers by changing a single argument. The package automatically handles API differences between underlying solver libraries, particularly in preconditioner definitions and matrix format requirements. This design philosophy aligns with the broader SciML ecosystem's goal of composable, high-performance scientific computing tools.
+
+The package distinguishes itself from Base Julia's LinearAlgebra in several ways:
+
+  - **Performance optimizations**: Pure Julia implementations like `RFLUFactorization` [@RecursiveFactorization] can outperform BLAS for small to medium matrices, while hardware-specific wrappers (`AppleAccelerateLUFactorization`, `MKLLUFactorization`) provide optimal performance across different platforms
+  - **Caching infrastructure**: Automatic reuse of symbolic and numerical factorizations when solving multiple systems with the same structure
+  - **Unified Krylov interface**: Seamless access to multiple Krylov implementations with consistent preconditioner handling
+  - **GPU acceleration**: First-class support for offloading to CUDA, Metal, and AMD GPUs with automatic data transfer
+  - **Polyalgorithm selection**: Intelligent algorithm choice based on matrix properties and problem size
+  - **Sparse solver diversity**: Access to KLU, UMFPACK, Pardiso, Sparspak, and CliqueTrees solvers through a common interface
+
+LinearSolve.jl is a critical dependency in the SciML ecosystem, particularly for DifferentialEquations.jl [@rackauckas2017differentialequations] where linear solves appear in implicit time integration and nonlinear system solving. It enables downstream packages and users to easily experiment with different linear solvers to find optimal performance for their specific applications.
+
+# Example
+
+The package provides comprehensive tutorials in the documentation:
+
+  - [Tutorial I: Basics](https://docs.sciml.ai/LinearSolve/stable/tutorials/linear/) demonstrates defining linear problems and solving with different algorithms
+  - [Tutorial II: Caching Interface](https://docs.sciml.ai/LinearSolve/stable/tutorials/caching_interface/) explains how to efficiently reuse factorizations
+  - [Tutorial III: GPU Computing](https://docs.sciml.ai/LinearSolve/stable/tutorials/gpu/) shows GPU-accelerated solving for large matrices
+  - [Tutorial IV: Autotuning](https://docs.sciml.ai/LinearSolve/stable/tutorials/autotune/) demonstrates automatic algorithm selection
+
+A simple demonstration showing the unified interface:
+
+```julia
+using LinearSolve
+
+# Define the linear problem
+n = 4
+A = rand(n, n)
+b = rand(n)
+prob = LinearProblem(A, b)
+
+# Initialize with default algorithm
+linsolve = init(prob)
+sol = solve!(linsolve)
+sol.u  # Solution vector
+
+# Reuse for a different right-hand side
+b2 = rand(n)
+linsolve.b = b2
+sol2 = solve!(linsolve)
+
+# Switch to an iterative solver (GMRES)
+using IterativeSolvers  # Load extension
+linsolve = init(prob, IterativeSolversJL_GMRES())
+sol3 = solve!(linsolve)
+
+# Update the matrix and resolve
+A2 = rand(n, n)
+linsolve.A = A2
+sol4 = solve!(linsolve)
+```
+
+This example demonstrates the key features: defining a problem once, efficiently solving multiple related systems through caching, and seamlessly switching between solver algorithms.
+
+# Acknowledgements
+
+We acknowledge contributions from the entire SciML community and the JuliaLang community for their development of the underlying solver packages that LinearSolve.jl interfaces with.
+
+# References


### PR DESCRIPTION
## Summary

This PR adds a Journal of Open Source Software (JOSS) paper submission for LinearSolve.jl, following the structure and format used in DataInterpolations.jl.

## Changes

- **joss/paper.md**: Main paper content describing LinearSolve.jl's features, statement of need, and example usage
- **joss/paper.bib**: Bibliography with comprehensive references

## Paper Content

The paper highlights LinearSolve.jl's key contributions to the Julia ecosystem:

### Core Features
- Unified interface for linear solvers across the Julia ecosystem
- High-performance implementations with hardware-specific optimizations (MKL, Apple Accelerate, OpenBLAS)
- Fast pure Julia LU factorizations that can outperform BLAS for certain problem sizes

### Solver Ecosystem
- Comprehensive sparse solver support (KLU, UMFPACK, Pardiso, Sparspak, CliqueTrees)
- Unified Krylov method interface (Krylov.jl, IterativeSolvers.jl, KrylovKit.jl)
- GPU acceleration for CUDA, Metal, and AMD GPUs
- Mixed precision solvers for memory-bandwidth-limited problems

### Advanced Capabilities
- Intelligent polyalgorithm for automatic solver selection
- Advanced caching infrastructure for symbolic and numerical factorizations
- Seamless integration with ModelingToolkit.jl and the broader SciML ecosystem

## Example Structure

The paper follows JOSS guidelines with:
- YAML metadata header with authors and affiliations
- Summary section describing the package
- Statement of need explaining the problem and solution
- Example code demonstrating the unified interface
- Comprehensive bibliography

## Next Steps

This is a first draft following the DataInterpolations.jl template. Please review and suggest:
- Additional authors who should be credited
- Corrections to technical content
- Additional references that should be cited
- Any other improvements to make this submission-ready

## Test Results

✅ Package loads successfully with the new files
✅ No breaking changes (only documentation added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)