### PR TITLE
Fix missing retcode in DiagonalFactorization and other solvers

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -1250,7 +1250,10 @@ function SciMLBase.solve!(cache::LinearCache, alg::CHOLMODFactorization; kwargs.
     end
 
     cache.u .= @get_cacheval(cache, :CHOLMODFactorization) \ cache.b
-    return SciMLBase.build_linear_solution(alg, cache.u, nothing, cache)
+    return SciMLBase.build_linear_solution(
+        alg, cache.u, nothing, cache;
+        retcode = ReturnCode.Success
+    )
 end
 
 ## NormalCholeskyFactorization
@@ -1403,7 +1406,10 @@ function SciMLBase.solve!(
         cache.isfresh = false
     end
     y = ldiv!(cache.u, @get_cacheval(cache, :NormalBunchKaufmanFactorization), A' * cache.b)
-    return SciMLBase.build_linear_solution(alg, y, nothing, cache)
+    return SciMLBase.build_linear_solution(
+        alg, y, nothing, cache;
+        retcode = ReturnCode.Success
+    )
 end
 
 ## DiagonalFactorization
@@ -1434,7 +1440,10 @@ function SciMLBase.solve!(
     else
         cache.u .= A.diag .\ cache.b
     end
-    return SciMLBase.build_linear_solution(alg, cache.u, nothing, cache)
+    return SciMLBase.build_linear_solution(
+        alg, cache.u, nothing, cache;
+        retcode = ReturnCode.Success
+    )
 end
 
 ## SparspakFactorization is here since it's MIT licensed, not GPL

--- a/src/simplelu.jl
+++ b/src/simplelu.jl
@@ -214,7 +214,10 @@ function SciMLBase.solve!(cache::LinearCache, alg::SimpleLUFactorization; kwargs
     cache.cacheval.b .= cache.b
     cache.cacheval.x .= cache.u
     y = simplelu_solve!(cache.cacheval)
-    return SciMLBase.build_linear_solution(alg, y, nothing, cache)
+    return SciMLBase.build_linear_solution(
+        alg, y, nothing, cache;
+        retcode = ReturnCode.Success
+    )
 end
 
 function init_cacheval(

--- a/src/solve_function.jl
+++ b/src/solve_function.jl
@@ -53,7 +53,10 @@ function SciMLBase.solve!(
     (; solve_func) = alg
 
     u = solve_func(A, b, u, p, isfresh, Pl, Pr, cacheval; kwargs...)
-    return SciMLBase.build_linear_solution(alg, u, nothing, cache)
+    return SciMLBase.build_linear_solution(
+        alg, u, nothing, cache;
+        retcode = ReturnCode.Success
+    )
 end
 
 """
@@ -102,7 +105,10 @@ end
 function SciMLBase.solve!(cache::LinearCache, alg::DirectLdiv!{false}, args...; kwargs...)
     (; A, b, u) = cache
     ldiv!(u, A, b)
-    return SciMLBase.build_linear_solution(alg, u, nothing, cache)
+    return SciMLBase.build_linear_solution(
+        alg, u, nothing, cache;
+        retcode = ReturnCode.Success
+    )
 end
 
 # For caching DirectLdiv! with general matrices, just use regular ldiv!
@@ -110,7 +116,10 @@ end
 function SciMLBase.solve!(cache::LinearCache, alg::DirectLdiv!{true}, args...; kwargs...)
     (; A, b, u) = cache
     ldiv!(u, A, b)
-    return SciMLBase.build_linear_solution(alg, u, nothing, cache)
+    return SciMLBase.build_linear_solution(
+        alg, u, nothing, cache;
+        retcode = ReturnCode.Success
+    )
 end
 
 # Specialized handling for Tridiagonal matrices to avoid mutating cache.A
@@ -147,7 +156,10 @@ function SciMLBase.solve!(
     copyto!(cacheval.du, A.du)
     # Perform ldiv! on the copy, preserving the original A
     ldiv!(u, cacheval, b)
-    return SciMLBase.build_linear_solution(alg, u, nothing, cache)
+    return SciMLBase.build_linear_solution(
+        alg, u, nothing, cache;
+        retcode = ReturnCode.Success
+    )
 end
 
 function SciMLBase.solve!(
@@ -160,5 +172,8 @@ function SciMLBase.solve!(
     copyto!(cacheval.ev, A.ev)
     # Perform ldiv! on the copy, preserving the original A
     ldiv!(u, cacheval, b)
-    return SciMLBase.build_linear_solution(alg, u, nothing, cache)
+    return SciMLBase.build_linear_solution(
+        alg, u, nothing, cache;
+        retcode = ReturnCode.Success
+    )
 end

--- a/test/resolve.jl
+++ b/test/resolve.jl
@@ -110,11 +110,21 @@ linsolve = init(
     prob, DiagonalFactorization(),
     alias = LinearAliasSpecifier(alias_A = false, alias_b = false)
 )
-@test solve!(linsolve).u ≈ [1.0, 0.5]
-@test solve!(linsolve).u ≈ [1.0, 0.5]
+sol = solve!(linsolve)
+@test sol.u ≈ [1.0, 0.5]
+@test sol.retcode == ReturnCode.Success
+sol = solve!(linsolve)
+@test sol.u ≈ [1.0, 0.5]
+@test sol.retcode == ReturnCode.Success
 A = Diagonal([1.0, 4.0])
 linsolve.A = A
 @test solve!(linsolve).u ≈ [1.0, 0.5]
+
+# Test retcode for default algorithm with Diagonal
+prob_diag = LinearProblem(Diagonal(ones(2)), ones(2))
+sol_diag = solve(prob_diag)
+@test sol_diag.u ≈ ones(2)
+@test sol_diag.retcode == ReturnCode.Success
 
 A = Symmetric(
     [


### PR DESCRIPTION
## Summary
- Several solver implementations were calling `build_linear_solution` without `retcode = ReturnCode.Success`, causing the return code to remain `Default` even on successful solves
- Fixed `DiagonalFactorization`, `CHOLMODFactorization`, `NormalBunchKaufmanFactorization`, `SimpleLUFactorization`, `LinearSolveFunction`, and all `DirectLdiv!` variants
- Added retcode assertions to existing Diagonal tests in `test/resolve.jl`

## Test plan
- [x] Verified `solve(LinearProblem(Diagonal(ones(2)), ones(2))).retcode == ReturnCode.Success`
- [x] Verified `DiagonalFactorization()` returns `ReturnCode.Success`
- [ ] CI passes

Fixes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)