### PR TITLE
Decouple residualsafety from safetyfallback, fix QR fallback reuse

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -368,7 +368,7 @@ function is_algorithm_available(alg::DefaultAlgorithmChoice.T)
 end
 
 """
-    DefaultLinearSolver(;safetyfallback=true)
+    DefaultLinearSolver(;safetyfallback=true, residualsafety=false)
 
 The default linear solver. This is the algorithm chosen when `solve(prob)`
 is called. It's a polyalgorithm that detects the optimal method for a given
@@ -377,10 +377,11 @@ is called. It's a polyalgorithm that detects the optimal method for a given
 ## Keyword Arguments
 
   - `safetyfallback`: determines whether to fallback to a column-pivoted QR factorization
-    when an LU factorization fails. When `true`, the inner LU algorithm is given
-    `residualsafety=true`, which makes it compute the post-solve residual `‖A*x - b‖` and
-    return `ReturnCode.APosterioriSafetyFailure` if it exceeds `abstol + reltol * ‖b‖`.
-    The default solver then falls back to column-pivoted QR. Defaults to `true`.
+    when an LU factorization fails. Defaults to `true`.
+  - `residualsafety`: when `true`, the inner LU algorithm computes the post-solve residual
+    `‖A*x - b‖` and returns `ReturnCode.APosterioriSafetyFailure` if it exceeds
+    `abstol + reltol * ‖b‖`. The default solver then falls back to column-pivoted QR.
+    Defaults to `false`.
 
 ## Residual Safety
 
@@ -394,7 +395,8 @@ handle it.
 struct DefaultLinearSolver <: SciMLLinearSolveAlgorithm
     alg::DefaultAlgorithmChoice.T
     safetyfallback::Bool
-    DefaultLinearSolver(alg; safetyfallback = true) = new(alg, safetyfallback)
+    residualsafety::Bool
+    DefaultLinearSolver(alg; safetyfallback = true, residualsafety = false) = new(alg, safetyfallback, residualsafety)
 end
 
 const BLASELTYPES = Union{Float32, Float64, ComplexF32, ComplexF64}

--- a/src/appleaccelerate.jl
+++ b/src/appleaccelerate.jl
@@ -314,7 +314,9 @@ function SciMLBase.solve!(
     A = cache.A
     A = convert(AbstractMatrix, A)
     check_safety = alg.residualsafety && cache.isfresh
-    A_original = check_safety ? _copy_A_for_safety(cache) : A
+    needs_backup = check_safety ||
+        (cache.alg isa DefaultLinearSolver && cache.alg.safetyfallback && cache.isfresh)
+    A_original = needs_backup ? _copy_A_for_safety(cache) : A
     verbose = cache.verbose
     if cache.isfresh
         cacheval = @get_cacheval(cache, :AppleAccelerateLUFactorization)

--- a/src/common.jl
+++ b/src/common.jl
@@ -131,6 +131,7 @@ function Base.setproperty!(cache::LinearCache, name::Symbol, x)
         setfield!(cache, :isfresh, true)
         setfield!(cache, :precsisfresh, true)
         if cache.cacheval isa DefaultLinearSolverInit
+            cache.cacheval.fell_back_to_qr = false
             if x === getfield(cache, :A) && cache.cacheval.a_backup_allocated
                 A_backup = cache.cacheval.A_backup
                 if size(A_backup) == size(x)

--- a/src/default.jl
+++ b/src/default.jl
@@ -32,6 +32,7 @@ mutable struct DefaultLinearSolverInit{
     residual_buf::Tb  # pre-allocated buffer for post-solve residual check (same size/type as b)
     a_backup_synced::Bool  # true if A_backup content matches cache.A (before LU modifies it)
     a_backup_allocated::Bool  # true once A_backup has been replaced with a private buffer
+    fell_back_to_qr::Bool  # true after QR fallback; reuse QR until matrix is refreshed
 end
 
 function resize_cacheval!(cache, cacheval::DefaultLinearSolverInit, i)
@@ -566,7 +567,7 @@ end
     end
     return Expr(
         :call, :DefaultLinearSolverInit, caches...,
-        :A_original, :(similar(b)), true, false
+        :A_original, :(similar(b)), true, false, false
     )
 end
 
@@ -618,6 +619,23 @@ function _do_qr_fallback(cache::LinearCache, alg, sol, reason::Symbol, args...; 
     copyto!(cache.A, cache.cacheval.A_backup)
     cache.isfresh = true
     sol = SciMLBase.solve!(cache, QRFactorization(ColumnNorm()), args...; kwargs...)
+    cache.cacheval.fell_back_to_qr = true
+    return SciMLBase.build_linear_solution(
+        alg, sol.u, sol.resid, sol.cache;
+        retcode = sol.retcode, iters = sol.iters, stats = sol.stats
+    )
+end
+
+"""
+    _reuse_qr_fallback(cache::LinearCache, alg, args...; kwargs...)
+
+Reuse the cached QR factorization from a previous QR fallback. Called when
+`fell_back_to_qr` is `true` and `isfresh` is `false`, meaning the matrix hasn't
+changed since the QR fallback and we should keep using QR instead of the
+(potentially corrupted) LU factorization.
+"""
+function _reuse_qr_fallback(cache::LinearCache, alg, args...; kwargs...)
+    sol = SciMLBase.solve!(cache, QRFactorization(ColumnNorm()), args...; kwargs...)
     return SciMLBase.build_linear_solution(
         alg, sol.u, sol.resid, sol.cache;
         retcode = sol.retcode, iters = sol.iters, stats = sol.stats
@@ -652,27 +670,27 @@ end
     _algchoice_to_alg_with_safety(alg::Symbol)
 
 Like `algchoice_to_alg`, but generates an expression that passes
-`residualsafety = alg.safetyfallback` at runtime. Used in the `@generated solve!`
+`residualsafety = alg.residualsafety` at runtime. Used in the `@generated solve!`
 so that the inner LU algorithm does its own residual check when the default solver
-has `safetyfallback=true`.
+has `residualsafety=true`.
 """
 function _algchoice_to_alg_with_safety(alg::Symbol)
     return if alg === :LUFactorization
-        :(LUFactorization(residualsafety = alg.safetyfallback))
+        :(LUFactorization(residualsafety = alg.residualsafety))
     elseif alg === :GenericLUFactorization
-        :(GenericLUFactorization(residualsafety = alg.safetyfallback))
+        :(GenericLUFactorization(residualsafety = alg.residualsafety))
     elseif alg === :MKLLUFactorization
-        :(MKLLUFactorization(residualsafety = alg.safetyfallback))
+        :(MKLLUFactorization(residualsafety = alg.residualsafety))
     elseif alg === :AppleAccelerateLUFactorization
-        :(AppleAccelerateLUFactorization(residualsafety = alg.safetyfallback))
+        :(AppleAccelerateLUFactorization(residualsafety = alg.residualsafety))
     elseif alg === :RFLUFactorization
-        :(RFLUFactorization(throwerror = false, residualsafety = alg.safetyfallback))
+        :(RFLUFactorization(throwerror = false, residualsafety = alg.residualsafety))
     elseif alg === :BLISLUFactorization
-        :(BLISLUFactorization(throwerror = false, residualsafety = alg.safetyfallback))
+        :(BLISLUFactorization(throwerror = false, residualsafety = alg.residualsafety))
     elseif alg === :CudaOffloadLUFactorization
-        :(CudaOffloadLUFactorization(throwerror = false, residualsafety = alg.safetyfallback))
+        :(CudaOffloadLUFactorization(throwerror = false, residualsafety = alg.residualsafety))
     elseif alg === :MetalLUFactorization
-        :(MetalLUFactorization(throwerror = false, residualsafety = alg.safetyfallback))
+        :(MetalLUFactorization(throwerror = false, residualsafety = alg.residualsafety))
     else
         error("Algorithm $alg does not support residualsafety")
     end
@@ -701,7 +719,7 @@ end
                     DefaultAlgorithmChoice.GenericLUFactorization,
                 )
             )
-            # Pass residualsafety = alg.safetyfallback so the inner algorithm does
+            # Pass residualsafety = alg.residualsafety so the inner algorithm does
             # its own residual check and returns APosterioriSafetyFailure if needed.
             inner_alg_expr = _algchoice_to_alg_with_safety(alg)
             newex = quote
@@ -782,7 +800,15 @@ end
             Expr(:elseif, :(alg.alg == $(alg_enum)), newex, ex)
         end
     end
-    return ex = Expr(:if, ex.args...)
+    alg_dispatch = Expr(:if, ex.args...)
+    return quote
+        if cache.cacheval isa DefaultLinearSolverInit &&
+                cache.cacheval.fell_back_to_qr && !cache.isfresh
+            _reuse_qr_fallback(cache, alg, args...; kwargs...)
+        else
+            $alg_dispatch
+        end
+    end
 end
 
 """

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -5,7 +5,12 @@
     return quote
         A = convert(AbstractMatrix, cache.A)
         check_safety = _get_residualsafety(alg) && cache.isfresh
-        A_original = check_safety ? _copy_A_for_safety(cache) : A
+        # Back up A before in-place LU when:
+        #   - residualsafety is enabled (for residual check using original A), OR
+        #   - the default solver has safetyfallback (for restoring A after LU failure)
+        needs_backup = check_safety ||
+            (cache.alg isa DefaultLinearSolver && cache.alg.safetyfallback && cache.isfresh)
+        A_original = needs_backup ? _copy_A_for_safety(cache) : A
 
         if cache.isfresh
             fact = do_factorization(alg, cache.A, cache.b, cache.u)
@@ -239,7 +244,9 @@ function SciMLBase.solve!(cache::LinearCache, alg::LUFactorization; kwargs...)
     A = cache.A
     A = convert(AbstractMatrix, A)
     check_safety = alg.residualsafety && cache.isfresh
-    A_original = check_safety ? _copy_A_for_safety(cache) : A
+    needs_backup = check_safety ||
+        (cache.alg isa DefaultLinearSolver && cache.alg.safetyfallback && cache.isfresh)
+    A_original = needs_backup ? _copy_A_for_safety(cache) : A
     if cache.isfresh
         cacheval = @get_cacheval(cache, :LUFactorization)
         local fact
@@ -332,7 +339,9 @@ function SciMLBase.solve!(
     A = cache.A
     A = convert(AbstractMatrix, A)
     check_safety = alg.residualsafety && cache.isfresh
-    A_original = check_safety ? _copy_A_for_safety(cache) : A
+    needs_backup = check_safety ||
+        (cache.alg isa DefaultLinearSolver && cache.alg.safetyfallback && cache.isfresh)
+    A_original = needs_backup ? _copy_A_for_safety(cache) : A
     fact, ipiv = LinearSolve.@get_cacheval(cache, :GenericLUFactorization)
 
     if cache.isfresh

--- a/src/mkl.jl
+++ b/src/mkl.jl
@@ -304,7 +304,9 @@ function SciMLBase.solve!(
     A = cache.A
     A = convert(AbstractMatrix, A)
     check_safety = alg.residualsafety && cache.isfresh
-    A_original = check_safety ? _copy_A_for_safety(cache) : A
+    needs_backup = check_safety ||
+        (cache.alg isa DefaultLinearSolver && cache.alg.safetyfallback && cache.isfresh)
+    A_original = needs_backup ? _copy_A_for_safety(cache) : A
     verbose = cache.verbose
     if cache.isfresh
         cacheval = @get_cacheval(cache, :MKLLUFactorization)

--- a/src/openblas.jl
+++ b/src/openblas.jl
@@ -325,7 +325,9 @@ function SciMLBase.solve!(
     A = cache.A
     A = convert(AbstractMatrix, A)
     check_safety = alg.residualsafety && cache.isfresh
-    A_original = check_safety ? _copy_A_for_safety(cache) : A
+    needs_backup = check_safety ||
+        (cache.alg isa DefaultLinearSolver && cache.alg.safetyfallback && cache.isfresh)
+    A_original = needs_backup ? _copy_A_for_safety(cache) : A
     verbose = cache.verbose
     if cache.isfresh
         cacheval = @get_cacheval(cache, :OpenBLASLUFactorization)

--- a/test/default_algs.jl
+++ b/test/default_algs.jl
@@ -304,11 +304,12 @@ sol_nosafe = solve(
         LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization; safetyfallback = false
     )
 )
-# With safetyfallback (default), residual check should trigger QR fallback
+# With residualsafety=true, residual check should trigger QR fallback
 sol_safe = solve(
     LinearProblem(copy(A_nearsing), copy(b_nearsing)),
     LinearSolve.DefaultLinearSolver(
-        LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
+        LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization;
+        residualsafety = true
     )
 )
 sol_qr_ref = solve(
@@ -368,3 +369,31 @@ sol_lu_well_rs = solve(
 )
 @test sol_lu_well_rs.retcode === ReturnCode.Success
 @test sol_lu_well_rs.u ≈ A_wellcond \ b_wellcond
+
+# QR fallback reuse: after QR fallback, subsequent solves with the same matrix
+# should use QR (not the corrupted in-place LU cache).
+# Regression test for https://github.com/SciML/LinearSolve.jl/issues/911
+# Simulates the ODE solver pattern: first solve triggers QR fallback,
+# then subsequent stages reuse the factorization without updating A.
+A_illcond = copy(A_nearsing)
+b1 = randn(n)
+b2 = randn(n)
+prob_reuse_qr = LinearProblem(A_illcond, b1)
+alg_reuse = LinearSolve.DefaultLinearSolver(
+    LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization;
+    residualsafety = true
+)
+cache_qr_reuse = init(prob_reuse_qr, alg_reuse)
+sol_stage1 = solve!(cache_qr_reuse)
+@test sol_stage1.retcode === ReturnCode.Success
+@test cache_qr_reuse.cacheval.fell_back_to_qr
+# Stage 2: only change b, not A (simulates Rosenbrock stage reuse)
+cache_qr_reuse.b = b2
+sol_stage2 = solve!(cache_qr_reuse)
+@test sol_stage2.retcode === ReturnCode.Success
+# Verify the solution matches a fresh QR solve (not corrupted by LU)
+sol_qr_stage2_ref = solve(LinearProblem(copy(A_nearsing), copy(b2)), QRFactorization(ColumnNorm()))
+@test sol_stage2.u ≈ sol_qr_stage2_ref.u
+# After setting a new A, fell_back_to_qr should be reset
+cache_qr_reuse.A = copy(A_nearsing)  # triggers setproperty! for :A
+@test !cache_qr_reuse.cacheval.fell_back_to_qr


### PR DESCRIPTION
## Summary

Fixes #911 — mass-matrix ODE regression introduced in v3.62.

Two interacting bugs were causing Rosenbrock solvers (e.g. Rodas5P) to reject all timesteps on ill-conditioned Jacobians:

1. **`residualsafety` was coupled to `safetyfallback`**, making the post-solve residual check (`‖A*x - b‖ > √eps·‖b‖`) always active. This tolerance is too tight for ill-conditioned (but non-singular) matrices (κ > ~2.2e5), triggering unnecessary QR fallbacks.

2. **QR fallback corrupted the LU cache for in-place algorithms** (MKL, AppleAccelerate, GenericLU). After QR fallback restored A from backup, subsequent solves within the same ODE step reused the corrupted LU factorization instead of QR.

### Changes

- **Add `residualsafety::Bool` kwarg to `DefaultLinearSolver`** (default `false`), decoupled from `safetyfallback`. Users who want the post-solve residual check can opt in with `residualsafety=true`.
- **Add `fell_back_to_qr` flag** to `DefaultLinearSolverInit`. After QR fallback, subsequent solves with the same matrix reuse QR (via `_reuse_qr_fallback`) instead of the corrupted LU. The flag resets when `cache.A` is updated.
- **Decouple A backup from residual check**: When `safetyfallback=true`, always back up A before in-place LU factorization (needed to restore A after `SingularException`), even when `residualsafety=false`.
- Updated `_algchoice_to_alg_with_safety` to use `alg.residualsafety` instead of `alg.safetyfallback`.
- Added regression test for QR fallback reuse pattern.

### Files changed

- `src/LinearSolve.jl` — Added `residualsafety` field to `DefaultLinearSolver`
- `src/default.jl` — Added `fell_back_to_qr` flag, `_reuse_qr_fallback` helper, QR reuse check in generated `solve!`
- `src/common.jl` — Reset `fell_back_to_qr` on `cache.A` update
- `src/factorization.jl` — Decouple A backup from residual check (also LUFactorization, GenericLUFactorization)
- `src/mkl.jl`, `src/openblas.jl`, `src/appleaccelerate.jl` — Same backup decoupling
- `test/default_algs.jl` — Updated test to use `residualsafety=true`, added QR reuse regression test

## Test plan

- [x] `Pkg.test()` passes locally (all tests pass, 0 failures)
- [x] QR fallback reuse test: verifies stage 2 solve matches fresh QR solve
- [x] Existing residual safety tests pass with explicit `residualsafety=true`
- [x] A backup sync test passes (singular matrix replacement via `copyto!`)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)