### PR TITLE
Fix WOperator type mismatch in A_backup assignment

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -390,7 +390,7 @@ function __init(
     # For DefaultLinearSolver, store reference to original prob.A for safety fallback.
     # When alias_A=false (default), cache.A is a copy and prob.A is untouched,
     # so prob.A serves as a zero-cost backup for restoring cache.A after in-place LU.
-    if cacheval isa DefaultLinearSolverInit
+    if cacheval isa DefaultLinearSolverInit && prob.A isa typeof(cacheval.A_backup)
         cacheval.A_backup = prob.A
     end
     isfresh = true


### PR DESCRIPTION
## Summary

- Fixes `MethodError: Cannot convert WOperator to MatrixOperator` when using implicit SDE solvers (e.g. `ImplicitEM`, `ISSEM`) with `jac_prototype = MatrixOperator(...)` in StochasticDiffEq.jl
- The root cause: when `init_cacheval` is overridden for `WOperator` (in OrdinaryDiffEqDifferentiation), it unwraps to `A.J` (a `MatrixOperator`), so `DefaultLinearSolverInit` gets its `A_backup::TA` field typed as `MatrixOperator`. The subsequent `cacheval.A_backup = prob.A` at `common.jl:394` then fails because `prob.A` is a `WOperator` and no `convert(MatrixOperator, WOperator)` method exists.
- Fix: guard the `A_backup` overwrite with `prob.A isa typeof(cacheval.A_backup)`. This is safe because `A_backup` is only used for the LU→QR safety fallback path, which is never reached for `WOperator` inputs (they dispatch to `KrylovJL_GMRES`).

## Test plan

- [x] Verified all 12 tests pass in `StochasticDiffEq.jl/test/utility_tests.jl` (previously 2 errors in `calc_W!` and `Implicit solver with lazy W`)
- [ ] LinearSolve.jl CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)