### PR TITLE
fix: handle LinearCache resize for A_backup

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -154,15 +154,12 @@ function Base.setproperty!(cache::LinearCache, name::Symbol, x)
 end
 
 function Base.resize!(cache::LinearCache, i::Int)
-    if cache.cacheval isa DefaultLinearSolverInit
-        A_backup = cache.cacheval.A_backup
-        if A_backup isa AbstractMatrix
-            setfield!(cache.cacheval, :A_backup, similar(A_backup, i, i))
-        end
-    end
+    resize_cacheval!(cache, cache.cacheval, i)
     setfield!(cache, :isfresh, true)
     return cache
 end
+
+resize_cacheval!(cache, cacheval, i) = nothing
 
 function update_cacheval!(cache::LinearCache, name::Symbol, x)
     return update_cacheval!(cache, cache.cacheval, name, x)

--- a/src/default.jl
+++ b/src/default.jl
@@ -31,6 +31,13 @@ mutable struct DefaultLinearSolverInit{
     A_backup::TA  # reference to original prob.A for restoring cache.A after in-place LU
 end
 
+function resize_cacheval!(cache, cacheval::DefaultLinearSolverInit, i)
+    A_backup = cacheval.A_backup
+    if A_backup isa AbstractMatrix
+        setfield!(cacheval, :A_backup, similar(A_backup, i, i))
+    end
+end
+
 @generated function __setfield!(cache::DefaultLinearSolverInit, alg::DefaultLinearSolver, v)
     ex = :()
     for alg in first.(EnumX.symbol_map(DefaultAlgorithmChoice.T))

--- a/src/simplelu.jl
+++ b/src/simplelu.jl
@@ -223,3 +223,7 @@ function init_cacheval(
     )
     return LUSolver(convert(AbstractMatrix, A))
 end
+
+function resize_cacheval!(cache, cacheval::LUSolver{T}, i) where {T}
+    setfield!(cache, :cacheval, LUSolver{T}(i))
+end

--- a/test/resize.jl
+++ b/test/resize.jl
@@ -1,0 +1,185 @@
+using LinearSolve, LinearAlgebra, Test
+
+@testset "LinearCache resize!" begin
+    # Helper: create a cache with a given algorithm, resize it, and solve
+    function test_resize(alg; n_init = 3, n_new = 6, atol = 1e-10,
+            check_retcode = true, kwargs...)
+        A_init = rand(n_init, n_init) + 5I
+        b_init = rand(n_init)
+        prob = LinearProblem(A_init, b_init)
+        cache = init(prob, alg;
+            alias = LinearAliasSpecifier(alias_A = false, alias_b = false),
+            kwargs...)
+
+        # Solve at original size to populate cacheval
+        sol1 = solve!(cache)
+        if check_retcode
+            @test sol1.retcode == ReturnCode.Success
+        end
+        @test length(sol1.u) == n_init
+
+        # Resize
+        resize!(cache, n_new)
+        @test cache.isfresh == true
+
+        # Set new A, b, u of the new size
+        A_new = rand(n_new, n_new) + 5I
+        b_new = rand(n_new)
+        u_new = zeros(n_new)
+
+        # Compute expected solution BEFORE solve (which may modify A in-place)
+        expected = A_new \ b_new
+
+        cache.A = A_new
+        cache.b = b_new
+        cache.u = u_new
+
+        # Solve at new size
+        sol2 = solve!(cache)
+        if check_retcode
+            @test sol2.retcode == ReturnCode.Success
+        end
+        @test length(sol2.u) == n_new
+        @test sol2.u ≈ expected atol = atol
+    end
+
+    @testset "Default (nothing)" begin
+        test_resize(nothing)
+    end
+
+    @testset "LUFactorization" begin
+        test_resize(LUFactorization())
+    end
+
+    @testset "QRFactorization" begin
+        test_resize(QRFactorization())
+    end
+
+    @testset "SVDFactorization" begin
+        test_resize(SVDFactorization())
+    end
+
+    @testset "GenericLUFactorization" begin
+        test_resize(GenericLUFactorization())
+    end
+
+    @testset "KrylovJL_GMRES" begin
+        test_resize(KrylovJL_GMRES(); atol = 1e-6, maxiters = 100)
+    end
+
+    @testset "SimpleLUFactorization" begin
+        test_resize(SimpleLUFactorization(); check_retcode = false)
+    end
+
+    @testset "NormalCholeskyFactorization" begin
+        test_resize(NormalCholeskyFactorization())
+    end
+
+    @testset "CholeskyFactorization" begin
+        # Cholesky requires SPD matrix — custom test
+        A_init = let X = rand(3, 3); X' * X + 5I end
+        prob = LinearProblem(A_init, rand(3))
+        cache = init(prob, CholeskyFactorization();
+            alias = LinearAliasSpecifier(alias_A = false, alias_b = false))
+        solve!(cache)
+
+        resize!(cache, 6)
+        @test cache.isfresh == true
+
+        A_new = let X = rand(6, 6); X' * X + 5I end
+        b_new = rand(6)
+        expected = A_new \ b_new
+        cache.A = A_new
+        cache.b = b_new
+        cache.u = zeros(6)
+
+        sol = solve!(cache)
+        @test sol.retcode == ReturnCode.Success
+        @test length(sol.u) == 6
+        @test sol.u ≈ expected
+    end
+
+    @testset "SimpleGMRES" begin
+        test_resize(SimpleGMRES(); atol = 1e-6, maxiters = 100)
+    end
+
+    @testset "DefaultLinearSolverInit A_backup resize" begin
+        A = rand(3, 3) + 5I
+        b = rand(3)
+        prob = LinearProblem(A, b)
+        cache = init(prob, nothing)
+        @test cache.cacheval isa LinearSolve.DefaultLinearSolverInit
+        @test size(cache.cacheval.A_backup) == (3, 3)
+
+        resize!(cache, 5)
+        @test size(cache.cacheval.A_backup) == (5, 5)
+        @test cache.isfresh == true
+    end
+
+    @testset "resize then setproperty! with same object" begin
+        # Reproduces the exact OrdinaryDiffEq crash scenario
+        A = rand(3, 3) + 5I
+        b = rand(3)
+        prob = LinearProblem(A, b)
+        cache = init(prob, nothing;
+            alias = LinearAliasSpecifier(alias_A = false, alias_b = false))
+
+        sol = solve!(cache)
+        @test sol.retcode == ReturnCode.Success
+
+        # Set A to a new larger matrix
+        A_new = rand(5, 5) + 5I
+        b_new = rand(5)
+        cache.A = A_new
+        cache.b = b_new
+        cache.u = zeros(5)
+        sol = solve!(cache)
+        @test sol.retcode == ReturnCode.Success
+
+        # Set A to the same object again (in-place mutation + re-assignment)
+        A_new .= rand(5, 5) + 5I
+        b_new .= rand(5)
+        expected = A_new \ b_new
+        @test_nowarn (cache.A = A_new)
+        cache.b = b_new
+
+        sol = solve!(cache)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.u ≈ expected
+    end
+
+    @testset "multiple resizes" begin
+        A = rand(3, 3) + 5I
+        b = rand(3)
+        prob = LinearProblem(A, b)
+        cache = init(prob, LUFactorization();
+            alias = LinearAliasSpecifier(alias_A = false, alias_b = false))
+
+        sol = solve!(cache)
+        @test sol.retcode == ReturnCode.Success
+
+        # Resize up
+        resize!(cache, 7)
+        A2 = rand(7, 7) + 5I
+        b2 = rand(7)
+        expected2 = A2 \ b2
+        cache.A = A2
+        cache.b = b2
+        cache.u = zeros(7)
+        sol = solve!(cache)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.u ≈ expected2
+
+        # Resize down
+        resize!(cache, 2)
+        A3 = rand(2, 2) + 5I
+        b3 = rand(2)
+        expected3 = A3 \ b3
+        cache.A = A3
+        cache.b = b3
+        cache.u = zeros(2)
+        sol = solve!(cache)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.u ≈ expected3
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ if GROUP == "All" || GROUP == "Core"
     @time @safetestset "BandedMatrices" include("banded.jl")
     @time @safetestset "Butterfly Factorization" include("butterfly.jl")
     @time @safetestset "Mixed Precision" include("test_mixed_precision.jl")
+    @time @safetestset "Resize" include("resize.jl")
     # ParU_jll requires Julia >= 1.12 (SuiteSparse_jll in older stdlib is incompatible)
     if VERSION >= v"1.12.0-"
         Pkg.activate("paru")


### PR DESCRIPTION
## Summary

- Fix `BoundsError` when ODE systems are resized (e.g., via `resize!` callbacks) after #901 introduced `copyto!(A_backup, x)` in `setproperty!`
- `A_backup` in `DefaultLinearSolverInit` retains its original dimensions while `cache.A` gets resized externally, causing a size mismatch crash
- Add `Base.resize!(cache::LinearCache, i::Int)` so integrators can proactively resize `A_backup`

## Changes

1. **`setproperty!`** (defensive): Check `size(A_backup) == size(x)` before `copyto!`. When sizes differ, replace `A_backup` with `copy(x)` instead of crashing.
2. **New `Base.resize!`** (proactive): Resize `A_backup` to `(i, i)` and mark cache as stale (`isfresh = true`). Algorithm-specific caches don't need explicit resizing since `isfresh = true` forces recomputation.

## Context

PR #901 fixed stale QR fallback by syncing `A_backup` in `setproperty!`, but didn't account for the case where the linear system is resized externally (common in ODE solvers with `resize!` callbacks). The `copyto!` call crashes with `BoundsError: attempt to access 1×1 Matrix{Float64} at index [1:25]` when trying to copy a resized 5×5 matrix into the old 1×1 `A_backup`.

OrdinaryDiffEq.jl had a no-op stub `Base.resize!(p::LinearSolve.LinearCache, i) = p` that shadowed any real resize logic. A companion PR will remove that stub so this new `resize!` method takes effect.

## Test plan

- [x] Verified `resize!` + `solve!` works with `ImplicitEuler` (1→5)
- [x] Verified `resize!` + `solve!` works with `Rosenbrock23` (1→5)
- [x] Verified dynamic resize via `DiscreteCallback` with `Rosenbrock23` (the exact CI failure scenario)
- [x] Verified `Base.resize!(cache::LinearCache, i)` directly resizes `A_backup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)