### PR TITLE
Fix IterativeSolversJL_IDRS

### DIFF
--- a/ext/LinearSolveIterativeSolversExt.jl
+++ b/ext/LinearSolveIterativeSolversExt.jl
@@ -75,7 +75,7 @@ function LinearSolve.init_cacheval(
         verbosity = verbose
     end
     restart = (alg.gmres_restart == 0) ? min(20, size(A, 1)) : alg.gmres_restart
-    s = :idrs_s in keys(alg.kwargs) ? alg.kwargs.idrs_s : 4 # shadow space
+    s = get(alg.kwargs, :idrs_s, 4) # shadow space
 
     kwargs = (
         abstol = abstol, reltol = reltol, maxiter = maxiters,
@@ -106,9 +106,10 @@ function LinearSolve.init_cacheval(
         history = IterativeSolvers.ConvergenceHistory(partial = true)
         history[:abstol] = abstol
         history[:reltol] = reltol
+        filter_kwargs(; idrs_s = 0, kwargs...) = kwargs
         IterativeSolvers.idrs_iterable!(
             history, u, A, b, s, Pl, abstol, reltol, maxiters;
-            alg.kwargs...
+            filter_kwargs(; alg.kwargs...)...
         )
     elseif alg.generate_iterator === IterativeSolvers.bicgstabl_iterator!
         !!LinearSolve._isidentity_struct(Pr) &&

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -765,7 +765,7 @@ function IterativeSolversJL_GMRES end
 
 """
 ```julia
-IterativeSolversJL_IDRS(args...; Pl = nothing, kwargs...)
+IterativeSolversJL_IDRS(args...; Pl = nothing, idrs_s = 4, kwargs...)
 ```
 
 A wrapper over the IterativeSolvers.jl IDR(S).

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -509,6 +509,7 @@ end
                     ("CG", IterativeSolversJL_CG(; kwargs...)),
                     ("GMRES", IterativeSolversJL_GMRES(; kwargs...)),
                     ("IDRS", IterativeSolversJL_IDRS(; kwargs...)),
+                    ("IDRS(2)", IterativeSolversJL_IDRS(; idrs_s = 2, kwargs...)),
                     # ("BICGSTAB",IterativeSolversJL_BICGSTAB(; kwargs...)),
                     # ("MINRES",IterativeSolversJL_MINRES(; kwargs...)),
                 )


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Also, `IterativeSolversJL_IDRS(; Pl)` is documented but doesn't actually work. What should be done here? I didn't delete it from the docs to not have it look like this feature never existed. I didn't spend any time researching whether and how it might have worked in the past, though.
