### PR TITLE
Implement reinit! for DualLinearCache

### DIFF
--- a/test/forwarddiff_overloads.jl
+++ b/test/forwarddiff_overloads.jl
@@ -189,6 +189,34 @@ backslash_x_p = A \ b
 
 @test ≈(overload_x_p, backslash_x_p, rtol = 1e-9)
 
+# Test reinit! for DualLinearCache
+A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
+prob = LinearProblem(sparse(A), sparse(b))
+cache = init(prob, UMFPACKFactorization())
+overload_x_p = solve!(cache)
+backslash_x_p = A \ b
+@test ≈(overload_x_p, backslash_x_p, rtol = 1e-9)
+
+# Now use reinit! to update A
+new_A, new_b = h([ForwardDiff.Dual(10.0, 1.0, 0.0), ForwardDiff.Dual(10.0, 0.0, 1.0)])
+reinit!(cache; A = sparse(new_A))
+overload_x_p = solve!(cache, UMFPACKFactorization())
+backslash_x_p = new_A \ b
+@test ≈(overload_x_p, backslash_x_p, rtol = 1e-9)
+
+# Test reinit! with both A and b
+reinit!(cache; A = sparse(new_A), b = sparse(new_b))
+overload_x_p = solve!(cache, UMFPACKFactorization())
+backslash_x_p = new_A \ new_b
+@test ≈(overload_x_p, backslash_x_p, rtol = 1e-9)
+
+# Test reinit! with just b
+A2, b2 = h([ForwardDiff.Dual(7.0, 1.0, 0.0), ForwardDiff.Dual(7.0, 0.0, 1.0)])
+reinit!(cache; b = sparse(b2))
+overload_x_p = solve!(cache, UMFPACKFactorization())
+backslash_x_p = new_A \ b2
+@test ≈(overload_x_p, backslash_x_p, rtol = 1e-9)
+
 # Test that GenericLU doesn't create a DualLinearCache
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 


### PR DESCRIPTION
## Summary

- Implements the missing `reinit!` method for `DualLinearCache`
- Uses direct mutation pattern (same as `LinearCache` reinit!) instead of `setX!` helper functions
- Properly updates all DualLinearCache fields: `dual_A`, `dual_b`, `dual_u`, `partials_A`, `partials_b`, `partials_u`, and `partials_*_list` caches
- Handles freshness flags correctly for cache invalidation

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

This completes the work started in #836, implementing the `reinit!` method using direct mutation instead of the `setX!` helper functions, matching the pattern used in the regular `LinearCache` reinit! implementation.

Tests verify:
- reinit! with A only
- reinit! with both A and b
- reinit! with b only

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)