### PR TITLE
Opt out from generic dual number handling for SparspakFactorization

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -200,6 +200,11 @@ function SciMLBase.init(prob::DualAbstractLinearProblem, alg::GenericLUFactoriza
     return __init(prob, alg, args...; kwargs...)
 end
 
+# Opt out for SparspakFactorization
+function SciMLBase.init(prob::DualAbstractLinearProblem, alg::SparspakFactorization, args...; kwargs...)
+    return __init(prob, alg, args...; kwargs...)
+end
+
 function SciMLBase.init(prob::DualAbstractLinearProblem, alg::DefaultLinearSolver, args...; kwargs...)
     if alg.alg === DefaultAlgorithmChoice.GenericLUFactorization
         return __init(prob, alg, args...; kwargs...)

--- a/test/forwarddiff_overloads.jl
+++ b/test/forwarddiff_overloads.jl
@@ -3,6 +3,7 @@ using ForwardDiff
 using Test
 using SparseArrays
 using ComponentArrays
+using Sparspak
 
 function h(p)
     (A = [p[1] p[2]+1 p[2]^3;
@@ -188,7 +189,6 @@ backslash_x_p = A \ b
 
 @test ≈(overload_x_p, backslash_x_p, rtol = 1e-9)
 
-
 # Test that GenericLU doesn't create a DualLinearCache
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
@@ -196,6 +196,12 @@ prob = LinearProblem(A, b)
 @test init(prob, GenericLUFactorization()) isa LinearSolve.LinearCache
 
 @test init(prob) isa LinearSolve.LinearCache
+
+# Test that SparspakFactorization doesn't create a DualLinearCache
+A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
+
+prob = LinearProblem(sparse(A), b)
+@test init(prob, SparspakFactorization()) isa LinearSolve.LinearCache
 
 # Test ComponentArray with ForwardDiff (Issue SciML/DifferentialEquations.jl#1110)
 # This tests that ArrayInterface.restructure preserves ComponentArray structure


### PR DESCRIPTION
Sparspak handles sparse linear system solution for generic number types including dual numbers

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
Fixes #837 
