### PR TITLE
fix: STRUMPACK

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -54,17 +54,6 @@ jobs:
             version: "lts"
           - group: Trim
             version: "pre"
-          # Keep STRUMPACK coverage targeted to one stable platform/version
-          - group: LinearSolveSTRUMPACK
-            version: "lts"
-          - group: LinearSolveSTRUMPACK
-            version: "pre"
-          - group: LinearSolveSTRUMPACK
-            os: windows-latest
-          - group: LinearSolveSTRUMPACK
-            os: macos-latest
-          - group: LinearSolveSTRUMPACK
-            arch: x86
           # MKL Pardiso has numerical issues on pre-release Julia
           # See: https://github.com/SciML/LinearSolve.jl/issues/879
           - group: LinearSolvePardiso

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -33,6 +33,7 @@ jobs:
         group:
           - "Core"
           - "DefaultsLoading"
+          - "LinearSolveSTRUMPACK"
           - "LinearSolveHYPRE"
           - "LinearSolvePETSc"
           - "LinearSolvePardiso"
@@ -53,6 +54,17 @@ jobs:
             version: "lts"
           - group: Trim
             version: "pre"
+          # Keep STRUMPACK coverage targeted to one stable platform/version
+          - group: LinearSolveSTRUMPACK
+            version: "lts"
+          - group: LinearSolveSTRUMPACK
+            version: "pre"
+          - group: LinearSolveSTRUMPACK
+            os: windows-latest
+          - group: LinearSolveSTRUMPACK
+            os: macos-latest
+          - group: LinearSolveSTRUMPACK
+            arch: x86
           # MKL Pardiso has numerical issues on pre-release Julia
           # See: https://github.com/SciML/LinearSolve.jl/issues/879
           - group: LinearSolvePardiso

--- a/Project.toml
+++ b/Project.toml
@@ -57,6 +57,7 @@ RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 Sparspak = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
+STRUMPACK_jll = "86fbd0b9-476f-557c-b766-62c724b42d8c"
 blis_jll = "6136c539-28a5-5bf0-87cc-b183200dce32"
 
 [extensions]
@@ -88,6 +89,7 @@ LinearSolvePETScMPIExt = ["PETSc", "PartitionedArrays", "SparseArrays", "SparseM
 LinearSolveParUExt = ["ParU_jll", "SparseArrays"]
 LinearSolvePardisoExt = ["Pardiso", "SparseArrays"]
 LinearSolveRecursiveFactorizationExt = "RecursiveFactorization"
+LinearSolveSTRUMPACKExt = ["SparseArrays", "STRUMPACK_jll"]
 LinearSolveSparseArraysExt = "SparseArrays"
 LinearSolveSparspakExt = ["SparseArrays", "Sparspak"]
 
@@ -145,6 +147,7 @@ Random = "1.10"
 RecursiveArrayTools = "3.37, 4"
 RecursiveFactorization = "0.2.26"
 Reexport = "1.2.2"
+STRUMPACK_jll = "8"
 SafeTestsets = "0.1"
 SciMLBase = "2.148, 3"
 SciMLLogging = "1.7"
@@ -190,6 +193,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
+STRUMPACK_jll = "86fbd0b9-476f-557c-b766-62c724b42d8c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Sparspak = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
@@ -199,4 +203,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["AlgebraicMultigrid", "Aqua", "Test", "IterativeSolvers", "InteractiveUtils", "KrylovKit", "KrylovPreconditioners", "Pkg", "Random", "SafeTestsets", "MultiFloats", "ForwardDiff", "HYPRE", "MPI", "PETSc", "BlockDiagonals", "FiniteDiff", "BandedMatrices", "FastAlmostBandedMatrices", "StaticArrays", "AllocCheck", "StableRNGs", "Zygote", "RecursiveFactorization", "Sparspak", "CliqueTrees", "FastLapackInterface", "SparseArrays", "ExplicitImports", "ComponentArrays", "Elemental"]
+test = ["AlgebraicMultigrid", "Aqua", "Test", "IterativeSolvers", "InteractiveUtils", "KrylovKit", "KrylovPreconditioners", "Pkg", "Random", "SafeTestsets", "MultiFloats", "ForwardDiff", "HYPRE", "MPI", "PETSc", "BlockDiagonals", "FiniteDiff", "BandedMatrices", "FastAlmostBandedMatrices", "StaticArrays", "AllocCheck", "StableRNGs", "Zygote", "RecursiveFactorization", "Sparspak", "CliqueTrees", "FastLapackInterface", "SparseArrays", "ExplicitImports", "ComponentArrays", "Elemental", "STRUMPACK_jll"]

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -225,7 +225,7 @@ SparspakFactorization
 
 !!! note
 
-    Using this solver requires `SparseArrays` and a discoverable STRUMPACK shared library (`libstrumpack`).
+    Using this solver requires `using SparseArrays` and loading `STRUMPACK_jll` (for example `import STRUMPACK_jll`).
 
 The following convenience keywords map to STRUMPACK runtime options:
 

--- a/ext/LinearSolveSTRUMPACKExt.jl
+++ b/ext/LinearSolveSTRUMPACKExt.jl
@@ -4,6 +4,7 @@ using LinearSolve: LinearSolve, LinearVerbosity, OperatorAssumptions
 using SparseArrays: SparseArrays, AbstractSparseMatrixCSC, getcolptr, rowvals, nonzeros
 using SciMLBase: SciMLBase, ReturnCode
 using SciMLLogging: @SciMLMessage
+using STRUMPACK_jll: libstrumpack
 using Libdl: Libdl
 
 const STRUMPACK_SUCCESS = Cint(0)
@@ -16,9 +17,30 @@ const STRUMPACK_INACCURATE_INERTIA = Cint(5)
 const STRUMPACK_DOUBLE = Cint(1)
 const STRUMPACK_MT = Cint(0)
 
-const _libstrumpack = Ref{Ptr{Cvoid}}(C_NULL)
+struct STRUMPACKSparseSolver
+    solver::Ptr{Cvoid}
+    precision::Cint
+    interface::Cint
+end
+
+const _libstrumpack = Ref{Union{Nothing, String}}(nothing)
 
 function _load_libstrumpack()
+    if libstrumpack isa AbstractString
+        handle = Libdl.dlopen_e(libstrumpack)
+        handle != C_NULL && return String(libstrumpack)
+    elseif libstrumpack isa Ptr
+        libpath = try
+            Libdl.dlpath(libstrumpack)
+        catch
+            nothing
+        end
+        if libpath !== nothing
+            handle = Libdl.dlopen_e(libpath)
+            handle != C_NULL && return String(libpath)
+        end
+    end
+
     for name in (
             "libstrumpack.so",
             "libstrumpack.so.8",
@@ -27,19 +49,19 @@ function _load_libstrumpack()
             "strumpack",
         )
         handle = Libdl.dlopen_e(name)
-        handle != C_NULL && return handle
+        handle != C_NULL && return String(name)
     end
-    return C_NULL
+    return nothing
 end
 
 function __init__()
     return _libstrumpack[] = _load_libstrumpack()
 end
 
-strumpack_isavailable() = _libstrumpack[] != C_NULL
+strumpack_isavailable() = _libstrumpack[] !== nothing
 
 mutable struct STRUMPACKCache
-    solver::Ref{Ptr{Cvoid}}
+    solver::Ref{STRUMPACKSparseSolver}
     rowptr::Vector{Int32}
     colind::Vector{Int32}
     nzval::Vector{Float64}
@@ -48,7 +70,7 @@ mutable struct STRUMPACKCache
 
     function STRUMPACKCache()
         cache = new(
-            Ref{Ptr{Cvoid}}(C_NULL),
+            Ref(STRUMPACKSparseSolver(C_NULL, 0, 0)),
             Int32[],
             Int32[],
             Float64[],
@@ -61,10 +83,10 @@ mutable struct STRUMPACKCache
 end
 
 function _strumpack_destroy!(cache::STRUMPACKCache)
-    _libstrumpack[] == C_NULL && return
-    cache.solver[] == C_NULL && return
-    ccall((:STRUMPACK_destroy, _libstrumpack[]), Cvoid, (Ref{Ptr{Cvoid}},), cache.solver)
-    cache.solver[] = C_NULL
+    _libstrumpack[] === nothing && return
+    cache.solver[].solver == C_NULL && return
+    ccall((:STRUMPACK_destroy, _libstrumpack[]), Cvoid, (Ref{STRUMPACKSparseSolver},), cache.solver)
+    cache.solver[] = STRUMPACKSparseSolver(C_NULL, 0, 0)
     return
 end
 
@@ -83,7 +105,7 @@ function _set_runtime_options!(cache::STRUMPACKCache, alg::LinearSolve.STRUMPACK
 end
 
 function _ensure_initialized!(cache::STRUMPACKCache, alg::LinearSolve.STRUMPACKFactorization)
-    cache.solver[] != C_NULL && return
+    cache.solver[].solver != C_NULL && return
     _set_runtime_options!(cache, alg)
 
     argc = Cint(length(cache.option_ptrs))
@@ -92,13 +114,13 @@ function _ensure_initialized!(cache::STRUMPACKCache, alg::LinearSolve.STRUMPACKF
     ccall(
         (:STRUMPACK_init_mt, _libstrumpack[]),
         Cvoid,
-        (Ref{Ptr{Cvoid}}, Cint, Cint, Cint, Ptr{Ptr{UInt8}}, Cint),
+        (Ref{STRUMPACKSparseSolver}, Cint, Cint, Cint, Ptr{Ptr{UInt8}}, Cint),
         cache.solver,
         STRUMPACK_DOUBLE,
         STRUMPACK_MT,
-        Cint(0),
+        argc,
         argv,
-        argc
+        Cint(0)
     )
     return
 end
@@ -176,8 +198,8 @@ function SciMLBase.solve!(
         alg::LinearSolve.STRUMPACKFactorization;
         kwargs...
     )
-    if _libstrumpack[] == C_NULL
-        error("STRUMPACKFactorization requires a discoverable STRUMPACK shared library (`libstrumpack`)")
+    if _libstrumpack[] === nothing
+        error("STRUMPACKFactorization requires `using SparseArrays` and loading `STRUMPACK_jll` (for example `import STRUMPACK_jll`)")
     end
 
     A = convert(AbstractMatrix, cache.A)
@@ -195,19 +217,20 @@ function SciMLBase.solve!(
 
     if cache.isfresh
         scache.rowptr, scache.colind, scache.nzval = _csc_to_csr_0based(A)
+        nref = Ref{Cint}(Cint(size(A, 1)))
         ccall(
             (:STRUMPACK_set_csr_matrix, _libstrumpack[]),
             Cvoid,
-            (Ptr{Cvoid}, Cint, Ref{Cint}, Ref{Cint}, Ref{Cdouble}, Cint),
+            (STRUMPACKSparseSolver, Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cdouble}, Cint),
             scache.solver[],
-            Cint(size(A, 1)),
+            nref,
             scache.rowptr,
             scache.colind,
             scache.nzval,
             Cint(0)
         )
 
-        info = ccall((:STRUMPACK_factor, _libstrumpack[]), Cint, (Ptr{Cvoid},), scache.solver[])
+        info = ccall((:STRUMPACK_factor, _libstrumpack[]), Cint, (STRUMPACKSparseSolver,), scache.solver[])
         if info != STRUMPACK_SUCCESS
             @SciMLMessage(
                 "STRUMPACK factorization failed (code $(Int(info)))",
@@ -232,7 +255,7 @@ function SciMLBase.solve!(
     info = ccall(
         (:STRUMPACK_solve, _libstrumpack[]),
         Cint,
-        (Ptr{Cvoid}, Ref{Cdouble}, Ref{Cdouble}, Cint),
+        (STRUMPACKSparseSolver, Ref{Cdouble}, Ref{Cdouble}, Cint),
         scache.solver[],
         bvec,
         xvec,

--- a/ext/LinearSolveSTRUMPACKExt.jl
+++ b/ext/LinearSolveSTRUMPACKExt.jl
@@ -23,12 +23,12 @@ struct STRUMPACKSparseSolver
     interface::Cint
 end
 
-const _libstrumpack = Ref{Union{Nothing, String}}(nothing)
+const _libstrumpack = Ref{Union{Nothing, Ptr{Cvoid}}}(nothing)
 
 function _load_libstrumpack()
     if libstrumpack isa AbstractString
         handle = Libdl.dlopen_e(libstrumpack)
-        handle != C_NULL && return String(libstrumpack)
+        handle != C_NULL && return handle
     elseif libstrumpack isa Ptr
         libpath = try
             Libdl.dlpath(libstrumpack)
@@ -37,7 +37,7 @@ function _load_libstrumpack()
         end
         if libpath !== nothing
             handle = Libdl.dlopen_e(libpath)
-            handle != C_NULL && return String(libpath)
+            handle != C_NULL && return handle
         end
     end
 
@@ -49,7 +49,7 @@ function _load_libstrumpack()
             "strumpack",
         )
         handle = Libdl.dlopen_e(name)
-        handle != C_NULL && return String(name)
+        handle != C_NULL && return handle
     end
     return nothing
 end
@@ -59,6 +59,12 @@ function __init__()
 end
 
 strumpack_isavailable() = _libstrumpack[] !== nothing
+
+function _strumpack_fptr(name::Symbol)
+    lib = _libstrumpack[]
+    lib === nothing && error("STRUMPACK library is not loaded")
+    return Libdl.dlsym(lib, name)
+end
 
 mutable struct STRUMPACKCache
     solver::Ref{STRUMPACKSparseSolver}
@@ -85,7 +91,7 @@ end
 function _strumpack_destroy!(cache::STRUMPACKCache)
     _libstrumpack[] === nothing && return
     cache.solver[].solver == C_NULL && return
-    ccall((:STRUMPACK_destroy, _libstrumpack[]), Cvoid, (Ref{STRUMPACKSparseSolver},), cache.solver)
+    ccall(_strumpack_fptr(:STRUMPACK_destroy), Cvoid, (Ref{STRUMPACKSparseSolver},), cache.solver)
     cache.solver[] = STRUMPACKSparseSolver(C_NULL, 0, 0)
     return
 end
@@ -112,7 +118,7 @@ function _ensure_initialized!(cache::STRUMPACKCache, alg::LinearSolve.STRUMPACKF
     argv = isempty(cache.option_ptrs) ? Ptr{Ptr{UInt8}}(C_NULL) : Ptr{Ptr{UInt8}}(pointer(cache.option_ptrs))
 
     ccall(
-        (:STRUMPACK_init_mt, _libstrumpack[]),
+        _strumpack_fptr(:STRUMPACK_init_mt),
         Cvoid,
         (Ref{STRUMPACKSparseSolver}, Cint, Cint, Cint, Ptr{Ptr{UInt8}}, Cint),
         cache.solver,
@@ -219,7 +225,7 @@ function SciMLBase.solve!(
         scache.rowptr, scache.colind, scache.nzval = _csc_to_csr_0based(A)
         nref = Ref{Cint}(Cint(size(A, 1)))
         ccall(
-            (:STRUMPACK_set_csr_matrix, _libstrumpack[]),
+            _strumpack_fptr(:STRUMPACK_set_csr_matrix),
             Cvoid,
             (STRUMPACKSparseSolver, Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cdouble}, Cint),
             scache.solver[],
@@ -230,7 +236,7 @@ function SciMLBase.solve!(
             Cint(0)
         )
 
-        info = ccall((:STRUMPACK_factor, _libstrumpack[]), Cint, (STRUMPACKSparseSolver,), scache.solver[])
+        info = ccall(_strumpack_fptr(:STRUMPACK_factor), Cint, (STRUMPACKSparseSolver,), scache.solver[])
         if info != STRUMPACK_SUCCESS
             @SciMLMessage(
                 "STRUMPACK factorization failed (code $(Int(info)))",
@@ -253,7 +259,7 @@ function SciMLBase.solve!(
     xvec = Float64.(cache.u)
 
     info = ccall(
-        (:STRUMPACK_solve, _libstrumpack[]),
+        _strumpack_fptr(:STRUMPACK_solve),
         Cint,
         (STRUMPACKSparseSolver, Ref{Cdouble}, Ref{Cdouble}, Cint),
         scache.solver[],

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -1514,7 +1514,7 @@ Any unexposed or version-specific knobs can still be passed through `options`.
 
     Using this solver requires:
     1. `using SparseArrays` (to enable sparse matrix support), and
-    2. a system installation of `libstrumpack` discoverable by the dynamic loader.
+    2. loading `STRUMPACK_jll` (for example `import STRUMPACK_jll`).
 """
 struct STRUMPACKFactorization <: AbstractSparseFactorization
     use_initial_guess::Bool
@@ -1540,7 +1540,7 @@ struct STRUMPACKFactorization <: AbstractSparseFactorization
         )
         ext = Base.get_extension(@__MODULE__, :LinearSolveSTRUMPACKExt)
         return if throwerror && (ext === nothing || !ext.strumpack_isavailable())
-            error("STRUMPACKFactorization requires a discoverable STRUMPACK shared library (`libstrumpack`) and `using SparseArrays`")
+            error("STRUMPACKFactorization requires `using SparseArrays` and loading `STRUMPACK_jll` (for example `import STRUMPACK_jll`)")
         else
             rel_tol !== nothing && rel_tol < 0 && error("`rel_tol` must be non-negative")
             abs_tol !== nothing && abs_tol < 0 && error("`abs_tol` must be non-negative")

--- a/test/defaults_loading.jl
+++ b/test/defaults_loading.jl
@@ -31,7 +31,7 @@ prob = LinearProblem(mat, rhs)
 
 STRUMPACKExt = Base.get_extension(LinearSolve, :LinearSolveSTRUMPACKExt)
 if STRUMPACKExt === nothing || !STRUMPACKExt.strumpack_isavailable()
-    @test_throws ["STRUMPACKFactorization", "libstrumpack"] STRUMPACKFactorization()
+    @test_throws ["STRUMPACKFactorization", "STRUMPACK_jll"] STRUMPACKFactorization()
 else
     @test STRUMPACKFactorization() isa STRUMPACKFactorization
 end

--- a/test/strumpack/strumpack.jl
+++ b/test/strumpack/strumpack.jl
@@ -1,4 +1,5 @@
 using LinearSolve, LinearAlgebra, SparseArrays, SciMLBase
+using STRUMPACK_jll
 using Test
 
 @testset "STRUMPACK Factorization" begin
@@ -6,7 +7,7 @@ using Test
     @test ext !== nothing
 
     if ext === nothing || !ext.strumpack_isavailable()
-        @test_throws ["STRUMPACKFactorization", "libstrumpack"] STRUMPACKFactorization()
+        @test_throws ["STRUMPACKFactorization", "STRUMPACK_jll"] STRUMPACKFactorization()
         @test STRUMPACKFactorization(throwerror = false) isa STRUMPACKFactorization
         @test STRUMPACKFactorization(
             throwerror = false,
@@ -45,7 +46,7 @@ using Test
         A = sparse([4.0 1.0; 2.0 3.0])
         b = [1.0, -1.0]
         prob = LinearProblem(A, b)
-        @test_throws ["STRUMPACKFactorization", "libstrumpack"] solve(
+        @test_throws ["STRUMPACKFactorization", "STRUMPACK_jll"] solve(
             prob,
             STRUMPACKFactorization(throwerror = false)
         )


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

- Fixes STRUMPACK FFI handling to match the C API (solver struct/signatures), resolving runtime crashes during factor/solve.
- Gates STRUMPACK extension activation on SparseArrays + STRUMPACK_jll and wires STRUMPACK_jll in test deps.
- Updates STRUMPACK error/help text and solver docs to reflect the JLL-based loading requirement.
- Validated with STRUMPACK, defaults-loading, and core test runs (previously failing segfault path now stable).

closes #953 
