### PR TITLE
Fix SVDFactorization CUDA failure by deferring algorithm selection

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -455,13 +455,12 @@ end
 ## SVDFactorization
 
 """
-`SVDFactorization(full=false,alg=LinearAlgebra.DivideAndConquer())`
+    SVDFactorization(full=false, alg=nothing)
+Julia's built-in `svd`. Equivalent to `svd!(A)`.
 
-Julia's built in `svd`. Equivalent to `svd!(A)`.
-
-  - On dense matrices, this uses the current BLAS implementation of the user's computer
-    which by default is OpenBLAS but will use MKL if the user does `using MKL` in their
-    system.
+- On dense matrices, this uses the current BLAS implementation.
+- When `alg = nothing`, the backend default SVD algorithm is used
+  (required for CUDA compatibility).
 """
 struct SVDFactorization{A} <: AbstractDenseFactorization
     full::Bool
@@ -473,30 +472,43 @@ SVDFactorization() = SVDFactorization(false, nothing)
 function do_factorization(alg::SVDFactorization, A, b, u)
     A = convert(AbstractMatrix, A)
     if ArrayInterface.can_setindex(typeof(A))
-        fact = svd!(A; alg.full, alg.alg)
+        if alg.alg === nothing
+            return svd!(A; full = alg.full)
+        else
+            return svd!(A; full = alg.full, alg = alg.alg)
+        end
     else
-        fact = svd(A; alg.full)
+        if alg.alg === nothing
+            return svd(A; full = alg.full)
+        else
+            return svd(A; full = alg.full, alg = alg.alg)
+        end
     end
-    return fact
 end
 
 function init_cacheval(alg::SVDFactorization, A::Union{Matrix, SMatrix}, b, u, Pl, Pr,
-        maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
-        assumptions::OperatorAssumptions)
+    maxiters::Int, abstol, reltol,
+    verbose::Union{LinearVerbosity, Bool},
+    assumptions::OperatorAssumptions
+)
     ArrayInterface.svd_instance(convert(AbstractMatrix, A))
 end
 
 const PREALLOCATED_SVD = ArrayInterface.svd_instance(rand(1, 1))
 
 function init_cacheval(alg::SVDFactorization, A::Matrix{Float64}, b, u, Pl, Pr,
-        maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
-        assumptions::OperatorAssumptions)
+    maxiters::Int, abstol, reltol,
+    verbose::Union{LinearVerbosity, Bool},
+    assumptions::OperatorAssumptions
+    )
     PREALLOCATED_SVD
 end
 
 function init_cacheval(alg::SVDFactorization, A, b, u, Pl, Pr,
-        maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
-        assumptions::OperatorAssumptions)
+    maxiters::Int, abstol, reltol,
+    verbose::Union{LinearVerbosity, Bool},
+    assumptions::OperatorAssumptions
+)
     nothing
 end
 


### PR DESCRIPTION
This PR removes the hard-coded LinearAlgebra.DivideAndConquer()
algorithm from SVDFactorization so that downstream svd implementations
(e.g. CuArray / cuSOLVER) can select a compatible default algorithm.

This fixes failures when running SVD on CUDA arrays.

Closes #488
