### PR TITLE
Use nonzeros(A) instead of A.nzval in pattern check

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -201,7 +201,7 @@ function SciMLBase.solve!(
         cacheval = LinearSolve.@get_cacheval(cache, :UMFPACKFactorization)
         if alg.reuse_symbolic
             # Caches the symbolic factorization: https://github.com/JuliaLang/julia/pull/33738
-            if length(cacheval.nzval) != length(A.nzval) || alg.check_pattern && pattern_changed(cacheval, A)
+            if length(cacheval.nzval) != length(nonzeros(A)) || alg.check_pattern && pattern_changed(cacheval, A)
                 fact = lu(
                     SparseMatrixCSC(size(A)..., getcolptr(A), rowvals(A),
                         nonzeros(A)),
@@ -331,7 +331,7 @@ function SciMLBase.solve!(cache::LinearSolve.LinearCache, alg::KLUFactorization;
     if cache.isfresh
         cacheval = LinearSolve.@get_cacheval(cache, :KLUFactorization)
         if alg.reuse_symbolic
-            if length(cacheval.nzval) != length(A.nzval) || alg.check_pattern && pattern_changed(cacheval, A)
+            if length(cacheval.nzval) != length(nonzeros(A)) || alg.check_pattern && pattern_changed(cacheval, A)
                 fact = KLU.klu(
                     SparseMatrixCSC(size(A)..., getcolptr(A), rowvals(A),
                         nonzeros(A)),

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -782,6 +782,25 @@ end
     reinit!(cache; A = B1, b = b1)
     u = solve!(cache)
     @test norm(u - u0, Inf) < 1.0e-8
+
+    pr = LinearProblem(B, b)
+    solver = UMFPACKFactorization()
+    cache = init(pr, solver)
+    u = solve!(cache)
+    @test norm(u - u0, Inf) < 1.0e-8
+    reinit!(cache; A = B1, b = b1)
+    u = solve!(cache)
+    @test norm(u - u0, Inf) < 1.0e-8
+
+    pr = LinearProblem(B, b)
+    solver = KLUFactorization()
+    cache = init(pr, solver)
+    u = solve!(cache)
+    @test norm(u - u0, Inf) < 1.0e-8
+    reinit!(cache; A = B1, b = b1)
+    u = solve!(cache)
+    @test norm(u - u0, Inf) < 1.0e-8
+
 end
 
 @testset "ParallelSolves" begin


### PR DESCRIPTION
Sparse matrices are assumed to follow the AbstractSparseMatrixCSC interface which is being discussed here: https://github.com/JuliaSparse/SparseArrays.jl/issues/265

Note that UmfpackLU and KLUFactorization don't have this method (and probably also shouldn't).

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
