### PR TITLE
warn when preconditioner is passed to KrylovKitJL (#228)

### DIFF
--- a/ext/LinearSolveKrylovKitExt.jl
+++ b/ext/LinearSolveKrylovKitExt.jl
@@ -25,6 +25,11 @@ LinearSolve.default_alias_A(::KrylovKitJL, ::Any, ::Any) = true
 LinearSolve.default_alias_b(::KrylovKitJL, ::Any, ::Any) = true
 
 function SciMLBase.solve!(cache::LinearCache, alg::KrylovKitJL; kwargs...)
+    # KrylovKit doesn't use Pl/Pr, so warn if the user set one
+    if !(cache.Pl isa LinearAlgebra.UniformScaling) ||
+       !(cache.Pr isa LinearAlgebra.UniformScaling)
+        @warn "KrylovKit does not support preconditioners. Pl/Pr will be ignored. Use KrylovJL_GMRES() if you need preconditioning." maxlog=1
+    end
     atol = float(cache.abstol)
     rtol = float(cache.reltol)
     maxiter = cache.maxiters


### PR DESCRIPTION
Fixes #228

KrylovKit silently ignores `Pl`/`Pr` when passed through LinearSolve's
interface which can be confusing to debug. Added a `@warn` with `maxlog=1`
so it only fires once and doesn't spam on repeated solves.