### PR TITLE
Remove ignored link for linkcheck in make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,6 @@ makedocs(
     warnonly = [:docs_block, :missing_docs],
     linkcheck_ignore = [
         "https://cli.github.com/manual/installation",
-        "https://github.com/SciML/LinearSolve.jl/tree/main/lib/LinearSolvePyAMG",
     ],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],


### PR DESCRIPTION
Removed a link from the linkcheck_ignore list in the documentation configuration.

cleanup for #900 
