### PR TITLE
Fix verbosity log tests to use regex matching

### DIFF
--- a/test/verbosity.jl
+++ b/test/verbosity.jl
@@ -101,19 +101,19 @@ end
     prob = LinearProblem(A, b)
 
     @test_logs (:warn,
-        "LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.") solve(
+        r"LU factorization failed, falling back to QR factorization\. `A` is potentially rank-deficient\.") solve(
         prob,
         verbose = LinearVerbosity(default_lu_fallback = WarnLevel()))
 
     @test_logs (:info,
-        "LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.") solve(
+        r"LU factorization failed, falling back to QR factorization\. `A` is potentially rank-deficient\.") solve(
         prob,
         verbose = LinearVerbosity(default_lu_fallback = InfoLevel()))
 
     verb = LinearVerbosity(default_lu_fallback = WarnLevel())
 
     @test_logs (:warn,
-        "LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.") solve(
+        r"LU factorization failed, falling back to QR factorization\. `A` is potentially rank-deficient\.") solve(
         prob,
         verbose = verb)
 end


### PR DESCRIPTION
## Summary
- Fix failing verbosity log tests by using regex patterns instead of exact string matching
- SciMLLogging now adds a prefix to log messages ("Verbosity toggle: <option_name> \n ..."), causing exact string matching to fail

## Test plan
- [x] Verified the regex patterns match the expected log message content
- [ ] CI tests should pass after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)