### PR TITLE
HYPRE: Tests and Docs (GSoC week 9)

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -5,6 +5,7 @@ pages = [
     "tutorials/linear.md",
     "Tutorials" => Any[
         "tutorials/caching_interface.md",
+        "tutorials/hypre_mpi.md",
         "tutorials/petsc_mpi.md",
         "tutorials/accelerating_choices.md",
         "tutorials/gpu.md",

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -409,55 +409,6 @@ For the MPI workflow, `sol.u` is a distributed `HYPREVector` holding the owned l
 each rank. Unlike the PETSc `SparseMatrixCSC` MPI path, the full Julia solution is not
 replicated back onto every rank automatically.
 
-#### Basic usage
-
-```julia
-using LinearSolve, HYPRE, SparseArrays
-
-HYPRE.Init()
-
-n = 8
-A = spdiagm(0 => collect(2.0:9.0))
-b = collect(2.0:9.0)
-
-prob = LinearProblem(A, b)
-sol = solve(prob, HYPREAlgorithm(HYPRE.PCG))
-```
-
-#### MPI auto-construction from plain Julia arrays
-
-```julia
-using LinearSolve, HYPRE, MPI, SparseArrays
-
-MPI.Init()
-HYPRE.Init()
-
-comm = MPI.COMM_WORLD
-n = 20
-A = spdiagm(0 => collect(1.0:n))
-b = 2.0 .* collect(1.0:n)
-
-prob = LinearProblem(A, b)
-sol = solve(prob, HYPREAlgorithm(HYPRE.PCG; comm = comm))
-
-# sol.u is a distributed HYPREVector over the owned local rows on each rank.
-local_x = Vector{Float64}(undef, sol.u.iupper - sol.u.ilower + 1)
-copy!(local_x, sol.u)
-```
-
-If the matrix structure is unchanged and only the right-hand side changes, reuse the cached
-distributed HYPRE objects:
-
-```julia
-using SciMLBase
-
-cache = SciMLBase.init(prob, HYPREAlgorithm(HYPRE.PCG; comm = comm))
-sol = solve!(cache)
-
-b2 = 3.0 .* collect(1.0:n)
-cache.b = b2
-sol = solve!(cache)
-```
 
 ```@docs
 HYPREAlgorithm

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -384,6 +384,80 @@ KrylovKitJL
     Using HYPRE solvers requires Julia version 1.9 or higher, and that the package HYPRE.jl
     is installed.
 
+!!! note
+
+    Initialize HYPRE before solving:
+    ```julia
+    using HYPRE
+    HYPRE.Init()
+    ```
+
+[HYPRE](https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods)
+targets large sparse linear systems and is especially useful when the solve itself should run
+across multiple MPI ranks.
+
+`HYPREAlgorithm` supports two workflows:
+
+- Serial auto-conversion: pass ordinary Julia sparse matrices and vectors and let
+  LinearSolve construct `HYPREMatrix` / `HYPREVector` values automatically.
+- MPI auto-construction: pass a communicator with `comm = MPI.COMM_WORLD` (or another MPI
+  communicator), and LinearSolve will split a plain Julia matrix/vector into contiguous local
+  row blocks before constructing distributed HYPRE objects.
+
+For the MPI workflow, `sol.u` is a distributed `HYPREVector` holding the owned local rows on
+each rank. Unlike the PETSc `SparseMatrixCSC` MPI path, the full Julia solution is not
+replicated back onto every rank automatically.
+
+#### Basic usage
+
+```julia
+using LinearSolve, HYPRE, SparseArrays
+
+HYPRE.Init()
+
+n = 8
+A = spdiagm(0 => collect(2.0:9.0))
+b = collect(2.0:9.0)
+
+prob = LinearProblem(A, b)
+sol = solve(prob, HYPREAlgorithm(HYPRE.PCG))
+```
+
+#### MPI auto-construction from plain Julia arrays
+
+```julia
+using LinearSolve, HYPRE, MPI, SparseArrays
+
+MPI.Init()
+HYPRE.Init()
+
+comm = MPI.COMM_WORLD
+n = 20
+A = spdiagm(0 => collect(1.0:n))
+b = 2.0 .* collect(1.0:n)
+
+prob = LinearProblem(A, b)
+sol = solve(prob, HYPREAlgorithm(HYPRE.PCG; comm = comm))
+
+# sol.u is a distributed HYPREVector over the owned local rows on each rank.
+local_x = Vector{Float64}(undef, sol.u.iupper - sol.u.ilower + 1)
+copy!(local_x, sol.u)
+```
+
+If the matrix structure is unchanged and only the right-hand side changes, reuse the cached
+distributed HYPRE objects:
+
+```julia
+using SciMLBase
+
+cache = SciMLBase.init(prob, HYPREAlgorithm(HYPRE.PCG; comm = comm))
+sol = solve!(cache)
+
+b2 = 3.0 .* collect(1.0:n)
+cache.b = b2
+sol = solve!(cache)
+```
+
 ```@docs
 HYPREAlgorithm
 ```

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -392,9 +392,10 @@ KrylovKitJL
     HYPRE.Init()
     ```
 
-[HYPRE](https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods)
-targets large sparse linear systems and is especially useful when the solve itself should run
-across multiple MPI ranks.
+[HYPRE.jl](https://github.com/fredrikekre/HYPRE.jl) is the Julia interface to
+[hypre](https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods).
+It targets large sparse linear systems and is especially useful when the solve itself should
+run across multiple MPI ranks.
 
 `HYPREAlgorithm` supports two workflows:
 

--- a/docs/src/tutorials/hypre_mpi.md
+++ b/docs/src/tutorials/hypre_mpi.md
@@ -1,0 +1,165 @@
+# Solving Linear Systems with HYPRE and MPI
+
+This tutorial shows how to solve a linear system with `HYPREAlgorithm` on an MPI
+communicator using ordinary Julia sparse matrices and vectors.
+
+Use this workflow when:
+
+- your matrix is a plain Julia sparse matrix such as `SparseMatrixCSC`
+- you want LinearSolve to construct distributed `HYPREMatrix` / `HYPREVector` objects for you
+- you want the solve itself to run across multiple MPI ranks
+
+Unlike a standard serial Julia workflow, this path uses a non-standard execution model:
+the script is launched under `mpiexecjl`, `mpiexec`, or `mpirun`, and each rank participates
+in the solve.
+
+## Package setup
+
+Load the HYPRE and MPI stack first:
+
+```julia
+using LinearSolve, HYPRE, MPI, SparseArrays, LinearAlgebra
+```
+
+This brings in the LinearSolve interface, the Julia HYPRE wrapper, MPI bindings, and sparse
+matrix support.
+
+Initialize MPI and HYPRE before constructing the solver:
+
+```julia
+MPI.Init()
+```
+
+```julia
+HYPRE.Init()
+```
+
+## Building a sparse linear problem
+
+Start from an ordinary Julia sparse matrix and right-hand side:
+
+```julia
+n = 20
+```
+
+Here `n` is the global problem size. Every MPI rank starts from the same global Julia matrix
+and vector, and LinearSolve splits them into contiguous row blocks when it constructs the
+distributed HYPRE objects.
+
+```julia
+A = spdiagm(0 => collect(1.0:n))
+b = 2.0 .* collect(1.0:n)
+```
+
+This example uses a diagonal system so it is easy to inspect the local solution on each rank.
+
+## Solving on an MPI communicator
+
+Pass the communicator through `HYPREAlgorithm`:
+
+```julia
+alg = HYPREAlgorithm(HYPRE.PCG; comm = MPI.COMM_WORLD)
+```
+
+The `comm = MPI.COMM_WORLD` keyword is what switches this into the communicator-based
+distributed HYPRE path.
+
+Now solve the problem:
+
+```julia
+sol = solve(LinearProblem(A, b), alg; abstol = 1.0e-10, reltol = 1.0e-10)
+```
+
+For this workflow, `sol.u` is a distributed `HYPREVector`, not a replicated Julia vector.
+Each rank owns only its local row interval. You can copy out that local piece with:
+
+```julia
+local_x = Vector{Float64}(undef, sol.u.iupper - sol.u.ilower + 1)
+copy!(local_x, sol.u)
+```
+
+To see what each rank owns, print the local bounds and values:
+
+```julia
+@show MPI.Comm_rank(MPI.COMM_WORLD), sol.u.ilower, sol.u.iupper, local_x
+```
+
+For this diagonal example, every entry of `local_x` should be close to `2.0`.
+
+Save the script and run it with MPI:
+
+```bash
+mpiexecjl -n 2 julia --project hypre_mpi_example.jl
+```
+
+Here `-n 2` means "launch 2 MPI ranks". You can replace `2` with another positive integer
+such as `1`, `4`, or `8` depending on how many ranks you want to use for the run.
+
+This command assumes you have installed the Julia MPI launcher wrapper `mpiexecjl`. If not,
+use `$(MPI.mpiexec()) -n 2 julia --project hypre_mpi_example.jl` or an MPI launcher on your
+machine such as `mpiexec` or `mpirun`, as long as it comes from the same MPI installation as
+the Julia MPI stack.
+
+## Reusing the HYPRE cache
+
+If the matrix structure is unchanged, it is more efficient to reuse the cached HYPRE objects
+than to rebuild them on every solve.
+
+First, initialize the cache:
+
+```julia
+import SciMLBase
+```
+
+The caching interface lives in `SciMLBase`, so import it explicitly before using `init` and
+`solve!`.
+
+```julia
+prob = LinearProblem(A, b)
+```
+
+```julia
+cache = SciMLBase.init(
+    prob,
+    HYPREAlgorithm(HYPRE.PCG; comm = MPI.COMM_WORLD);
+    abstol = 1.0e-10,
+    reltol = 1.0e-10
+)
+```
+
+Run the first solve:
+
+```julia
+sol = solve!(cache)
+```
+
+This allocates and stores the distributed HYPRE matrix, vectors, and solver inside the cache.
+
+Now change only the right-hand side:
+
+```julia
+b2 = 3.0 .* collect(1.0:n)
+cache.b = b2
+sol = solve!(cache)
+```
+
+Because the matrix structure is unchanged, updating `cache.b` refreshes the distributed
+right-hand side without rebuilding the whole solver stack.
+
+You can inspect the updated local solution again with:
+
+```julia
+copy!(local_x, sol.u)
+@show MPI.Comm_rank(MPI.COMM_WORLD), local_x
+```
+
+For this second solve, every entry of `local_x` should be close to `3.0`.
+
+## Choosing the right HYPRE workflow
+
+This tutorial covers the plain Julia matrix/vector MPI workflow. If you already have
+distributed HYPRE objects, you can continue to pass `HYPREMatrix` and `HYPREVector`
+directly instead of using the auto-construction path.
+
+For a short standalone script, it is usually fine to let process exit clean up MPI and HYPRE
+state. If you prefer to be explicit, you can call `MPI.Finalize()` at the end of the script.

--- a/ext/LinearSolveHYPREExt.jl
+++ b/ext/LinearSolveHYPREExt.jl
@@ -1,7 +1,7 @@
 module LinearSolveHYPREExt
 
 using LinearAlgebra
-using HYPRE.LibHYPRE: HYPRE_Complex
+using HYPRE.LibHYPRE: HYPRE_Complex, HYPREError, HYPRE_ERROR_CONV
 using HYPRE: HYPRE, HYPREMatrix, HYPRESolver, HYPREVector
 using LinearSolve: HYPREAlgorithm, LinearCache, LinearProblem, LinearSolve,
     OperatorAssumptions, default_tol, init_cacheval, __issquare,
@@ -217,6 +217,23 @@ create_solver(::Type{S}, comm) where {S <: COMM_SOLVERS} = S(comm)
 const NO_COMM_SOLVERS = Union{HYPRE.BoomerAMG, HYPRE.Hybrid, HYPRE.ILU}
 create_solver(::Type{S}, comm) where {S <: NO_COMM_SOLVERS} = S()
 
+function hypre_retcode(
+        cache::LinearCache, resid, iters::Integer; convergence_error::Bool = false
+    )
+    if !isfinite(resid)
+        return SciMLBase.ReturnCode.Failure
+    end
+
+    tol = max(abs(float(cache.abstol)), abs(float(cache.reltol)))
+    if !convergence_error && resid <= tol
+        return SciMLBase.ReturnCode.Success
+    elseif iters >= cache.maxiters
+        return SciMLBase.ReturnCode.MaxIters
+    else
+        return SciMLBase.ReturnCode.ConvergenceFailure
+    end
+end
+
 function create_solver(alg::HYPREAlgorithm, cache::LinearCache)
     # If the solver is already instantiated, return it directly
     if alg.solver isa HYPRE.HYPRESolver
@@ -308,7 +325,16 @@ function SciMLBase.solve!(cache::LinearCache, alg::HYPREAlgorithm, args...; kwar
     cache.isfresh = false
 
     # Solve!
-    HYPRE.solve!(hcache.solver, hcache.u, hcache.A, hcache.b)
+    convergence_error = false
+    try
+        HYPRE.solve!(hcache.solver, hcache.u, hcache.A, hcache.b)
+    catch err
+        if err isa HYPREError && (err.ierr & HYPRE_ERROR_CONV) != 0
+            convergence_error = true
+        else
+            rethrow()
+        end
+    end
 
     # Copy back if the output is not HYPREVector
     if cache.u !== hcache.u
@@ -323,7 +349,7 @@ function SciMLBase.solve!(cache::LinearCache, alg::HYPREAlgorithm, args...; kwar
     N = 1 # length((size(u)...,))
     resid = HYPRE.GetFinalRelativeResidualNorm(hcache.solver)
     iters = Int(HYPRE.GetNumIterations(hcache.solver))
-    retc = SciMLBase.ReturnCode.Default # TODO: Fetch from solver
+    retc = hypre_retcode(cache, resid, iters; convergence_error)
     stats = nothing
 
     ret = SciMLBase.LinearSolution{

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -211,6 +211,9 @@ For example, to use `HYPRE.PCG` as the solver, with `HYPRE.BoomerAMG` as the pre
 the algorithm should be defined as follows:
 
 ```julia
+using HYPRE
+
+HYPRE.Init()
 A, b = setup_system(...)
 prob = LinearProblem(A, b)
 alg = HYPREAlgorithm(HYPRE.PCG)
@@ -222,8 +225,10 @@ For automatic distributed construction from a plain Julia sparse matrix on an MP
 communicator, pass the communicator through `comm`:
 
 ```julia
-using MPI
+using HYPRE, MPI
 
+MPI.Init()
+HYPRE.Init()
 alg = HYPREAlgorithm(HYPRE.PCG; comm = MPI.COMM_WORLD)
 sol = solve(prob, alg)
 ```

--- a/test/hypretests.jl
+++ b/test/hypretests.jl
@@ -187,7 +187,5 @@ test_retcode_failure()
 
 # Test MPI execution
 mpitestfile = joinpath(@__DIR__, "hypretests_mpi.jl")
-mpicmd = `$(mpiexec()) -n 2 $(Base.julia_cmd()) $(mpitestfile)`
-mpicmd = addenv(mpicmd, "JULIA_LOAD_PATH" => join(LOAD_PATH, ':'))
-r = run(ignorestatus(mpicmd))
+r = run(ignorestatus(`$(mpiexec()) -n 2 $(Base.julia_cmd()) $(mpitestfile)`))
 @test r.exitcode == 0

--- a/test/hypretests.jl
+++ b/test/hypretests.jl
@@ -35,7 +35,9 @@ end
 to_array(x) = x
 
 function failure_prob()
-    n = 100
+    n = 200
+    # This SPD 1D Laplacian does not converge in a single PCG iteration, so with
+    # maxiters = 1 we should get a non-success retcode rather than an exception.
     A = spdiagm(-1 => -ones(n - 1), 0 => 2.0 .* ones(n), 1 => -ones(n - 1))
     b = ones(n)
     return LinearProblem(A, b)

--- a/test/hypretests.jl
+++ b/test/hypretests.jl
@@ -34,6 +34,13 @@ function to_array(b::HYPREVector)
 end
 to_array(x) = x
 
+function failure_prob()
+    n = 100
+    A = spdiagm(-1 => -ones(n - 1), 0 => 2.0 .* ones(n), 1 => -ones(n - 1))
+    b = ones(n)
+    return LinearProblem(A, b)
+end
+
 function generate_probs(alg)
     rng = MersenneTwister(1234)
     n = 100
@@ -128,6 +135,17 @@ function test_interface(alg; kw...)
     return
 end
 
+function test_retcode_failure()
+    prob = failure_prob()
+    sol = solve(
+        prob, HYPREAlgorithm(HYPRE.PCG);
+        abstol = 1.0e-12, reltol = 1.0e-12, maxiters = 1
+    )
+    @test sol.retcode == SciMLBase.ReturnCode.MaxIters
+    @test sol.iters == 1
+    return @test sol.resid > sol.cache.reltol
+end
+
 const comm = MPI.COMM_WORLD
 
 # HYPRE.BiCGSTAB
@@ -165,8 +183,11 @@ test_interface(HYPREAlgorithm(HYPRE.PCG))
 test_interface(HYPREAlgorithm(HYPRE.PCG), Pl = HYPRE.BoomerAMG)
 test_interface(HYPREAlgorithm(HYPRE.PCG(comm)))
 test_interface(HYPREAlgorithm(HYPRE.PCG(comm)), Pl = HYPRE.BoomerAMG())
+test_retcode_failure()
 
 # Test MPI execution
 mpitestfile = joinpath(@__DIR__, "hypretests_mpi.jl")
-r = run(ignorestatus(`$(mpiexec()) -n 2 $(Base.julia_cmd()) $(mpitestfile)`))
+mpicmd = `$(mpiexec()) -n 2 $(Base.julia_cmd()) $(mpitestfile)`
+mpicmd = addenv(mpicmd, "JULIA_LOAD_PATH" => join(LOAD_PATH, ':'))
+r = run(ignorestatus(mpicmd))
 @test r.exitcode == 0

--- a/test/hypretests_mpi.jl
+++ b/test/hypretests_mpi.jl
@@ -123,3 +123,14 @@ sol = solve!(cache)
 @test sol.iters > 0
 copy!(local_sol, sol.u)
 @test local_sol ≈ fill(3.0, local_size)
+
+# Automatic distributed construction failure retcode
+A_fail = spdiagm(-1 => -ones(19), 0 => 2.0 .* ones(20), 1 => -ones(19))
+b_fail = ones(20)
+sol = solve(
+    LinearProblem(A_fail, b_fail), HYPREAlgorithm(HYPRE.PCG; comm = comm);
+    abstol = 1.0e-12, reltol = 1.0e-12, maxiters = 1
+)
+@test sol.retcode == SciMLBase.ReturnCode.MaxIters
+@test sol.iters == 1
+@test sol.resid > sol.cache.reltol

--- a/test/hypretests_mpi.jl
+++ b/test/hypretests_mpi.jl
@@ -125,8 +125,13 @@ copy!(local_sol, sol.u)
 @test local_sol ≈ fill(3.0, local_size)
 
 # Automatic distributed construction failure retcode
-A_fail = spdiagm(-1 => -ones(19), 0 => 2.0 .* ones(20), 1 => -ones(19))
-b_fail = ones(20)
+n_fail = 200
+# This SPD 1D Laplacian does not converge in a single PCG iteration, so with
+# maxiters = 1 we should get a non-success retcode rather than an exception.
+A_fail = spdiagm(
+    -1 => -ones(n_fail - 1), 0 => 2.0 .* ones(n_fail), 1 => -ones(n_fail - 1)
+)
+b_fail = ones(n_fail)
 sol = solve(
     LinearProblem(A_fail, b_fail), HYPREAlgorithm(HYPRE.PCG; comm = comm);
     abstol = 1.0e-12, reltol = 1.0e-12, maxiters = 1


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Included in this PR:
- add a 2-rank MPI test path for automatic distributed construction from plain Julia sparse matrices and vectors
- add explicit HYPRE non-convergence `retcode` handling
- add failure-mode coverage for both the serial HYPRE path and the communicator-based MPI path
- update the `HYPREAlgorithm` docstring and the main solver docs to describe the serial and communicator-based HYPRE workflows

AI Disclosure: Used GPT 5.4