### PR TITLE
Fix type inference for ForwardDiff Dual problems

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -417,9 +417,11 @@ function _solve_direct_dual!(
     dual_A = getfield(cache, :dual_A)
     dual_b = getfield(cache, :dual_b)
 
-    # Solve by creating a LinearProblem with the dual values and using LinearSolve
+    # Use __init to create a regular LinearCache (bypasses ForwardDiff extension)
+    # then solve! on that cache directly with the dual values
     dual_prob = LinearProblem(dual_A, dual_b)
-    dual_sol = solve(dual_prob, getfield(cache, :linear_cache).alg, args...; kwargs...)
+    dual_cache = __init(dual_prob, getfield(cache, :linear_cache).alg, args...; kwargs...)
+    dual_sol = SciMLBase.solve!(dual_cache)
 
     # Update the cache
     if getfield(cache, :dual_u) isa AbstractArray

--- a/test/forwarddiff_overloads.jl
+++ b/test/forwarddiff_overloads.jl
@@ -202,17 +202,20 @@ A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
 prob = LinearProblem(A, b)
 
+# Helper to check if type is DualLinearCache (extension type not directly accessible)
+is_dual_cache(x) = nameof(typeof(x)) == :DualLinearCache
+
 # GenericLUFactorization now returns DualLinearCache for type stability
 # (the optimization for GenericLU happens at solve-time instead of init-time)
-@test init(prob, GenericLUFactorization()) isa LinearSolve.LinearSolveForwardDiffExt.DualLinearCache
+@test is_dual_cache(init(prob, GenericLUFactorization()))
 
 # Test inference with explicit algorithm
-@test (@inferred init(prob, LUFactorization())) isa LinearSolve.LinearSolveForwardDiffExt.DualLinearCache
-@test (@inferred init(prob, GenericLUFactorization())) isa LinearSolve.LinearSolveForwardDiffExt.DualLinearCache
+@test is_dual_cache(@inferred init(prob, LUFactorization()))
+@test is_dual_cache(@inferred init(prob, GenericLUFactorization()))
 
 # Test inference with default algorithm (nothing) - this was the main bug
 # Previously returned Union{LinearCache, DualLinearCache} due to runtime conditional
-@test (@inferred init(prob, nothing)) isa LinearSolve.LinearSolveForwardDiffExt.DualLinearCache
+@test is_dual_cache(@inferred init(prob, nothing))
 
 # Test that SparspakFactorization still opts out (sparse solvers can't handle Duals the same way)
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])


### PR DESCRIPTION
## Summary

- Removes runtime conditional from `init` that was checking `alg.alg === DefaultAlgorithmChoice.GenericLUFactorization`
- This conditional caused `init` to return `Union{LinearCache, DualLinearCache}`, breaking type inference
- Moves the GenericLUFactorization optimization to `solve!` instead, where it has no impact on type stability

## Problem

The `init` function for `DualAbstractLinearProblem` with `DefaultLinearSolver` had a runtime conditional:

```julia
function SciMLBase.init(prob::DualAbstractLinearProblem, alg::DefaultLinearSolver, args...; kwargs...)
    if alg.alg === DefaultAlgorithmChoice.GenericLUFactorization
        return __init(...)      # → LinearCache
    else
        return __dual_init(...) # → DualLinearCache
    end
end
```

Since `alg.alg` is determined at runtime by `defaultalg()`, the compiler sees both branches as possible, resulting in a `Union` return type that breaks inference for downstream code (e.g., OrdinaryDiffEq's Rosenbrock methods).

## Solution

1. `init` now always returns `DualLinearCache` for type stability
2. At solve-time, `solve!` checks if the algorithm supports direct dual solving
3. Added `_use_direct_dual_solve()` helper to detect GenericLUFactorization
4. Added `_solve_direct_dual!()` function that solves the dual system directly without separating primal/partials

This preserves the performance optimization for `GenericLUFactorization` (which can work directly with any number type) while ensuring `init` has a concrete return type.

## Test plan

- [ ] Existing tests pass
- [ ] Inference test: `@inferred init(prob_dual, nothing)` now returns `DualLinearCache` instead of `Union`
- [ ] Correctness: Solutions with ForwardDiff Dual numbers produce correct results
- [ ] This fixes inference issues in OrdinaryDiffEq's Rosenbrock DAE tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)