### PR TITLE
ci: disable coverage on self-hosted runners to fix master Tests

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -76,4 +76,11 @@ jobs:
       group: "${{ matrix.group }}"
       julia-version: "${{ matrix.version }}"
       self-hosted: ${{ matrix.group != 'Trim' }}
+      # Coverage processing requires the General registry, which is not
+      # reliably available on the self-hosted runners (the
+      # `julia-processcoverage` action creates a temp env and tries to
+      # `Pkg.add("CoverageTools")`, which fails when the registry is missing).
+      # Restrict coverage to the github-hosted Trim job, which is also the
+      # only run where the codecov upload step is reachable in practice.
+      coverage: ${{ matrix.group == 'Trim' }}
     secrets: "inherit"


### PR DESCRIPTION
**Please ignore this PR until reviewed by @ChrisRackauckas.**

## Summary

The `Tests` workflow has been red on `main` since run [25311044931](https://github.com/SciML/LinearSolve.jl/actions/runs/25311044931) (2026-05-04). The single failing job was `Tests (1, x64, LinearSolveAutotune, ubuntu-latest)`, which failed inside `julia-actions/julia-processcoverage@v1` with:

```
registry `General=23338594-aafe-5451-b93e-139f81909106` not found.
   Resolving package versions...
ERROR: LoadError: expected package `CoverageTools [c36e975a]` to be registered
```

## Root cause

`julia-processcoverage` activates a fresh temp env (`coveragetempenv`) and runs `Pkg.add("CoverageTools")`. On the self-hosted runner `demeter3-19`, the General registry was missing/desynced in the depot used by that temp env, so the resolver could not find `CoverageTools`. The `CoverageTools` package itself is fine and registered — the failure is purely a local registry-state issue on one self-hosted runner. (Other self-hosted runners e.g. `demeter3-10` ran the same step successfully in the same workflow run.)

## Fix

Restrict `coverage: true` to the `Trim` group in `.github/workflows/Tests.yml`. Trim is the only matrix entry that runs on a github-hosted runner, and looking at the reusable [`SciML/.github/.github/workflows/tests.yml@v1`](https://github.com/SciML/.github/blob/v1/.github/workflows/tests.yml), the codecov upload step is gated on `pull_request.head.repo.full_name == github.repository`, so on `push` events to `main` the codecov upload never runs anyway — meaning `julia-processcoverage` was wasted work that just gave the self-hosted depot another way to break the workflow. Now coverage is collected and uploaded on Trim only, where it actually has a chance of being useful.

This is a minimal, targeted fix; the underlying broken depot state on `demeter3-19` should be cleaned up separately, but that is out of scope for a code-side patch.

## Test plan

- [ ] CI on this PR (push to fork triggers `Tests` via the `pull_request` trigger).
- [ ] Confirm no self-hosted matrix entry runs `julia-processcoverage` after this change.
- [ ] After merge, confirm the next `push` run on `main` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)