### PR TITLE
HYPRE: add communicator-aware automatic distributed construction (GSoC week 7 and 8)

### DIFF
--- a/ext/LinearSolveHYPREExt.jl
+++ b/ext/LinearSolveHYPREExt.jl
@@ -10,6 +10,8 @@ using SciMLLogging: SciMLLogging, verbosity_to_int, @SciMLMessage
 using SciMLBase: LinearProblem, LinearAliasSpecifier, SciMLBase
 using Setfield: @set!
 
+const MPI = HYPRE.MPI
+
 mutable struct HYPRECache
     solver::Union{HYPRE.HYPRESolver, Nothing}
     A::Union{HYPREMatrix, Nothing}
@@ -28,6 +30,45 @@ function LinearSolve.init_cacheval(
     return HYPRECache(nothing, nothing, nothing, nothing, true, true, true)
 end
 
+function local_row_partition(nrows::Integer, comm::MPI.Comm)
+    nranks = MPI.Comm_size(comm)
+    rank = MPI.Comm_rank(comm)
+    q, r = divrem(nrows, nranks)
+    nlocal = q + (rank < r ? 1 : 0)
+    ilower = rank * q + min(rank, r) + 1
+    iupper = ilower + nlocal - 1
+    return ilower, iupper
+end
+
+is_distributed_comm(comm) = !(comm === nothing) && comm != MPI.COMM_NULL && MPI.Comm_size(comm) > 1
+
+auto_hypre_matrix(::HYPREAlgorithm, A::HYPREMatrix) = A
+auto_hypre_vector(::HYPREAlgorithm, b::HYPREVector) = b
+
+function auto_hypre_matrix(alg::HYPREAlgorithm, A)
+    if !is_distributed_comm(alg.comm)
+        return A isa HYPREMatrix ? A : HYPREMatrix(A)
+    end
+    if !(A isa AbstractMatrix)
+        throw(ArgumentError("distributed HYPRE auto-construction requires an AbstractMatrix input"))
+    end
+    ilower, iupper = local_row_partition(size(A, 1), alg.comm)
+    Alocal = A[ilower:iupper, :]
+    return HYPREMatrix(alg.comm, Alocal, ilower, iupper)
+end
+
+function auto_hypre_vector(alg::HYPREAlgorithm, b)
+    if !is_distributed_comm(alg.comm)
+        return b isa HYPREVector ? b : HYPREVector(b)
+    end
+    if !(b isa AbstractVector)
+        throw(ArgumentError("distributed HYPRE auto-construction requires an AbstractVector input"))
+    end
+    ilower, iupper = local_row_partition(length(b), alg.comm)
+    blocal = b[ilower:iupper]
+    return HYPREVector(alg.comm, blocal, ilower, iupper)
+end
+
 # Overload set_(A|b|u) in order to keep track of "isfresh" for all of them
 const LinearCacheHYPRE = LinearCache{<:Any, <:Any, <:Any, <:Any, <:Any, HYPRECache}
 
@@ -35,15 +76,15 @@ function Base.setproperty!(cache::LinearCacheHYPRE, name::Symbol, x)
     if name === :A
         cache.cacheval.isfresh_A = true
         setfield!(cache, :isfresh, true)
-        return setfield!(cache, name, x isa HYPREMatrix ? x : HYPREMatrix(x))
+        return setfield!(cache, name, auto_hypre_matrix(cache.alg, x))
     elseif name == :b
         cache.cacheval.isfresh_b = true
         setfield!(cache, :isfresh, true)
-        return setfield!(cache, name, x isa HYPREVector ? x : HYPREVector(x))
+        return setfield!(cache, name, auto_hypre_vector(cache.alg, x))
     elseif name == :u
         cache.cacheval.isfresh_u = true
         setfield!(cache, :isfresh, true)
-        return setfield!(cache, name, x isa HYPREVector ? x : HYPREVector(x))
+        return setfield!(cache, name, auto_hypre_vector(cache.alg, x))
     end
     return setfield!(cache, name, x)
 end
@@ -137,9 +178,9 @@ function SciMLBase.init(
         init_cache_verb = verb_spec
     end
 
-    A = A isa HYPREMatrix ? A : HYPREMatrix(A)
-    b = b isa HYPREVector ? b : HYPREVector(b)
-    u0 = u0 isa HYPREVector ? u0 : (u0 === nothing ? nothing : HYPREVector(u0))
+    A = auto_hypre_matrix(alg, A)
+    b = auto_hypre_vector(alg, b)
+    u0 = u0 === nothing ? nothing : auto_hypre_vector(alg, u0)
 
     # Create solution vector/initial guess
     if u0 === nothing

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -169,7 +169,7 @@ struct PETScAlgorithm <: SciMLLinearSolveAlgorithm
 end
 
 """
-`HYPREAlgorithm(solver; Pl = nothing)`
+`HYPREAlgorithm(solver; comm = nothing, Pl = nothing)`
 
 [HYPRE.jl](https://github.com/fredrikekre/HYPRE.jl) is an interface to
 [`hypre`](https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods)
@@ -201,6 +201,8 @@ The single positional argument `solver` has the following choices:
 
 ## Keyword Arguments
 
+  - `comm`: optional MPI communicator used to auto-construct distributed
+    `HYPREMatrix` / `HYPREVector` inputs from plain Julia sparse matrices and vectors.
   - `Pl`: A choice of left preconditioner.
 
 ## Example
@@ -215,15 +217,26 @@ alg = HYPREAlgorithm(HYPRE.PCG)
 prec = HYPRE.BoomerAMG
 sol = solve(prob, alg; Pl = prec)
 ```
+
+For automatic distributed construction from a plain Julia sparse matrix on an MPI
+communicator, pass the communicator through `comm`:
+
+```julia
+using MPI
+
+alg = HYPREAlgorithm(HYPRE.PCG; comm = MPI.COMM_WORLD)
+sol = solve(prob, alg)
+```
 """
 struct HYPREAlgorithm <: SciMLLinearSolveAlgorithm
     solver::Any
-    function HYPREAlgorithm(solver)
+    comm::Any
+    function HYPREAlgorithm(solver; comm = nothing)
         ext = Base.get_extension(@__MODULE__, :LinearSolveHYPREExt)
         if ext === nothing
             error("HYPREAlgorithm requires that HYPRE is loaded, i.e. `using HYPRE`")
         else
-            return new{}(solver)
+            return new{}(solver, comm)
         end
     end
 end

--- a/test/hypretests_mpi.jl
+++ b/test/hypretests_mpi.jl
@@ -80,3 +80,46 @@ sol = solve!(cache)
 @test sol.iters > 0
 copy!(local_sol, sol.u)
 @test local_sol ≈ 4 * (ilower:iupper)
+
+# Automatic distributed construction from plain Julia arrays
+function get_julia_system(scale)
+    diagvals = collect(1.0:20.0)
+    A = spdiagm(0 => diagvals)
+    b = scale .* diagvals
+    return A, b
+end
+
+A_julia, b_julia = get_julia_system(1.0)
+alg = HYPREAlgorithm(HYPRE.PCG; comm = comm)
+prob = LinearProblem(A_julia, b_julia)
+sol = solve(prob, alg)
+@test sol.resid < TOL
+@test sol.iters > 0
+@test sol.u isa HYPREVector
+@test sol.u.comm == comm
+@test sol.u.ilower == ilower
+@test sol.u.iupper == iupper
+copy!(local_sol, sol.u)
+@test local_sol ≈ ones(local_size)
+
+A_julia, b_julia = get_julia_system(2.0)
+cache = init(LinearProblem(A_julia, b_julia), HYPREAlgorithm(HYPRE.PCG; comm = comm))
+@test cache.A isa HYPREMatrix
+@test cache.b isa HYPREVector
+@test cache.u isa HYPREVector
+@test cache.A.comm == cache.b.comm == cache.u.comm == comm
+@test cache.A.ilower == cache.b.ilower == cache.u.ilower == ilower
+@test cache.A.iupper == cache.b.iupper == cache.u.iupper == iupper
+sol = solve!(cache)
+@test sol.resid < TOL
+@test sol.iters > 0
+copy!(local_sol, sol.u)
+@test local_sol ≈ fill(2.0, local_size)
+
+_, b_julia = get_julia_system(3.0)
+cache.b = b_julia
+sol = solve!(cache)
+@test sol.resid < TOL
+@test sol.iters > 0
+copy!(local_sol, sol.u)
+@test local_sol ≈ fill(3.0, local_size)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Included in this PR:
- add an optional `comm` keyword to `HYPREAlgorithm`
- add `auto_hypre_matrix` and `auto_hypre_vector` in the HYPRE extension
- compute a contiguous row partition from the MPI communicator for plain Julia inputs
- auto-construct distributed `HYPREMatrix` / `HYPREVector` values from local Julia row slices
- wire the new helpers into both `SciMLBase.init` and cached `setproperty!`
- preserve the existing serial fallback when `comm === nothing` or the communicator size is 1
- add a new 2-rank MPI test path for automatic distributed construction from plain Julia sparse matrices and vectors

AI Disclosure: Used GPT 5.4
