### PR TITLE
Remove LUFactorization method for AbstractSciMLOperator

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -301,18 +301,6 @@ function LinearSolve.init_cacheval(
 end
 
 function LinearSolve.init_cacheval(
-        alg::LUFactorization, A::AbstractSciMLOperator, b, u, Pl, Pr,
-        maxiters::Int, abstol, reltol,
-        verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions)
-    if has_concretization(A)
-        return LinearSolve.init_cacheval(alg, convert(AbstractMatrix, A), b, u, Pl, Pr,
-            maxiters, abstol, reltol, verbose, assumptions)
-    else
-        nothing
-    end
-end
-
-function LinearSolve.init_cacheval(
         alg::CHOLMODFactorization, A::AbstractSciMLOperator, b, u, Pl, Pr,
         maxiters::Int, abstol, reltol,
         verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions)

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -584,11 +584,6 @@ end
         sol_operator = solve(prob_operator, UMFPACKFactorization())
         @test sol_matrix.u ≈ sol_operator.u
 
-        # Test LU with operator
-        sol_matrix = solve(prob_matrix, LUFactorization())
-        sol_operator = solve(prob_operator, LUFactorization())
-        @test sol_matrix.u ≈ sol_operator.u
-
         # Test WOperator with sparse Jacobian
         n_w = 8
         M = sparse(I(n_w) * 1.0)
@@ -611,11 +606,6 @@ end
         # Test UMFPACK with WOperator
         sol_woperator = solve(prob_woperator, UMFPACKFactorization())
         sol_wmatrix = solve(prob_wmatrix, UMFPACKFactorization())
-        @test sol_woperator.u ≈ sol_wmatrix.u
-
-        # Test LU with WOperator
-        sol_woperator = solve(prob_woperator, LUFactorization())
-        sol_wmatrix = solve(prob_wmatrix, LUFactorization())
         @test sol_woperator.u ≈ sol_wmatrix.u
     end
 


### PR DESCRIPTION
The LUFactorization method for AbstractSciMLOperator was causing issues with the default algorithm selection. This removes it while keeping support for KLU and UMFPACK factorizations with operators that have concretization support.

Fixes #848
