### PR TITLE
Remove V100 CUDA compatibility workarounds

### DIFF
--- a/test/gpu/LocalPreferences.toml
+++ b/test/gpu/LocalPreferences.toml
@@ -1,7 +1,0 @@
-[CUDA_Runtime_jll]
-version = "12.6"
-
-[CUDA_Driver_jll]
-# Disable forward-compat driver — V100 runners need the system driver
-# since CUDA_Driver_jll v13+ drops compute capability 7.0 support
-compat = "false"

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -1,8 +1,6 @@
 [deps]
 BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
-CUDA_Driver_jll = "4ee394cb-3365-5eb0-8335-949819d2adfc"
-CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"
 CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
 CUSOLVERRF = "a8cc9031-bad2-4722-94f5-40deabb4245c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -11,5 +9,3 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[compat]
-CUDA = "4, 5"


### PR DESCRIPTION
## Summary
- Remove `test/gpu/LocalPreferences.toml` that pinned CUDA runtime to 12.6 for V100 compatibility
- Remove `CUDA_Driver_jll` and `CUDA_Runtime_jll` dependency additions from test/gpu/Project.toml
- Remove unnecessary CUDA compat bounds widening

demeter4's driver has been downgraded to CUDA 12.9 (from 13.x), so these workarounds are no longer needed. The CUDA 12.x driver will automatically select a compatible toolkit for the V100s.

Reverts the workaround parts of #921 (keeps the legitimate GPU code fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)