### PR TITLE
Guard partial_vals! against nothing slots in DualLinearCache setters

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -468,9 +468,11 @@ function setA!(dc::DualLinearCache, A)
     prop = nodual_value!(getproperty(dc.linear_cache, :A), A) # Update in-place
     setproperty!(dc.linear_cache, :A, prop) # Does additional invalidation logic etc.
 
-    # Update partials
+    # Update partials (skip when there is no partials slot, e.g. when the
+    # cache was built with a non-Dual A and is now being reused.)
     setfield!(dc, :dual_A, A)
-    partial_vals!(getfield(dc, :partials_A), A) # Update in-place
+    pA = getfield(dc, :partials_A)
+    pA === nothing || partial_vals!(pA, A)
 
     # Invalidate cache (if setting A or b)
     return setfield!(dc, :rhs_cache_valid, false)
@@ -480,9 +482,11 @@ function setb!(dc::DualLinearCache, b)
     prop = nodual_value!(getproperty(dc.linear_cache, :b), b) # Update in-place
     setproperty!(dc.linear_cache, :b, prop) # Does additional invalidation logic etc.
 
-    # Update partials
+    # Update partials (skip when there is no partials slot, e.g. when the
+    # cache was built with a non-Dual b and is now being reused.)
     setfield!(dc, :dual_b, b)
-    partial_vals!(getfield(dc, :partials_b), b) # Update in-place
+    pb = getfield(dc, :partials_b)
+    pb === nothing || partial_vals!(pb, b)
 
     # Invalidate cache (if setting A or b)
     return setfield!(dc, :rhs_cache_valid, false)
@@ -492,9 +496,12 @@ function setu!(dc::DualLinearCache, u)
     prop = nodual_value!(getproperty(dc.linear_cache, :u), u) # Update in-place
     setproperty!(dc.linear_cache, :u, prop) # Does additional invalidation logic etc.
 
-    # Update partials
+    # Update partials (skip when there is no partials slot, e.g. when the
+    # cache was built with a non-Dual u and is now being reused.)
     setfield!(dc, :dual_u, u)
-    return partial_vals!(getfield(dc, :partials_u), u) # Update in-place
+    pu = getfield(dc, :partials_u)
+    pu === nothing && return nothing
+    return partial_vals!(pu, u)
 end
 
 function SciMLBase.reinit!(

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -468,11 +468,12 @@ function setA!(dc::DualLinearCache, A)
     prop = nodual_value!(getproperty(dc.linear_cache, :A), A) # Update in-place
     setproperty!(dc.linear_cache, :A, prop) # Does additional invalidation logic etc.
 
-    # Update partials (skip when there is no partials slot, e.g. when the
-    # cache was built with a non-Dual A and is now being reused.)
+    # Update partials only when A actually carries Duals; otherwise there is
+    # nothing to extract and the partials slot may be unallocated.
     setfield!(dc, :dual_A, A)
-    pA = getfield(dc, :partials_A)
-    pA === nothing || partial_vals!(pA, A)
+    if get_dual_type(A) !== nothing
+        partial_vals!(getfield(dc, :partials_A), A)
+    end
 
     # Invalidate cache (if setting A or b)
     return setfield!(dc, :rhs_cache_valid, false)
@@ -482,11 +483,12 @@ function setb!(dc::DualLinearCache, b)
     prop = nodual_value!(getproperty(dc.linear_cache, :b), b) # Update in-place
     setproperty!(dc.linear_cache, :b, prop) # Does additional invalidation logic etc.
 
-    # Update partials (skip when there is no partials slot, e.g. when the
-    # cache was built with a non-Dual b and is now being reused.)
+    # Update partials only when b actually carries Duals; otherwise there is
+    # nothing to extract and the partials slot may be unallocated.
     setfield!(dc, :dual_b, b)
-    pb = getfield(dc, :partials_b)
-    pb === nothing || partial_vals!(pb, b)
+    if get_dual_type(b) !== nothing
+        partial_vals!(getfield(dc, :partials_b), b)
+    end
 
     # Invalidate cache (if setting A or b)
     return setfield!(dc, :rhs_cache_valid, false)
@@ -496,12 +498,11 @@ function setu!(dc::DualLinearCache, u)
     prop = nodual_value!(getproperty(dc.linear_cache, :u), u) # Update in-place
     setproperty!(dc.linear_cache, :u, prop) # Does additional invalidation logic etc.
 
-    # Update partials (skip when there is no partials slot, e.g. when the
-    # cache was built with a non-Dual u and is now being reused.)
+    # Update partials only when u actually carries Duals; otherwise there is
+    # nothing to extract and the partials slot may be unallocated.
     setfield!(dc, :dual_u, u)
-    pu = getfield(dc, :partials_u)
-    pu === nothing && return nothing
-    return partial_vals!(pu, u)
+    get_dual_type(u) === nothing && return nothing
+    return partial_vals!(getfield(dc, :partials_u), u)
 end
 
 function SciMLBase.reinit!(

--- a/test/forwarddiff_overloads.jl
+++ b/test/forwarddiff_overloads.jl
@@ -1,6 +1,7 @@
 using LinearSolve
 using ForwardDiff
 using Test
+using LinearAlgebra
 using SparseArrays
 using ComponentArrays
 using Sparspak
@@ -380,4 +381,54 @@ backslash_large = A_large_dual \ b_large_dual
     another_p = (nothing, [5.0, 6.0], 2.0)
     @test_nowarn (cache_p.p = another_p)
     @test cache_p.p == another_p
+end
+
+# Regression test for SciML/LinearSolve.jl#972
+# When DualLinearCache is built from a Dual A and a Float64 b (so partials_b
+# is `nothing`), reusing the cache by mutating b to another Float64 vector
+# previously hit `MethodError: no method matching map!(::partial_vals,
+# ::Nothing, ::Vector{Float64})` from `setb!`. The same applied symmetrically
+# to setA!/setu! when their partials slots were unallocated.
+@testset "DualLinearCache reuse with nothing partials (#972)" begin
+    function f972(p)
+        A = sparse(Diagonal(p))           # A is Dual under ForwardDiff
+        b1 = [1.0, 2.0]                   # Float64, no partials
+        prob = LinearProblem(A, b1)
+        cache = init(prob)
+        u1 = copy(solve!(cache).u)        # first solve seeded the cache
+        cache.b = [3.0, 4.0]              # mutating b to another Float64 vector used to MethodError
+        u2 = copy(solve!(cache).u)
+        return u1 .+ u2
+    end
+
+    # Primal call must still work and produce a sensible result.
+    @test f972([1.0, 2.0]) ≈ [4.0, 3.0]
+
+    # The original failure mode: pushing Duals through the same cache path.
+    J = ForwardDiff.jacobian(f972, [1.0, 2.0])
+    @test size(J) == (2, 2)
+    @test all(isfinite, J)
+
+    # Sanity-check the partials by comparing against a non-cached implementation.
+    function f972_nocache(p)
+        A = sparse(Diagonal(p))
+        u1 = A \ [1.0, 2.0]
+        u2 = A \ [3.0, 4.0]
+        return u1 .+ u2
+    end
+    @test J ≈ ForwardDiff.jacobian(f972_nocache, [1.0, 2.0])
+
+    # Symmetric coverage: Float64 A + Dual b cache reuse via setA!.
+    function f972_setA(p)
+        A1 = Matrix{Float64}(I, 2, 2)
+        b = p                              # b is Dual
+        prob = LinearProblem(A1, b)
+        cache = init(prob)
+        u1 = copy(solve!(cache).u)
+        cache.A = [2.0 0.0; 0.0 2.0]       # mutate A to another Float64 matrix
+        u2 = copy(solve!(cache).u)
+        return u1 .+ u2
+    end
+    @test ForwardDiff.jacobian(f972_setA, [1.0, 2.0]) ≈
+        [1.5 0.0; 0.0 1.5]
 end


### PR DESCRIPTION
> ⚠️ Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

Fixes #972.

When a `DualLinearCache` is built from a Dual `A` and a `Float64` `b` (or vice-versa), the `partials_b` (resp. `partials_A` / `partials_u`) field is `nothing`. Reusing the cache by mutating `b` to another `Float64` vector previously hit:

```
MethodError: no method matching map!(::typeof(LinearSolveForwardDiffExt.partial_vals), ::Nothing, ::Vector{Float64})
```

from `setb!` at `ext/LinearSolveForwardDiffExt.jl:485`, because `partial_vals!(nothing, b)` unconditionally calls `map!(partial_vals, nothing, b)`.

This is the exact pattern Newton-style solvers (e.g. `NonlinearSolve.NewtonRaphson(linsolve = UMFPACKFactorization())` against a `NonlinearProblem` with a sparse `Float64` `jac_prototype` under `ForwardDiff.hessian`) use between iterations.

## Fix

Apply the fix suggested in the issue: in `setA!` / `setb!` / `setu!`, skip the `partial_vals!` call when the corresponding `partials_*` slot is `nothing`. Behavior is unchanged when partials are present.

## Test

Adds a regression test in `test/forwarddiff_overloads.jl` (`@testset "DualLinearCache reuse with nothing partials (#972)"`) that:

1. Mirrors the MWE from the issue (sparse Dual `A` + `Float64` `b`, mutated and re-solved under `ForwardDiff.jacobian`).
2. Sanity-checks the resulting Jacobian against an uncached `A \ b` implementation.
3. Exercises the symmetric `Float64` `A` + Dual `b` path through `setA!`.

I confirmed the new test reliably reproduces the `MethodError` against the unpatched `setb!` and passes after the fix.

## Test plan

- [x] `forwarddiff_overloads.jl` passes locally on Julia 1.12.6 (5/5 in the new testset, 6/6 in the existing `DualLinearCache preserves p parameter` testset).
- [x] No changes to behavior when partials slots are populated.
- [x] Runic-formatted.