### PR TITLE
PETSc: complete GSoC weeks 1–4 for multi-rank SparseMatrixCSC support

### DIFF
--- a/ext/LinearSolvePETScExt.jl
+++ b/ext/LinearSolvePETScExt.jl
@@ -580,31 +580,27 @@ function run_ksp!(pcache, petsclib, alg, b::AbstractVector, u::AbstractVector)
     end
 end
 
-function run_ksp_mpi!(pcache, petsclib, alg, b::AbstractVector, u::AbstractVector)
-    petsc_x = pcache.petsc_x
-    petsc_b = pcache.petsc_b
-    local_range = (pcache.rstart + 1):pcache.rend
-
-    local_b = LibPETSc.VecGetArray(petsclib, petsc_b)
+function copyto_local_petsc_vec!(petsclib, petsc_vec, values::AbstractVector)
+    local_values = LibPETSc.VecGetArray(petsclib, petsc_vec)
     try
-        copyto!(local_b, view(b, local_range))
+        copyto!(local_values, values)
     finally
-        LibPETSc.VecRestoreArray(petsclib, petsc_b, local_b)
+        LibPETSc.VecRestoreArray(petsclib, petsc_vec, local_values)
     end
+    return nothing
+end
 
-    local_x = LibPETSc.VecGetArray(petsclib, petsc_x)
+function copyfrom_local_petsc_vec!(dest::AbstractVector, petsclib, petsc_vec)
+    local_values = LibPETSc.VecGetArray(petsclib, petsc_vec)
     try
-        copyto!(local_x, view(u, local_range))
+        copyto!(dest, local_values)
     finally
-        LibPETSc.VecRestoreArray(petsclib, petsc_x, local_x)
+        LibPETSc.VecRestoreArray(petsclib, petsc_vec, local_values)
     end
+    return nothing
+end
 
-    if alg.transposed
-        LibPETSc.KSPSolveTranspose(petsclib, pcache.ksp, petsc_b, petsc_x)
-    else
-        LibPETSc.KSPSolve(petsclib, pcache.ksp, petsc_b, petsc_x)
-    end
-
+function gather_petsc_vec_to_all!(u::AbstractVector, petsclib, petsc_x)
     scatter, gathered_x = LibPETSc.VecScatterCreateToAll(petsclib, petsc_x)
     try
         LibPETSc.VecScatterBegin(
@@ -615,18 +611,29 @@ function run_ksp_mpi!(pcache, petsclib, alg, b::AbstractVector, u::AbstractVecto
             petsclib, scatter, petsc_x, gathered_x,
             LibPETSc.INSERT_VALUES, LibPETSc.SCATTER_FORWARD
         )
-
-        gathered = LibPETSc.VecGetArray(petsclib, gathered_x)
-        try
-            copyto!(u, gathered)
-        finally
-            LibPETSc.VecRestoreArray(petsclib, gathered_x, gathered)
-        end
+        copyfrom_local_petsc_vec!(u, petsclib, gathered_x)
     finally
         LibPETSc.VecScatterDestroy(petsclib, scatter)
         PETSc.destroy(gathered_x)
     end
+    return nothing
+end
 
+function run_ksp_mpi!(pcache, petsclib, alg, b::AbstractVector, u::AbstractVector)
+    petsc_x = pcache.petsc_x
+    petsc_b = pcache.petsc_b
+    local_range = (pcache.rstart + 1):pcache.rend
+
+    copyto_local_petsc_vec!(petsclib, petsc_b, view(b, local_range))
+    copyto_local_petsc_vec!(petsclib, petsc_x, view(u, local_range))
+
+    if alg.transposed
+        LibPETSc.KSPSolveTranspose(petsclib, pcache.ksp, petsc_b, petsc_x)
+    else
+        LibPETSc.KSPSolve(petsclib, pcache.ksp, petsc_b, petsc_x)
+    end
+
+    gather_petsc_vec_to_all!(u, petsclib, petsc_x)
     return nothing
 end
 
@@ -800,7 +807,13 @@ function SciMLBase.solve!(cache::LinearCache, alg::PETScAlgorithm; kwargs...)
     # vector type so that MPI extensions can create distributed Vecs.
     # run_ksp! performs I/O + KSPSolve, also dispatching on vector type.
     ensure_vecs!(pcache, petsclib, comm, cache.b)
-    run_ksp!(pcache, petsclib, alg, cache.b, cache.u)
+    try
+        run_ksp!(pcache, petsclib, alg, cache.b, cache.u)
+    catch
+        return build_linear_solution(
+            alg, cache.u, nothing, cache; retcode = ReturnCode.Failure
+        )
+    end
 
     # ── Convergence metadata ──────────────────────────────────────────────────
     iters = Int(LibPETSc.KSPGetIterationNumber(petsclib, pcache.ksp))

--- a/ext/LinearSolvePETScExt.jl
+++ b/ext/LinearSolvePETScExt.jl
@@ -619,6 +619,15 @@ function gather_petsc_vec_to_all!(u::AbstractVector, petsclib, petsc_x)
     return nothing
 end
 
+function postsolve_solution_check(cache, alg, pcache, A::AbstractMatrix, u::AbstractVector)
+    if pcache.comm == MPI.COMM_SELF || A isa SparseMatrixCSC
+        return LinearSolve._check_residual_safety(cache, alg, A, u)
+    end
+    return nothing
+end
+
+postsolve_solution_check(cache, alg, pcache, A, u) = nothing
+
 function run_ksp_mpi!(pcache, petsclib, alg, b::AbstractVector, u::AbstractVector)
     petsc_x = pcache.petsc_x
     petsc_b = pcache.petsc_b
@@ -820,9 +829,8 @@ function SciMLBase.solve!(cache::LinearCache, alg::PETScAlgorithm; kwargs...)
     if retcode === ReturnCode.Success && any(!isfinite, cache.u)
         retcode = ReturnCode.Failure
     end
-    if retcode === ReturnCode.Success &&
-            (pcache.comm == MPI.COMM_SELF || cache.A isa SparseMatrixCSC)
-        failed = LinearSolve._check_residual_safety(cache, alg, cache.A, cache.u)
+    if retcode === ReturnCode.Success
+        failed = postsolve_solution_check(cache, alg, pcache, cache.A, cache.u)
         failed !== nothing && return failed
     end
 

--- a/ext/LinearSolvePETScExt.jl
+++ b/ext/LinearSolvePETScExt.jl
@@ -540,8 +540,12 @@ function ensure_vecs!(pcache, petsclib, comm, b)
     if pcache.vec_n != n || pcache.petsc_x === nothing || pcache.petsc_b === nothing
         pcache.petsc_x !== nothing && PETSc.destroy(pcache.petsc_x)
         pcache.petsc_b !== nothing && PETSc.destroy(pcache.petsc_b)
-        pcache.petsc_x = create_seq_vec(petsclib, n)
-        pcache.petsc_b = create_seq_vec(petsclib, n)
+        if comm == MPI.COMM_SELF
+            pcache.petsc_x = create_seq_vec(petsclib, n)
+            pcache.petsc_b = create_seq_vec(petsclib, n)
+        else
+            pcache.petsc_x, pcache.petsc_b = LibPETSc.MatCreateVecs(petsclib, pcache.petsc_A)
+        end
         pcache.vec_n = n
     end
     return pcache.petsc_x, pcache.petsc_b
@@ -551,12 +555,12 @@ end
 #
 # run_ksp! abstracts the VecPlaceArray / KSPSolve / VecResetArray pattern.
 # For serial AbstractVector: zero-copy via VecPlaceArray.
+# For replicated Julia vectors on a multi-rank communicator: copy the owned
+# rows into a distributed PETSc Vec, solve, then gather the full solution back
+# onto every rank with VecScatterCreateToAll.
 # Overloaded by LinearSolvePETScMPIExt for PVector (uses VecGetArray copy path).
 function run_ksp!(pcache, petsclib, alg, b::AbstractVector, u::AbstractVector)
-    pcache.comm != MPI.COMM_SELF && error(
-        "PETSc multi-rank SparseMatrixCSC support currently stops at matrix assembly. " *
-            "Distributed RHS/solution handling for standard Julia vectors is planned for later work."
-    )
+    pcache.comm != MPI.COMM_SELF && return run_ksp_mpi!(pcache, petsclib, alg, b, u)
 
     petsc_x = pcache.petsc_x
     petsc_b = pcache.petsc_b
@@ -574,6 +578,56 @@ function run_ksp!(pcache, petsclib, alg, b::AbstractVector, u::AbstractVector)
         LibPETSc.VecResetArray(petsclib, petsc_x)
         LibPETSc.VecResetArray(petsclib, petsc_b)
     end
+end
+
+function run_ksp_mpi!(pcache, petsclib, alg, b::AbstractVector, u::AbstractVector)
+    petsc_x = pcache.petsc_x
+    petsc_b = pcache.petsc_b
+    local_range = (pcache.rstart + 1):pcache.rend
+
+    local_b = LibPETSc.VecGetArray(petsclib, petsc_b)
+    try
+        copyto!(local_b, view(b, local_range))
+    finally
+        LibPETSc.VecRestoreArray(petsclib, petsc_b, local_b)
+    end
+
+    local_x = LibPETSc.VecGetArray(petsclib, petsc_x)
+    try
+        copyto!(local_x, view(u, local_range))
+    finally
+        LibPETSc.VecRestoreArray(petsclib, petsc_x, local_x)
+    end
+
+    if alg.transposed
+        LibPETSc.KSPSolveTranspose(petsclib, pcache.ksp, petsc_b, petsc_x)
+    else
+        LibPETSc.KSPSolve(petsclib, pcache.ksp, petsc_b, petsc_x)
+    end
+
+    scatter, gathered_x = LibPETSc.VecScatterCreateToAll(petsclib, petsc_x)
+    try
+        LibPETSc.VecScatterBegin(
+            petsclib, scatter, petsc_x, gathered_x,
+            LibPETSc.INSERT_VALUES, LibPETSc.SCATTER_FORWARD
+        )
+        LibPETSc.VecScatterEnd(
+            petsclib, scatter, petsc_x, gathered_x,
+            LibPETSc.INSERT_VALUES, LibPETSc.SCATTER_FORWARD
+        )
+
+        gathered = LibPETSc.VecGetArray(petsclib, gathered_x)
+        try
+            copyto!(u, gathered)
+        finally
+            LibPETSc.VecRestoreArray(petsclib, gathered_x, gathered)
+        end
+    finally
+        LibPETSc.VecScatterDestroy(petsclib, scatter)
+        PETSc.destroy(gathered_x)
+    end
+
+    return nothing
 end
 
 # ── Null space ────────────────────────────────────────────────────────────────

--- a/ext/LinearSolvePETScExt.jl
+++ b/ext/LinearSolvePETScExt.jl
@@ -807,13 +807,7 @@ function SciMLBase.solve!(cache::LinearCache, alg::PETScAlgorithm; kwargs...)
     # vector type so that MPI extensions can create distributed Vecs.
     # run_ksp! performs I/O + KSPSolve, also dispatching on vector type.
     ensure_vecs!(pcache, petsclib, comm, cache.b)
-    try
-        run_ksp!(pcache, petsclib, alg, cache.b, cache.u)
-    catch
-        return build_linear_solution(
-            alg, cache.u, nothing, cache; retcode = ReturnCode.Failure
-        )
-    end
+    run_ksp!(pcache, petsclib, alg, cache.b, cache.u)
 
     # ── Convergence metadata ──────────────────────────────────────────────────
     iters = Int(LibPETSc.KSPGetIterationNumber(petsclib, pcache.ksp))
@@ -823,6 +817,14 @@ function SciMLBase.solve!(cache::LinearCache, alg::PETScAlgorithm; kwargs...)
     # reason < 0 → diverged or other failure.
     retcode = reason > 0 ? ReturnCode.Success :
         reason == 0 ? ReturnCode.Default : ReturnCode.Failure
+    if retcode === ReturnCode.Success && any(!isfinite, cache.u)
+        retcode = ReturnCode.Failure
+    end
+    if retcode === ReturnCode.Success &&
+            (pcache.comm == MPI.COMM_SELF || cache.A isa SparseMatrixCSC)
+        failed = LinearSolve._check_residual_safety(cache, alg, cache.A, cache.u)
+        failed !== nothing && return failed
+    end
 
     return build_linear_solution(alg, cache.u, resid, cache; retcode, iters)
 end

--- a/ext/LinearSolvePETScMPIExt.jl
+++ b/ext/LinearSolvePETScMPIExt.jl
@@ -24,14 +24,17 @@ module LinearSolvePETScMPIExt
 using PartitionedArrays: PartitionedArrays, PSparseMatrix, PVector,
     MPIArray, DebugArray, partition,
     own_length, ghost_length,
-    own_to_local, local_to_global, own_to_global, ghost_to_global
+    own_to_local, local_to_global, own_to_global, ghost_to_global,
+    consistent, own_values
 
 using SparseMatricesCSR: SparseMatrixCSR, getrowptr, getcolval
+using LinearAlgebra
 
 using PETSc
 import PETSc: MPI, LibPETSc
 
 using LinearSolve: PETScAlgorithm, LinearSolve
+using SciMLBase: ReturnCode, SciMLBase
 
 const PETScExt = Base.get_extension(LinearSolve, :LinearSolvePETScExt)
 
@@ -336,25 +339,56 @@ function PETScExt.run_ksp!(pcache, petsclib, alg, b::PVector, u::PVector)
     petsc_x = LibPETSc.VecCreateGhostWithArray(
         petsclib, comm, n_own, N, n_ghost, ghosts, arr_u
     )
-
-    if alg.transposed
-        LibPETSc.KSPSolveTranspose(petsclib, pcache.ksp, petsc_b, petsc_x)
-    else
-        LibPETSc.KSPSolve(petsclib, pcache.ksp, petsc_b, petsc_x)
-    end
-
-    # When arr_u === local_u, PETSc wrote the solution directly into the
-    # PVector's owned slots — nothing to copy back.
-    # If a type-conversion buffer was used, copy the owned DOFs back manually.
-    if arr_u !== local_u
-        own_idxs = own_to_local(row_idx)
-        @inbounds for (i, j) in enumerate(own_idxs)
-            local_u[j] = arr_u[i]
+    try
+        if alg.transposed
+            LibPETSc.KSPSolveTranspose(petsclib, pcache.ksp, petsc_b, petsc_x)
+        else
+            LibPETSc.KSPSolve(petsclib, pcache.ksp, petsc_b, petsc_x)
         end
+
+        # When arr_u === local_u, PETSc wrote the solution directly into the
+        # PVector's owned slots — nothing to copy back.
+        # If a type-conversion buffer was used, copy the owned DOFs back manually.
+        if arr_u !== local_u
+            own_idxs = own_to_local(row_idx)
+            @inbounds for (i, j) in enumerate(own_idxs)
+                local_u[j] = arr_u[i]
+            end
+        end
+    finally
+        PETSc.destroy(petsc_x)
+        PETSc.destroy(petsc_b)
+    end
+    return nothing
+end
+
+function PETScExt.postsolve_solution_check(cache, alg, pcache, A::PSparseMatrix, u::PVector)
+    u_consistent = consistent(u, partition(axes(A, 2))) |> fetch
+    Au = similar(u_consistent, axes(A, 1))
+    LinearAlgebra.mul!(Au, A, u_consistent)
+
+    local_Au = _local_part(own_values(Au))
+    local_b = _local_part(own_values(cache.b))
+    local_resid_sq = zero(typeof(abs2(zero(eltype(local_Au)))))
+    local_b_sq = zero(typeof(abs2(zero(eltype(local_b)))))
+    @inbounds for i in eachindex(local_Au, local_b)
+        local_resid_sq += abs2(local_Au[i] - local_b[i])
+        local_b_sq += abs2(local_b[i])
     end
 
-    PETSc.destroy(petsc_x)
-    PETSc.destroy(petsc_b)
+    data = pcache.mpi_data
+    comm = data === nothing ? MPI.COMM_SELF : data.comm
+    resid_sq = MPI.Allreduce(local_resid_sq, +, comm)
+    b_sq = MPI.Allreduce(local_b_sq, +, comm)
+    res_norm = sqrt(resid_sq)
+    b_norm = sqrt(b_sq)
+    tol = cache.abstol + cache.reltol * b_norm
+
+    if res_norm > tol
+        return SciMLBase.build_linear_solution(
+            alg, u, nothing, cache; retcode = ReturnCode.APosterioriSafetyFailure
+        )
+    end
     return nothing
 end
 

--- a/test/petsctests.jl
+++ b/test/petsctests.jl
@@ -222,6 +222,26 @@ end
     end
 end
 
+@testset "Serial: Retcode Handling" begin
+    n = 100
+    A = sprand(n, n, 0.05) + 10I
+    A = A'A
+    b = rand(n)
+
+    sol = solve(
+        LinearProblem(A, b),
+        PETScAlgorithm(:cg);
+        abstol = 1.0e-16,
+        reltol = 1.0e-16,
+        maxiters = 1
+    )
+
+    @test sol.retcode == SciMLBase.ReturnCode.Failure
+    @test sol.iters == 1
+    @test norm(A * sol.u - b) / norm(b) > sol.cache.reltol
+    PETScExt.cleanup_petsc_cache!(sol)
+end
+
 @testset "Serial: Cleanup" begin
     n = 50
     A = sprand(n, n, 0.1) + 10I; A = A'A; b = rand(n)

--- a/test/petsctests_mpi.jl
+++ b/test/petsctests_mpi.jl
@@ -44,6 +44,7 @@ end
     n = 12
     A = spdiagm(-1 => -ones(n - 1), 0 => 4.0 .* ones(n), 1 => -ones(n - 1))
     b = ones(n)
+    x_ref = A \ b
 
     function init_replicated_cache(; prec_matrix = nothing)
         alg = PETScAlgorithm(:gmres; comm = MPI.COMM_WORLD, pc_type = :jacobi, prec_matrix)
@@ -92,24 +93,43 @@ end
         PETScExt.cleanup_petsc_cache!(cache)
     end
 
-    @testset "solve path stays guarded until week 3-4" begin
+    @testset "basic 2-rank GMRES solve replicates full solution" begin
+        sol = solve(
+            LinearProblem(A, b),
+            PETScAlgorithm(:gmres; comm = MPI.COMM_WORLD);
+            abstol = 1.0e-10,
+            reltol = 1.0e-10
+        )
+        pcache = sol.cache.cacheval
+
+        @test sol.retcode == SciMLBase.ReturnCode.Success
+        @test norm(A * sol.u - b) / norm(b) < 1.0e-10
+        @test sol.u ≈ x_ref atol = 1.0e-10
+        @test pcache.rstart >= 0
+        @test pcache.rend >= pcache.rstart
+        PETScExt.cleanup_petsc_cache!(sol)
+    end
+
+    @testset "cache reuse with new rhs preserves full-solution contract" begin
         cache = SciMLBase.init(
             LinearProblem(A, b),
             PETScAlgorithm(:gmres; comm = MPI.COMM_WORLD);
             abstol = 1.0e-10,
             reltol = 1.0e-10
         )
-        err = try
-            solve!(cache)
-            nothing
-        catch e
-            e
-        finally
-            PETScExt.cleanup_petsc_cache!(cache)
-        end
+        sol1 = solve!(cache)
+        @test sol1.retcode == SciMLBase.ReturnCode.Success
+        @test sol1.u ≈ x_ref atol = 1.0e-10
 
-        @test err isa ErrorException
-        @test occursin("matrix assembly", sprint(showerror, err))
+        b2 = collect(1.0:n)
+        x_ref2 = A \ b2
+        cache.b = b2
+        sol2 = solve!(cache)
+
+        @test sol2.retcode == SciMLBase.ReturnCode.Success
+        @test norm(A * sol2.u - b2) / norm(b2) < 1.0e-10
+        @test sol2.u ≈ x_ref2 atol = 1.0e-10
+        PETScExt.cleanup_petsc_cache!(cache)
     end
 end
 

--- a/test/petsctests_mpi.jl
+++ b/test/petsctests_mpi.jl
@@ -284,6 +284,67 @@ end
     end
 end
 
+@testset "PSparseMatrix SplitMatrix: maxiters failure sets retcode" begin
+    n = 12
+    with_mpi() do distribute
+        rp = mpi_row_partition(distribute, n)
+
+        I_v, J_v, V_v = map(rp) do rng
+            Is, Js, Vs = Int[], Int[], Float64[]
+            for i in rng
+                push!(Is, i); push!(Js, i); push!(Vs, 4.0)
+                i > 1 && (push!(Is, i); push!(Js, i - 1); push!(Vs, -1.0))
+                i < n && (push!(Is, i); push!(Js, i + 1); push!(Vs, -1.0))
+            end
+            Is, Js, Vs
+        end |> tuple_of_arrays
+        A = psparse(I_v, J_v, V_v, rp, rp) |> fetch
+        b = PVector(map(rng -> ones(length(rng)), rp), rp)
+        u = PVector(map(rng -> zeros(length(rng)), rp), rp)
+
+        sol = solve(
+            LinearProblem(A, b; u0 = u),
+            PETScAlgorithm(:gmres);
+            abstol = 1.0e-16,
+            reltol = 1.0e-16,
+            maxiters = 1
+        )
+        @test sol.retcode == SciMLBase.ReturnCode.Failure
+        @test sol.iters == 1
+        PETScExt.cleanup_petsc_cache!(sol)
+    end
+end
+
+@testset "PSparseMatrix SplitMatrix: residual safety failure" begin
+    n = 12
+    with_mpi() do distribute
+        rp = mpi_row_partition(distribute, n)
+
+        I_v, J_v, V_v = map(rp) do rng
+            Is, Js, Vs = Int[], Int[], Float64[]
+            for i in rng
+                push!(Is, i); push!(Js, i); push!(Vs, 4.0)
+                i > 1 && (push!(Is, i); push!(Js, i - 1); push!(Vs, -1.0))
+                i < n && (push!(Is, i); push!(Js, i + 1); push!(Vs, -1.0))
+            end
+            Is, Js, Vs
+        end |> tuple_of_arrays
+        A = psparse(I_v, J_v, V_v, rp, rp) |> fetch
+        b = PVector(map(rng -> ones(length(rng)), rp), rp)
+        u = PVector(map(rng -> zeros(length(rng)), rp), rp)
+
+        sol = solve(
+            LinearProblem(A, b; u0 = u),
+            PETScAlgorithm(:gmres; ksp_options = (ksp_rtol = 0.9,));
+            abstol = 0.0,
+            reltol = 1.0e-12,
+            maxiters = 100
+        )
+        @test sol.retcode == SciMLBase.ReturnCode.APosterioriSafetyFailure
+        PETScExt.cleanup_petsc_cache!(sol)
+    end
+end
+
 @testset "PSparseMatrix SplitMatrix: reinit! (Case 2 — pattern change)" begin
     # Case 2: sparsity pattern changes between solves → KSP must be rebuilt.
     n = 8

--- a/test/petsctests_mpi.jl
+++ b/test/petsctests_mpi.jl
@@ -131,6 +131,21 @@ end
         @test sol2.u ≈ x_ref2 atol = 1.0e-10
         PETScExt.cleanup_petsc_cache!(cache)
     end
+
+    @testset "maxiters failure sets retcode" begin
+        sol = solve(
+            LinearProblem(A, b),
+            PETScAlgorithm(:gmres; comm = MPI.COMM_WORLD);
+            abstol = 1.0e-16,
+            reltol = 1.0e-16,
+            maxiters = 1
+        )
+
+        @test sol.retcode == SciMLBase.ReturnCode.Failure
+        @test sol.iters == 1
+        @test norm(A * sol.u - b) / norm(b) > sol.cache.reltol
+        PETScExt.cleanup_petsc_cache!(sol)
+    end
 end
 
 # ── Helper: uniform_partition over MPI.COMM_WORLD ────────────────────────────


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This PR completes the GSoC proposal weeks 1–4 PETSc deliverable for plain `SparseMatrixCSC` inputs on a multi-rank communicator.

Included in this PR:
- extend `PETScCache` with `rstart` and `rend`, initialized to `-1`
- remove the serial-only communicator guard for standard Julia matrices
- add a row-owned MPI AIJ assembly path for replicated `SparseMatrixCSC` inputs
- create matrix-compatible distributed PETSc vectors for this path with `MatCreateVecs`
- copy each rank's owned RHS slice into PETSc before `KSPSolve`
- gather the full PETSc solution back onto every rank with `VecScatterCreateToAll`
- keep the existing `PSparseMatrix` / `PVector` PETSc MPI path working
- add MPI tests covering ownership, assembly, basic distributed solve, and repeated solve with a new RHS
- revert unrelated HYPRE and PartitionedSolvers scaffolding changes from this branch
- update the GSoC progress report to reflect the current implementation state

AI Disclosure: Used Codex 5.3 to  get review of my code, write test and PR description in markdown.
