### PR TITLE
Fix headers for admonition warning blocks

### DIFF
--- a/docs/src/tutorials/accelerating_choices.md
+++ b/docs/src/tutorials/accelerating_choices.md
@@ -52,7 +52,7 @@ there are a few major tips to note when fine tuning the results to your system:
     MKLFactorization (X86) and hardcoding the choice for your problem if the default did not make
     the right guess.
 
-!!! warn
+!!! warning
     
     As noted, RecursiveFactorization.jl is one of the fastest linear solvers for smaller dense
     matrices but requires `using RecursiveFactorization` in order to be used in the default

--- a/docs/src/tutorials/gpu.md
+++ b/docs/src/tutorials/gpu.md
@@ -14,11 +14,11 @@ The offloading approach has the advantage of being simpler and requiring no chan
 existing CPU code, while having the disadvantage of having more overhead. In the following
 sections we will demonstrate how to use each of the approaches.
 
-!!! warn
+!!! warning
     
     GPUs are not always faster! Your matrices need to be sufficiently large in order for
-    GPU accelerations to actually be faster. For offloading it's around 1,000 x 1,000 matrices
-    and for Array type interface it's around 100 x 100. For sparse matrices, it is highly
+    GPU accelerations to actually be faster. For offloading it's around 1,000 × 1,000 matrices
+    and for Array type interface it's around 100 × 100. For sparse matrices, it is highly
     dependent on the sparsity pattern and the amount of fill-in.
 
 ## GPU-Offloading
@@ -91,7 +91,7 @@ Notice that the solution is a `CuArray`, and thus one must use `Array(sol.u)` if
 to return it to the CPU. This setup does no automated memory transfers and will thus only
 move things to CPU on command.
 
-!!! warn
+!!! warning
     
     Many GPU functionalities, such as `CUDA.cu`, have a built-in preference for `Float32`.
     Generally it is much faster to use 32-bit floating point operations on GPU than 64-bit

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -969,7 +969,7 @@ A fast factorization which uses a Cholesky factorization on A * A'. Can be much
 faster than LU factorization, but is not as numerically stable and thus should only
 be applied to well-conditioned matrices.
 
-!!! warn
+!!! warning
 
     `NormalCholeskyFactorization` should only be applied to well-conditioned matrices. As a
     method it is not able to easily identify possible numerical issues. As a check it is


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

`warn` not recognized by Documenter, needs to be `warning`