### PR TITLE
Add residual_safety verbosity toggle

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -134,6 +134,9 @@ function _check_residual_safety(cache::LinearCache, alg, A_original, y)
     b_norm = norm(b)
     tol = cache.abstol + cache.reltol * b_norm
     if res_norm > tol
+        @SciMLMessage(cache.verbose, :residual_safety) do
+            return "Residual safety check failed: ‖A*x - b‖ = $(res_norm), tol = $(tol) (abstol = $(cache.abstol), reltol = $(cache.reltol), ‖b‖ = $(b_norm), ratio = $(res_norm / tol))"
+        end
         return SciMLBase.build_linear_solution(
             alg, y, nothing, cache; retcode = ReturnCode.APosterioriSafetyFailure
         )

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -1,6 +1,7 @@
 SciMLLogging.@verbosity_specifier LinearVerbosity begin
     toggles = (
         :default_lu_fallback,
+        :residual_safety,
         :no_right_preconditioning,
         :using_IterativeSolvers,
         :IterativeSolvers_iterations,
@@ -21,6 +22,7 @@ SciMLLogging.@verbosity_specifier LinearVerbosity begin
     presets = (
         None = (
             default_lu_fallback = Silent(),
+            residual_safety = Silent(),
             no_right_preconditioning = Silent(),
             using_IterativeSolvers = Silent(),
             IterativeSolvers_iterations = Silent(),
@@ -39,6 +41,7 @@ SciMLLogging.@verbosity_specifier LinearVerbosity begin
         ),
         Minimal = (
             default_lu_fallback = Silent(),
+            residual_safety = Silent(),
             no_right_preconditioning = Silent(),
             using_IterativeSolvers = Silent(),
             IterativeSolvers_iterations = Silent(),
@@ -57,6 +60,7 @@ SciMLLogging.@verbosity_specifier LinearVerbosity begin
         ),
         Standard = (
             default_lu_fallback = Silent(),
+            residual_safety = Silent(),
             no_right_preconditioning = Silent(),
             using_IterativeSolvers = Silent(),
             IterativeSolvers_iterations = Silent(),
@@ -75,6 +79,7 @@ SciMLLogging.@verbosity_specifier LinearVerbosity begin
         ),
         Detailed = (
             default_lu_fallback = WarnLevel(),
+            residual_safety = WarnLevel(),
             no_right_preconditioning = InfoLevel(),
             using_IterativeSolvers = InfoLevel(),
             IterativeSolvers_iterations = Silent(),
@@ -93,6 +98,7 @@ SciMLLogging.@verbosity_specifier LinearVerbosity begin
         ),
         All = (
             default_lu_fallback = WarnLevel(),
+            residual_safety = WarnLevel(),
             no_right_preconditioning = InfoLevel(),
             using_IterativeSolvers = InfoLevel(),
             IterativeSolvers_iterations = InfoLevel(),
@@ -112,7 +118,7 @@ SciMLLogging.@verbosity_specifier LinearVerbosity begin
     )
 
     groups = (
-        error_control = (:default_lu_fallback, :blas_errors, :blas_invalid_args),
+        error_control = (:default_lu_fallback, :residual_safety, :blas_errors, :blas_invalid_args),
         performance = (:no_right_preconditioning,),
         numerical = (
             :using_IterativeSolvers, :IterativeSolvers_iterations,
@@ -133,6 +139,7 @@ diagnostic messages, warnings, and errors during linear system solution.
 
 ## Error Control Group
 - `default_lu_fallback`: Messages when falling back to LU factorization from other methods
+- `residual_safety`: Messages from the residual safety check (`‖A*x - b‖` vs tolerance)
 - `blas_errors`: Critical BLAS errors that stop computation
 - `blas_invalid_args`: BLAS errors due to invalid arguments
 
@@ -196,7 +203,7 @@ verbose = LinearVerbosity(
 """ LinearVerbosity
 
 # Group classifications (for backwards compatibility)
-const error_control_options = (:default_lu_fallback, :blas_errors, :blas_invalid_args)
+const error_control_options = (:default_lu_fallback, :residual_safety, :blas_errors, :blas_invalid_args)
 const performance_options = (:no_right_preconditioning,)
 const numerical_options = (
     :using_IterativeSolvers, :IterativeSolvers_iterations,


### PR DESCRIPTION
## Summary

- Adds a `:residual_safety` toggle to `LinearVerbosity` that prints the actual residual norm, tolerance, and ratio when the post-solve residual safety check triggers QR fallback
- Silent by default (and in `Standard` preset), enabled in `Detailed` and `All` presets
- Helps diagnose #911 regression from #915 where `residualsafety=true` may be too aggressive for moderately ill-conditioned ODE Jacobians

## Usage

```julia
using SciMLLogging, LinearSolve
verbose = LinearVerbosity(residual_safety = SciMLLogging.WarnLevel())
sol = solve(prob; verbose = verbose)
```

Through ODE solvers:
```julia
verbose = ODEVerbosity(linear_verbosity = LinearVerbosity(residual_safety = SciMLLogging.WarnLevel()))
sol = solve(ode, Rodas5P(); verbose = verbose)
```

Output:
```
┌ Warning: Verbosity toggle: residual_safety
│  Residual safety check failed: ‖A*x - b‖ = 1.554, tol = 9.09e-8
│  (abstol = 1.49e-8, reltol = 1.49e-8, ‖b‖ = 5.10, ratio = 1.71e7)
└ @ LinearSolve ...
```

## Test plan

- [x] Existing `default_algs.jl` residual safety tests pass
- [x] Verified message fires on near-singular matrix test case
- [x] Verified no message on well-conditioned systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)