### PR TITLE
actually use LU factorisation in tutorial

### DIFF
--- a/docs/src/tutorials/caching_interface.md
+++ b/docs/src/tutorials/caching_interface.md
@@ -11,9 +11,9 @@ A \ b2
 then it would be more efficient to LU-factorize one time and reuse the factorization:
 
 ```julia
-LA.lu!(A)
-A \ b1
-A \ b2
+A_lu = LA.lu!(A)
+A_lu \ b1
+A_lu \ b2
 ```
 
 LinearSolve.jl's caching interface automates this process to use the most efficient


### PR DESCRIPTION
running `lu!(A)` consumes A, and returns the LU factorisation. using `A\b1` later will return wrong results.

## Checklist

- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
