### PR TITLE
Clean up ldiv!() overloads

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -8,7 +8,7 @@ using LinearSolve: LinearSolve, BLASELTYPES, pattern_changed, ArrayInterface,
     QRFactorization, RFLUFactorization, UMFPACKFactorization, solve
 using SciMLOperators: AbstractSciMLOperator, has_concretization
 using ArrayInterface: ArrayInterface
-using LinearAlgebra: LinearAlgebra, I, Hermitian, Symmetric, cholesky, ldiv!, lu, lu!, QR
+using LinearAlgebra: LinearAlgebra, I, Hermitian, Symmetric, cholesky, ldiv!, lu, lu!
 using SparseArrays: SparseArrays, AbstractSparseArray, AbstractSparseMatrixCSC,
     SparseMatrixCSC,
     nonzeros, rowvals, getcolptr, sparse, sprand
@@ -501,22 +501,6 @@ function LinearSolve.init_cacheval(
     end
 end
 
-# Specialize QR for the non-square case
-# Missing ldiv! definitions: https://github.com/JuliaSparse/SparseArrays.jl/issues/242
-function LinearSolve._ldiv!(
-        x::Vector,
-        A::Union{QR, LinearAlgebra.QRCompactWY}, b::Vector
-    )
-    return x .= A \ b
-end
-
-function LinearSolve._ldiv!(
-        x::AbstractVector,
-        A::Union{QR, LinearAlgebra.QRCompactWY}, b::AbstractVector
-    )
-    return x .= A \ b
-end
-
 # Ambiguity removal
 function LinearSolve._ldiv!(
         ::SVector,
@@ -534,19 +518,36 @@ function LinearSolve._ldiv!(
 end
 
 @static if Base.USE_GPL_LIBS
-    # SPQR and CHOLMOD Factor support
+    # ldiv!() for CHOLMOD was added in 1.12: https://github.com/JuliaSparse/SparseArrays.jl/pull/547
+    @static if VERSION < v"1.12"
+        function LinearSolve._ldiv!(
+                x::Vector,
+                A::SparseArrays.CHOLMOD.Factor, b::Vector
+            )
+            x .= A \ b
+        end
+        function LinearSolve._ldiv!(
+                x::AbstractVector,
+                A::SparseArrays.CHOLMOD.Factor, b::AbstractVector
+            )
+            x .= A \ b
+        end
+    end
+
+    # ldiv!() for SPQR should be in Julia 1.13: https://github.com/JuliaSparse/SparseArrays.jl/pull/676
     function LinearSolve._ldiv!(
             x::Vector,
-            A::Union{SparseArrays.SPQR.QRSparse, SparseArrays.CHOLMOD.Factor}, b::Vector
+            A::SparseArrays.SPQR.QRSparse, b::Vector
         )
         x .= A \ b
     end
     function LinearSolve._ldiv!(
             x::AbstractVector,
-            A::Union{SparseArrays.SPQR.QRSparse, SparseArrays.CHOLMOD.Factor}, b::AbstractVector
+            A::SparseArrays.SPQR.QRSparse, b::AbstractVector
         )
         x .= A \ b
     end
+
     function LinearSolve._ldiv!(
             ::SVector,
             A::Union{SparseArrays.CHOLMOD.Factor, SparseArrays.SPQR.QRSparse},

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -138,14 +138,6 @@ _ldiv!(x, A, b::SVector) = (x .= A \ b)
 _ldiv!(::SVector, A, b::SVector) = (A \ b)
 _ldiv!(::SVector, A, b) = (A \ b)
 
-function _ldiv!(x::Vector, A::Factorization, b::Vector)
-    # workaround https://github.com/JuliaLang/julia/issues/43507
-    # Fallback if working with non-square matrices
-    length(x) != length(b) && return ldiv!(x, A, b)
-    copyto!(x, b)
-    return ldiv!(A, x)
-end
-
 # RF Bad fallback: will fail if `A` is just a stand-in
 # This should instead just create the factorization type.
 function init_cacheval(


### PR DESCRIPTION
- The fallback _ldiv!() in factorization.jl exists to fix a bug in base Julia which has been fixed since 1.6: https://github.com/JuliaLang/julia/pull/43510 It was originally added in 2021: https://github.com/SciML/LinearSolve.jl/pull/81
- The _ldiv!() method in the SparseArrays extension for `QRCompactWY` seems to have originally been added in https://github.com/SciML/LinearSolve.jl/pull/188. It makes sense to have for the `QRSparse` types but I don't know why `QRCompactWY` was in there too. Maybe an accident? ldiv!() on `QRCompactWY` works in any case.
- ldiv!() for CHOLMOD was implemented for Julia 1.12 in https://github.com/JuliaSparse/SparseArrays.jl/pull/547.

The nonsquare tests still all pass.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API