### PR TITLE
Fix Julia 1.12 Val-based pivot deprecation warnings

### DIFF
--- a/ext/LinearSolveBandedMatricesExt.jl
+++ b/ext/LinearSolveBandedMatricesExt.jl
@@ -30,6 +30,7 @@ end
 do_factorization(alg::QRFactorization, A::BandedMatrix, b, u) = alg.inplace ? qr!(A) : qr(A)
 
 function do_factorization(alg::LUFactorization, A::BandedMatrix, b, u)
+    # BandedMatrices.jl requires Val-based pivot argument for lu!
     _pivot = alg.pivot isa NoPivot ? Val(false) : Val(true)
     return lu!(A, _pivot; check = false)
 end


### PR DESCRIPTION
## Summary
- Julia 1.12 deprecated `Val(true)`/`Val(false)` as pivot arguments to `cholesky`, `cholesky!`, `lu`, and `lu!` in favor of `RowMaximum()`/`NoPivot()` (PivotingStrategy types)
- Added `_normalize_pivot` helper function in `src/factorization.jl` that converts deprecated Val-based pivot arguments to the new PivotingStrategy types
- Applied the normalization in all code paths that pass pivot arguments to stdlib functions: `do_factorization`, `init_cacheval`, and `solve!` for `LUFactorization`, `CholeskyFactorization`, and `NormalCholeskyFactorization`
- BandedMatrices.jl `lu!` still requires Val-based pivot due to an upstream method ambiguity in ArrayLayouts.jl, so it is left as-is with a clarifying comment

## Test plan
- [x] Verified all 8 Cholesky/NormalCholesky test cases pass with `--depwarn=error` on Julia 1.12.4
- [x] Full `Pkg.test()` passes (all test groups: Core, NoPre, DefaultsLoading, Adjoint Sensitivity, ForwardDiff Overloads, Traits, Verbosity, BandedMatrices, Butterfly Factorization, Mixed Precision, LinearSolveHYPRE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)