### PR TITLE
Add preconditioning support for LSMR/LSQR/LSLQ/CGLS/CRLS

### DIFF
--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -350,6 +350,8 @@ function SciMLBase.solve!(cache::LinearCache, alg::KrylovJL; kwargs...)
             verbose, :no_right_preconditioning
         )
         Krylov.krylov_solve!(args...; M, kwargs...)
+    elseif cache.cacheval isa Krylov.LsmrWorkspace
+        Krylov.krylov_solve!(args...; M, N, kwargs...)
     else
         Krylov.krylov_solve!(args...; kwargs...)
     end

--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -350,8 +350,18 @@ function SciMLBase.solve!(cache::LinearCache, alg::KrylovJL; kwargs...)
             verbose, :no_right_preconditioning
         )
         Krylov.krylov_solve!(args...; M, kwargs...)
-    elseif cache.cacheval isa Krylov.LsmrWorkspace
+    elseif cache.cacheval isa Krylov.LsmrWorkspace ||
+           cache.cacheval isa Krylov.LsqrWorkspace ||
+           cache.cacheval isa Krylov.LslqWorkspace
         Krylov.krylov_solve!(args...; M, N, kwargs...)
+    elseif cache.cacheval isa Krylov.CglsWorkspace ||
+           cache.cacheval isa Krylov.CrlsWorkspace
+        N !== I &&
+            @SciMLMessage(
+            "$(alg.KrylovAlg) doesn't support right preconditioning.",
+            verbose, :no_right_preconditioning
+        )
+        Krylov.krylov_solve!(args...; M, kwargs...)
     else
         Krylov.krylov_solve!(args...; kwargs...)
     end

--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -351,11 +351,11 @@ function SciMLBase.solve!(cache::LinearCache, alg::KrylovJL; kwargs...)
         )
         Krylov.krylov_solve!(args...; M, kwargs...)
     elseif cache.cacheval isa Krylov.LsmrWorkspace ||
-           cache.cacheval isa Krylov.LsqrWorkspace ||
-           cache.cacheval isa Krylov.LslqWorkspace
+            cache.cacheval isa Krylov.LsqrWorkspace ||
+            cache.cacheval isa Krylov.LslqWorkspace
         Krylov.krylov_solve!(args...; M, N, kwargs...)
     elseif cache.cacheval isa Krylov.CglsWorkspace ||
-           cache.cacheval isa Krylov.CrlsWorkspace
+            cache.cacheval isa Krylov.CrlsWorkspace
         N !== I &&
             @SciMLMessage(
             "$(alg.KrylovAlg) doesn't support right preconditioning.",

--- a/test/nonsquare.jl
+++ b/test/nonsquare.jl
@@ -116,10 +116,7 @@ function LinearAlgebra.ldiv!(P::CountingDiagPrec, x::AbstractVector)
     return x
 end
 
-# Per-algorithm expectations:
-# - LSMR, LSQR, LSLQ: Krylov supports M and N; LinearSolve forwards both.
-# - CGLS, CRLS: Krylov supports only M; LinearSolve forwards M and warns on non-identity N.
-#   No assertion on Pr.calls since these solvers do not accept a right preconditioner.
+
 @testset "LS family preconditioning" begin
     m, n = 30, 10
     A = randn(m, n)

--- a/test/nonsquare.jl
+++ b/test/nonsquare.jl
@@ -124,7 +124,7 @@ end
     res = A \ b
 
     ls_algs = [
-        (KrylovJL_LSMR(),                    "LSMR", :both),
+        (KrylovJL_LSMR(), "LSMR", :both),
         (KrylovJL(KrylovAlg = Krylov.lsqr!), "LSQR", :both),
         (KrylovJL(KrylovAlg = Krylov.lslq!), "LSLQ", :both),
         (KrylovJL(KrylovAlg = Krylov.cgls!), "CGLS", :left_only),

--- a/test/nonsquare.jl
+++ b/test/nonsquare.jl
@@ -94,3 +94,38 @@ b = rand(m)
 prob = LinearProblem(A, b)
 res = A \ b
 @test solve(prob).u ≈ res
+
+# LSMR with preconditioning: identity-equivalent counting preconditioner
+# verifies Pl/Pr are actually forwarded to Krylov.lsmr! (and not silently dropped).
+mutable struct CountingDiagPrec
+    d::Vector{Float64}
+    calls::Int
+end
+CountingDiagPrec(d::AbstractVector) = CountingDiagPrec(collect(Float64, d), 0)
+Base.size(P::CountingDiagPrec) = (length(P.d), length(P.d))
+Base.size(P::CountingDiagPrec, ::Integer) = length(P.d)
+Base.eltype(::CountingDiagPrec) = Float64
+function LinearAlgebra.ldiv!(y::AbstractVector, P::CountingDiagPrec, x::AbstractVector)
+    P.calls += 1
+    @. y = x / P.d
+    return y
+end
+function LinearAlgebra.ldiv!(P::CountingDiagPrec, x::AbstractVector)
+    P.calls += 1
+    @. x = x / P.d
+    return x
+end
+
+@testset "LSMR preconditioning" begin
+    m, n = 30, 10
+    A = randn(m, n)
+    b = randn(m)
+    res = A \ b
+
+    Pl = CountingDiagPrec(ones(m))
+    Pr = CountingDiagPrec(ones(n))
+    sol = solve(LinearProblem(A, b), KrylovJL_LSMR(); Pl = Pl, Pr = Pr)
+    @test sol.u ≈ res
+    @test Pl.calls > 0
+    @test Pr.calls > 0
+end

--- a/test/nonsquare.jl
+++ b/test/nonsquare.jl
@@ -117,9 +117,8 @@ function LinearAlgebra.ldiv!(P::CountingDiagPrec, x::AbstractVector)
 end
 
 # Per-algorithm expectations:
-# - LSMR: Krylov supports M and N; LinearSolve forwards both (fixed in this PR).
-# - LSQR, LSLQ: Krylov supports M and N; LinearSolve currently drops both -> @test_broken.
-# - CGLS, CRLS: Krylov supports only M; LinearSolve currently drops it -> @test_broken on Pl.
+# - LSMR, LSQR, LSLQ: Krylov supports M and N; LinearSolve forwards both.
+# - CGLS, CRLS: Krylov supports only M; LinearSolve forwards M and warns on non-identity N.
 #   No assertion on Pr.calls since these solvers do not accept a right preconditioner.
 @testset "LS family preconditioning" begin
     m, n = 30, 10
@@ -128,25 +127,21 @@ end
     res = A \ b
 
     ls_algs = [
-        (KrylovJL_LSMR(),                    "LSMR", :working, :working),
-        (KrylovJL(KrylovAlg = Krylov.lsqr!), "LSQR", :broken,  :broken),
-        (KrylovJL(KrylovAlg = Krylov.lslq!), "LSLQ", :broken,  :broken),
-        (KrylovJL(KrylovAlg = Krylov.cgls!), "CGLS", :broken,  :unsupported),
-        (KrylovJL(KrylovAlg = Krylov.crls!), "CRLS", :broken,  :unsupported),
+        (KrylovJL_LSMR(),                    "LSMR", :both),
+        (KrylovJL(KrylovAlg = Krylov.lsqr!), "LSQR", :both),
+        (KrylovJL(KrylovAlg = Krylov.lslq!), "LSLQ", :both),
+        (KrylovJL(KrylovAlg = Krylov.cgls!), "CGLS", :left_only),
+        (KrylovJL(KrylovAlg = Krylov.crls!), "CRLS", :left_only),
     ]
 
-    for (alg, name, pl_status, pr_status) in ls_algs
+    for (alg, name, support) in ls_algs
         @testset "$name" begin
             Pl = CountingDiagPrec(ones(m))
             Pr = CountingDiagPrec(ones(n))
             sol = solve(LinearProblem(A, b), alg; Pl = Pl, Pr = Pr)
             @test sol.u ≈ res
-            pl_status === :working ? (@test Pl.calls > 0) : (@test_broken Pl.calls > 0)
-            if pr_status === :working
-                @test Pr.calls > 0
-            elseif pr_status === :broken
-                @test_broken Pr.calls > 0
-            end
+            @test Pl.calls > 0
+            support === :both && @test Pr.calls > 0
         end
     end
 end

--- a/test/nonsquare.jl
+++ b/test/nonsquare.jl
@@ -95,8 +95,8 @@ prob = LinearProblem(A, b)
 res = A \ b
 @test solve(prob).u ≈ res
 
-# LSMR with preconditioning: identity-equivalent counting preconditioner
-# verifies Pl/Pr are actually forwarded to Krylov.lsmr! (and not silently dropped).
+# Least-squares Krylov solvers with preconditioning: identity-equivalent counting
+# preconditioner verifies Pl/Pr are actually forwarded to Krylov (not silently dropped).
 mutable struct CountingDiagPrec
     d::Vector{Float64}
     calls::Int
@@ -116,16 +116,37 @@ function LinearAlgebra.ldiv!(P::CountingDiagPrec, x::AbstractVector)
     return x
 end
 
-@testset "LSMR preconditioning" begin
+# Per-algorithm expectations:
+# - LSMR: Krylov supports M and N; LinearSolve forwards both (fixed in this PR).
+# - LSQR, LSLQ: Krylov supports M and N; LinearSolve currently drops both -> @test_broken.
+# - CGLS, CRLS: Krylov supports only M; LinearSolve currently drops it -> @test_broken on Pl.
+#   No assertion on Pr.calls since these solvers do not accept a right preconditioner.
+@testset "LS family preconditioning" begin
     m, n = 30, 10
     A = randn(m, n)
     b = randn(m)
     res = A \ b
 
-    Pl = CountingDiagPrec(ones(m))
-    Pr = CountingDiagPrec(ones(n))
-    sol = solve(LinearProblem(A, b), KrylovJL_LSMR(); Pl = Pl, Pr = Pr)
-    @test sol.u ≈ res
-    @test Pl.calls > 0
-    @test Pr.calls > 0
+    ls_algs = [
+        (KrylovJL_LSMR(),                    "LSMR", :working, :working),
+        (KrylovJL(KrylovAlg = Krylov.lsqr!), "LSQR", :broken,  :broken),
+        (KrylovJL(KrylovAlg = Krylov.lslq!), "LSLQ", :broken,  :broken),
+        (KrylovJL(KrylovAlg = Krylov.cgls!), "CGLS", :broken,  :unsupported),
+        (KrylovJL(KrylovAlg = Krylov.crls!), "CRLS", :broken,  :unsupported),
+    ]
+
+    for (alg, name, pl_status, pr_status) in ls_algs
+        @testset "$name" begin
+            Pl = CountingDiagPrec(ones(m))
+            Pr = CountingDiagPrec(ones(n))
+            sol = solve(LinearProblem(A, b), alg; Pl = Pl, Pr = Pr)
+            @test sol.u ≈ res
+            pl_status === :working ? (@test Pl.calls > 0) : (@test_broken Pl.calls > 0)
+            if pr_status === :working
+                @test Pr.calls > 0
+            elseif pr_status === :broken
+                @test_broken Pr.calls > 0
+            end
+        end
+    end
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I ran into this when using LSMR. Making this PR was faster than writing a thorough issue as this seems like an obvious fix, but **I have not yet thoroughly tested this yet!** If more examples and tests are wanted I can turn this into a proper PR by the end of next week.

I could also imagine that the same issue holds for other methods too but I also didn't carefully check this yet.

EDIT: I added tests and extended the contribution to the other least-squares methods.