### PR TITLE
Fix runic and typos CI failures

### DIFF
--- a/ext/LinearSolveEnzymeExt.jl
+++ b/ext/LinearSolveEnzymeExt.jl
@@ -165,10 +165,10 @@ function _sparse_outer_sub!(
     # `Symmetric` disallows writing off-diagonal entries via `setindex!` on the wrapper.
     # Accumulate directly into the parent storage while preserving symmetry by updating
     # only the stored triangle with the reduced gradient for unique symmetric entries.
-    Aparent = parent(dA)
-    n = size(Aparent, 1)
+    A_parent = parent(dA)
+    n = size(A_parent, 1)
 
-    @assert size(Aparent, 1) == size(Aparent, 2)
+    @assert size(A_parent, 1) == size(A_parent, 2)
     @assert length(z) == n
     @assert length(y) == n
 
@@ -177,17 +177,17 @@ function _sparse_outer_sub!(
             zj = z[j]
             yj = y[j]
             for i in 1:(j - 1)
-                Aparent[i, j] -= z[i] * yj + zj * y[i]
+                A_parent[i, j] -= z[i] * yj + zj * y[i]
             end
-            Aparent[j, j] -= zj * yj
+            A_parent[j, j] -= zj * yj
         end
     else
         @inbounds for j in 1:n
             zj = z[j]
             yj = y[j]
-            Aparent[j, j] -= zj * yj
+            A_parent[j, j] -= zj * yj
             for i in (j + 1):n
-                Aparent[i, j] -= z[i] * yj + zj * y[i]
+                A_parent[i, j] -= z[i] * yj + zj * y[i]
             end
         end
     end

--- a/test/nopre/mooncake.jl
+++ b/test/nopre/mooncake.jl
@@ -295,5 +295,5 @@ end
     fA_closure = A -> fnice(A, b1, alg)
     fd_jac_A = FiniteDiff.finite_difference_jacobian(fA_closure, A) |> vec
     A_grad = en_jac[2] |> vec
-    @test A_grad ≈ fd_jac_A rtol = 1e-4
+    @test A_grad ≈ fd_jac_A rtol = 1.0e-4
 end


### PR DESCRIPTION
## Summary

- **Typos CI**: Rename `Aparent` → `A_parent` in `LinearSolveEnzymeExt.jl`. The variable name (short for "A parent") was flagged as a misspelling of "Apparent".
- **Runic CI**: Change `1e-4` → `1.0e-4` in `test/nopre/mooncake.jl` to satisfy Runic's float literal formatting.

## Test plan

- [x] These are formatting/naming fixes only, no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)