### PR TITLE
Make residualsafety A_original type stable

### DIFF
--- a/src/appleaccelerate.jl
+++ b/src/appleaccelerate.jl
@@ -313,11 +313,8 @@ function SciMLBase.solve!(
         error("Error, AppleAccelerate binary is missing but solve is being called. Report this issue")
     A = cache.A
     A = convert(AbstractMatrix, A)
-    if alg.residualsafety && cache.isfresh
-        A_original = _copy_A_for_safety(cache)
-    else
-        A_original = nothing
-    end
+    check_safety = alg.residualsafety && cache.isfresh
+    A_original = check_safety ? _copy_A_for_safety(cache) : A
     verbose = cache.verbose
     if cache.isfresh
         cacheval = @get_cacheval(cache, :AppleAccelerateLUFactorization)
@@ -386,7 +383,7 @@ function SciMLBase.solve!(
         aa_getrs!('N', A.factors, A.ipiv, cache.u; info)
     end
 
-    if A_original !== nothing
+    if check_safety
         failed = _check_residual_safety(cache, alg, A_original, cache.u)
         failed !== nothing && return failed
     end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -3,11 +3,9 @@
         kwargs...
     )
     return quote
-        if _get_residualsafety(alg) && cache.isfresh
-            A_original = _copy_A_for_safety(cache)
-        else
-            A_original = nothing
-        end
+        A = convert(AbstractMatrix, cache.A)
+        check_safety = _get_residualsafety(alg) && cache.isfresh
+        A_original = check_safety ? _copy_A_for_safety(cache) : A
 
         if cache.isfresh
             fact = do_factorization(alg, cache.A, cache.b, cache.u)
@@ -32,7 +30,7 @@
             cache.b
         )
 
-        if A_original !== nothing
+        if check_safety
             failed = _check_residual_safety(cache, alg, A_original, y)
             failed !== nothing && return failed
         end

--- a/src/mkl.jl
+++ b/src/mkl.jl
@@ -303,11 +303,8 @@ function SciMLBase.solve!(
         error("Error, MKL binary is missing but solve is being called. Report this issue")
     A = cache.A
     A = convert(AbstractMatrix, A)
-    if alg.residualsafety && cache.isfresh
-        A_original = _copy_A_for_safety(cache)
-    else
-        A_original = nothing
-    end
+    check_safety = alg.residualsafety && cache.isfresh
+    A_original = check_safety ? _copy_A_for_safety(cache) : A
     verbose = cache.verbose
     if cache.isfresh
         cacheval = @get_cacheval(cache, :MKLLUFactorization)
@@ -391,7 +388,7 @@ function SciMLBase.solve!(
         getrs!('N', A.factors, A.ipiv, cache.u; info)
     end
 
-    if A_original !== nothing
+    if check_safety
         failed = _check_residual_safety(cache, alg, A_original, cache.u)
         failed !== nothing && return failed
     end

--- a/src/openblas.jl
+++ b/src/openblas.jl
@@ -324,11 +324,8 @@ function SciMLBase.solve!(
         error("Error, OpenBLAS binary is missing but solve is being called. Report this issue")
     A = cache.A
     A = convert(AbstractMatrix, A)
-    if alg.residualsafety && cache.isfresh
-        A_original = _copy_A_for_safety(cache)
-    else
-        A_original = nothing
-    end
+    check_safety = alg.residualsafety && cache.isfresh
+    A_original = check_safety ? _copy_A_for_safety(cache) : A
     verbose = cache.verbose
     if cache.isfresh
         cacheval = @get_cacheval(cache, :OpenBLASLUFactorization)
@@ -397,7 +394,7 @@ function SciMLBase.solve!(
         openblas_getrs!('N', A.factors, A.ipiv, cache.u; info)
     end
 
-    if A_original !== nothing
+    if check_safety
         failed = _check_residual_safety(cache, alg, A_original, cache.u)
         failed !== nothing && return failed
     end


### PR DESCRIPTION
## Summary
- `A_original` in `LUFactorization` and `GenericLUFactorization` `solve!` was `Union{Matrix, Nothing}` due to conditional assignment (type unstable)
- Now always assigned as the same type as `A` — when `residualsafety` is off or cache is not fresh, `A_original` aliases `A` (zero cost) and the check is skipped via a `Bool` flag

## Test plan
- [x] Full `Pkg.test()` passes locally
- [x] Runic formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)