### PR TITLE
Update RecursiveArrayTools compat to support v4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "3.69.0"
+version = "3.70.0"
 authors = ["SciML"]
 
 [deps]
@@ -134,7 +134,7 @@ Pkg = "1.10"
 PrecompileTools = "1.2"
 Preferences = "1.4"
 Random = "1.10"
-RecursiveArrayTools = "3.37"
+RecursiveArrayTools = "3.37, 4"
 RecursiveFactorization = "0.2.26"
 Reexport = "1.2.2"
 SafeTestsets = "0.1"


### PR DESCRIPTION
## Summary
- Bump RecursiveArrayTools compat to include v4
- RecursiveArrayTools v4 makes `AbstractVectorOfArray <: AbstractArray`

## Context
Part of the ecosystem-wide update for RecursiveArrayTools v4. This supersedes #933 and #934 (CompatHelper PRs) with a single combined update.

## Notes
- CI will fail until upstream deps (SciMLBase, DiffEqBase, OrdinaryDiffEq) also allow RAT v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)