### PR TITLE
Update cache.isfresh assignment in reinit!()

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -430,7 +430,7 @@ function SciMLBase.reinit!(
     cache.p = p
     cache.Pl = Pl
     cache.Pr = Pr
-    cache.isfresh = true
+    cache.isfresh = isfresh
     cache.precsisfresh = precsisfresh
     return nothing
 end


### PR DESCRIPTION
This might be seen as a bugfix.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

I don't know how breaking this is; therefore I did not check the first two boxes. I couldn't find much documentation around `reinit!()`, which led me to reading the code in the first place. Therefore, I did not check the third box.

I would like to use the same system for multiple right-hand sides. Given that there is `reinit!(::LinearCache; b)`, I thought I had to

```julia
cache.b .*= 2 # some in-place modification
reinit!(cache; cache.b)
```

However, according to [this page](https://docs.sciml.ai/LinearSolve/v3.58/tutorials/caching_interface/#Linear-Solve-with-Caching-Interface), I don't even need to call `reinit!`.
