### PR TITLE
Default residualsafety to match safetyfallback

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -368,7 +368,7 @@ function is_algorithm_available(alg::DefaultAlgorithmChoice.T)
 end
 
 """
-    DefaultLinearSolver(;safetyfallback=true, residualsafety=false)
+    DefaultLinearSolver(;safetyfallback=true, residualsafety=safetyfallback)
 
 The default linear solver. This is the algorithm chosen when `solve(prob)`
 is called. It's a polyalgorithm that detects the optimal method for a given
@@ -381,7 +381,7 @@ is called. It's a polyalgorithm that detects the optimal method for a given
   - `residualsafety`: when `true`, the inner LU algorithm computes the post-solve residual
     `‖A*x - b‖` and returns `ReturnCode.APosterioriSafetyFailure` if it exceeds
     `abstol + reltol * ‖b‖`. The default solver then falls back to column-pivoted QR.
-    Defaults to `false`.
+    Defaults to the value of `safetyfallback` (i.e. `true` by default).
 
 ## Residual Safety
 
@@ -396,7 +396,7 @@ struct DefaultLinearSolver <: SciMLLinearSolveAlgorithm
     alg::DefaultAlgorithmChoice.T
     safetyfallback::Bool
     residualsafety::Bool
-    DefaultLinearSolver(alg; safetyfallback = true, residualsafety = false) = new(alg, safetyfallback, residualsafety)
+    DefaultLinearSolver(alg; safetyfallback = true, residualsafety = safetyfallback) = new(alg, safetyfallback, residualsafety)
 end
 
 const BLASELTYPES = Union{Float32, Float64, ComplexF32, ComplexF64}


### PR DESCRIPTION
## Summary

- Makes `residualsafety` default to the value of `safetyfallback` (i.e. `true` by default) in `DefaultLinearSolver`, instead of hardcoded `false`
- Individual LU algorithms (`LUFactorization`, `GenericLUFactorization`, etc.) still default to `residualsafety=false` when used directly

## Context

PR #912 disabled `residualsafety` by default to fix ODE regression #911, where ill-conditioned Rosenbrock Jacobians triggered QR fallback with corrupted LU cache reuse. But #912 also fixed the underlying QR reuse bug (`fell_back_to_qr` flag), so that regression no longer applies with this change.

With `residualsafety=false`, `NonlinearSolve.NewtonRaphson` fails on problems with ill-conditioned Jacobians (e.g. Generalized Rosenbrock function, problem 1 in the 23 test problems) because LU silently returns garbage solutions without any fallback to QR. This caused [SciML/NonlinearSolve.jl CI failures](https://github.com/SciML/NonlinearSolve.jl/actions/runs/22724423742/job/65942837302?pr=863).

The overhead of residual safety is one matrix copy (already done when `safetyfallback=true`) plus one matrix-vector multiply — O(n²) on top of the O(n³) LU factorization.

## Test plan

- [x] All LinearSolve.jl tests pass locally
- [x] NonlinearSolve Generalized Rosenbrock test converges with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)