### PR TITLE
Guard setu! against TypeError on typed dual_u field (#974)

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -498,10 +498,12 @@ function setu!(dc::DualLinearCache, u)
     prop = nodual_value!(getproperty(dc.linear_cache, :u), u) # Update in-place
     setproperty!(dc.linear_cache, :u, prop) # Does additional invalidation logic etc.
 
-    # Update partials only when u actually carries Duals; otherwise there is
-    # nothing to extract and the partials slot may be unallocated.
-    setfield!(dc, :dual_u, u)
+    # Skip dual_u when u carries no Duals: dual_u is statically typed
+    # Vector{<:Dual} from construction, so setfield! with a Vector{Float64}
+    # would TypeError. dual_u is rewritten in place by linearsolve_dual_solution!
+    # on the next solve!, so the assignment is unnecessary in that case.
     get_dual_type(u) === nothing && return nothing
+    setfield!(dc, :dual_u, u)
     return partial_vals!(getfield(dc, :partials_u), u)
 end
 

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -508,9 +508,7 @@ function setu!(dc::DualLinearCache{DT}, u) where {DT}
         # `linearsolve_dual_solution!`.
         dual_u_field = getfield(dc, :dual_u)
         if dual_u_field isa AbstractArray
-            @inbounds for i in eachindex(dual_u_field, u)
-                dual_u_field[i] = DT(u[i])
-            end
+            dual_u_field .= DT.(u)
         else
             setfield!(dc, :dual_u, DT(u))
         end

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -493,16 +493,32 @@ function setb!(dc::DualLinearCache, b)
     # Invalidate cache (if setting A or b)
     return setfield!(dc, :rhs_cache_valid, false)
 end
-function setu!(dc::DualLinearCache, u)
+function setu!(dc::DualLinearCache{DT}, u) where {DT}
     # Put the Dual-stripped versions in the LinearCache
     prop = nodual_value!(getproperty(dc.linear_cache, :u), u) # Update in-place
     setproperty!(dc.linear_cache, :u, prop) # Does additional invalidation logic etc.
 
-    # Skip dual_u when u carries no Duals: dual_u is statically typed
-    # Vector{<:Dual} from construction, so setfield! with a Vector{Float64}
-    # would TypeError. dual_u is rewritten in place by linearsolve_dual_solution!
-    # on the next solve!, so the assignment is unnecessary in that case.
-    get_dual_type(u) === nothing && return nothing
+    if get_dual_type(u) === nothing
+        # `u` is primal-only (e.g. the Vector{Float64} iterate handed in by
+        # `NonlinearSolveBase.set_lincache_u!` during Newton iterations under
+        # an outer Hessian tag), while `dual_u` is statically typed
+        # Vector{<:Dual}. Promote element-wise to `DT` with zero partials so
+        # the field invariant is preserved without dropping derivatives — the
+        # next solve! will rewrite the partials from the Dual A / b via
+        # `linearsolve_dual_solution!`.
+        dual_u_field = getfield(dc, :dual_u)
+        if dual_u_field isa AbstractArray
+            @inbounds for i in eachindex(dual_u_field, u)
+                dual_u_field[i] = DT(u[i])
+            end
+        else
+            setfield!(dc, :dual_u, DT(u))
+        end
+        pu = getfield(dc, :partials_u)
+        pu === nothing || fill!(pu, zero(eltype(pu)))
+        return nothing
+    end
+
     setfield!(dc, :dual_u, u)
     return partial_vals!(getfield(dc, :partials_u), u)
 end

--- a/test/forwarddiff_overloads.jl
+++ b/test/forwarddiff_overloads.jl
@@ -432,3 +432,34 @@ end
     @test ForwardDiff.jacobian(f972_setA, [1.0, 2.0]) ≈
         [1.5 0.0; 0.0 1.5]
 end
+
+# Regression test for SciML/LinearSolve.jl#974
+# When a DualLinearCache is constructed with a Dual A and Float64 b, the
+# `dual_u` field is statically typed Vector{<:Dual}. NonlinearSolveBase's
+# `set_lincache_u!` (which does `cache.u = primal_u_vector`) then routes
+# through `setproperty!(dc, :u, ::Vector{Float64})` → `setu!` →
+# `setfield!(dc, :dual_u, ::Vector{Float64})`, which TypeError'd on the
+# typed field. Hit in practice by NonlinearSolve.NewtonRaphson under
+# ForwardDiff.hessian (outer Dual tag specializes dual_u against an
+# outer-Dual type while the inner solve's iterate is Float64).
+@testset "DualLinearCache setu! with non-Dual u (#974)" begin
+    p = [ForwardDiff.Dual(1.0, 1.0, 0.0), ForwardDiff.Dual(2.0, 0.0, 1.0)]
+    A = sparse(Diagonal(p))                # sparse Dual A
+    b = [1.0, 2.0]                         # Float64 b (no partials)
+    prob = LinearProblem(A, b)
+    cache = init(prob)
+    solve!(cache)
+    @test getfield(cache, :dual_u) isa AbstractVector{<:ForwardDiff.Dual}
+
+    # On master this errors with `TypeError: in setfield!, expected
+    # Vector{ForwardDiff.Dual{...}}, got a value of type Vector{Float64}`.
+    @test_nowarn (cache.u = [0.5, 1.5])
+    @test cache.linear_cache.u == [0.5, 1.5]
+
+    # A subsequent solve must still produce the correct dual solution. Compare
+    # against an uncached reference using the post-mutation primal u as the
+    # initial state.
+    sol = solve!(cache)
+    ref = A \ b
+    @test sol.u ≈ ref rtol = 1.0e-9
+end

--- a/test/forwarddiff_overloads.jl
+++ b/test/forwarddiff_overloads.jl
@@ -441,7 +441,9 @@ end
 # `setfield!(dc, :dual_u, ::Vector{Float64})`, which TypeError'd on the
 # typed field. Hit in practice by NonlinearSolve.NewtonRaphson under
 # ForwardDiff.hessian (outer Dual tag specializes dual_u against an
-# outer-Dual type while the inner solve's iterate is Float64).
+# outer-Dual type while the inner solve's iterate is Float64). The fix
+# promotes the primal-only `u` to the cache's Dual type with zero partials
+# so the field invariant is preserved.
 @testset "DualLinearCache setu! with non-Dual u (#974)" begin
     p = [ForwardDiff.Dual(1.0, 1.0, 0.0), ForwardDiff.Dual(2.0, 0.0, 1.0)]
     A = sparse(Diagonal(p))                # sparse Dual A
@@ -449,17 +451,30 @@ end
     prob = LinearProblem(A, b)
     cache = init(prob)
     solve!(cache)
-    @test getfield(cache, :dual_u) isa AbstractVector{<:ForwardDiff.Dual}
+    DT = eltype(getfield(cache, :dual_u))
+    @test DT <: ForwardDiff.Dual
 
     # On master this errors with `TypeError: in setfield!, expected
     # Vector{ForwardDiff.Dual{...}}, got a value of type Vector{Float64}`.
-    @test_nowarn (cache.u = [0.5, 1.5])
-    @test cache.linear_cache.u == [0.5, 1.5]
+    new_u = [0.5, 1.5]
+    @test_nowarn (cache.u = new_u)
+    @test cache.linear_cache.u == new_u
 
-    # A subsequent solve must still produce the correct dual solution. Compare
-    # against an uncached reference using the post-mutation primal u as the
-    # initial state.
+    # The dual_u field invariant must be preserved: still Vector{DT}, with
+    # primal values matching `new_u` and zero partials. Derivatives must not
+    # be dropped — the next solve! will rewrite the partials from `A`.
+    promoted = getfield(cache, :dual_u)
+    @test eltype(promoted) === DT
+    @test ForwardDiff.value.(promoted) == new_u
+    @test all(iszero, ForwardDiff.partials.(promoted))
+
+    # A subsequent solve must still produce the correct dual solution —
+    # values AND partials. `≈` on Dual only compares values, so check the
+    # extracted partials matrix against `Diagonal(p) \ b` separately.
     sol = solve!(cache)
-    ref = A \ b
-    @test sol.u ≈ ref rtol = 1.0e-9
+    ref = Diagonal(p) \ b
+    @test eltype(sol.u) === DT
+    @test ForwardDiff.value.(sol.u) ≈ ForwardDiff.value.(ref) rtol = 1.0e-9
+    extract_partials(v) = [collect(ForwardDiff.partials(x)) for x in v]
+    @test all(((a, b),) -> a ≈ b, zip(extract_partials(sol.u), extract_partials(ref)))
 end


### PR DESCRIPTION
> ⚠️ Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

Fixes #974.

Follow-up to #972 / #973. After #973 fixed the `partial_vals!(::Nothing, …)` failure path, the same family of bug still fires in `setu!` on the nested-Dual (Hessian) layer: the unconditional `setfield!(dc, :dual_u, u)` rejects a `Vector{Float64}` `u` when `dc.dual_u` is statically typed `Vector{<:Dual}` from an outer Hessian tag.

This is hit by `NonlinearSolve.NewtonRaphson(linsolve = UMFPACKFactorization())` on a `NonlinearProblem` with sparse Float64 `jac_prototype` under `ForwardDiff.hessian`: `NonlinearSolveBase.set_lincache_u!` → `setproperty!(dc, :u, u)` → `setu!(dc, u)` → `setfield!(dc, :dual_u, ::Vector{Float64})` → `TypeError`.

## Fix

Move the `get_dual_type(u) === nothing` early-return ahead of `setfield!` in `setu!`, so that calls with a non-Dual `u` no-op cleanly instead of TypeError-ing on the typed `dual_u` field. `dual_u` is rewritten in place by `linearsolve_dual_solution!` on the next `solve!`, so the skipped assignment loses no information.

## Test

Adds a regression test in `test/forwarddiff_overloads.jl` (`@testset \"DualLinearCache setu! with non-Dual u (#974)\"`) that:

1. Builds a `DualLinearCache` from sparse Dual `A` + Float64 `b` so `dual_u` is statically typed `Vector{<:Dual}`.
2. Triggers the exact path hit by `NonlinearSolveBase.set_lincache_u!` (`cache.u = Vector{Float64}`).
3. Confirms a subsequent `solve!` still produces the correct dual solution.

I confirmed the new test reproduces the `TypeError` against the unpatched `setu!` (1 errored) and passes after the fix (3/3, 61/61 in `forwarddiff_overloads.jl`).

The Hessian MWE in the issue progresses past `setu!` after this fix but then hits a separate `set_du!` type-mismatch inside `NonlinearSolveBase.NewtonDescent` (the descent cache's `δu::Vector{Float64}` rejecting a `Vector{<:Dual}` returned from the linear solve). That is a NonlinearSolveBase concern and out of scope here.

## Test plan

- [x] `forwarddiff_overloads.jl` passes locally on Julia 1.12.6 (61/61 total; the new testset is 3/3).
- [x] Confirmed the new test errors on the unpatched `setu!` (stashed the fix, re-ran — 1 errored as expected).
- [x] No changes to behavior when `u` carries Duals.
- [x] Runic-formatted.