### PR TITLE
Make BandedMatrix default solver robust to singularities

### DIFF
--- a/test/banded.jl
+++ b/test/banded.jl
@@ -53,6 +53,13 @@ A[band(0)] .+= 1:n
 
 @test_nowarn solve(LinearProblem(A, b))
 
+# Singular BandedMatrix - should gracefully fall back to pivoted QR instead of throwing
+A_singular = BandedMatrix(zeros(n, n), (2, 2))
+A_singular[band(0)] .= [1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0]
+b_singular = ones(n)
+sol_singular = solve(LinearProblem(A_singular, b_singular))
+@test sol_singular.retcode == LinearSolve.ReturnCode.Success
+
 # Workaround for no lu from BandedMatrices
 A = BandedMatrix{BigFloat}(ones(3, 3), (0, 0))
 b = BigFloat[1, 2, 3]


### PR DESCRIPTION
## Summary

- Switch `BandedMatrix` default algorithm from `DirectLdiv!` to `LUFactorization`, enabling the existing safety fallback to column-pivoted QR on singular matrices
- Catch `LAPACKException`/`SingularException` in `LUFactorization.solve!` since BandedMatrices.jl's LAPACK wrappers (`gbtrf!`) throw unconditionally on singular matrices, ignoring `check=false`
- Fix `QRFactorization` on `BandedMatrix` to convert to dense `Matrix` when column pivoting is requested (BandedMatrices.jl only supports `NoPivot` for QR)
- Add `init_cacheval` for `QRFactorization{ColumnNorm}` on `BandedMatrix` to cache a dense `QRPivoted`

## Motivation

The default path for dense matrices gracefully handles singularities: LU with `check=false` detects failure via `issuccess`, then falls back to `QRFactorization(ColumnNorm())`. For `BandedMatrix`, the default was `DirectLdiv!` which calls raw `ldiv!` → `factorize(A)` → `lu(A)` → `gbtrf!`, throwing an unrecoverable `LAPACKException` on singular matrices. Additionally, `DirectLdiv!` re-factorizes on every `solve!` call (ignoring `isfresh`), so `LUFactorization` is strictly better for re-solves.

Three issues blocked the fallback path:
1. `defaultalg` selected `DirectLdiv!` (no safety fallback branch in `default.jl`)
2. `gbtrf!` throws `LAPACKException` instead of setting `info` (unlike dense `getrf!`)
3. The extension's `do_factorization` for QR silently dropped the pivot strategy, so `ColumnNorm` fallback did unpivoted QR

## Test plan

- [x] Added test for singular `BandedMatrix` — verifies graceful fallback returns `Success`
- [x] All existing BandedMatrix tests pass (square, symmetric, overdetermined, underdetermined, BigFloat)
- [x] Full `Pkg.test("LinearSolve")` with `GROUP=Core` passes (21 test suites, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)