### PR TITLE
ci: skip HYPRE and PETSc tests on Julia pre-release

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -65,6 +65,11 @@ jobs:
           # See: https://github.com/SciML/LinearSolve.jl/issues/879
           - group: LinearSolvePardiso
             version: "pre"
+          # Skip HYPRE and PETSc on pre-release Julia
+          - group: LinearSolveHYPRE
+            version: "pre"
+          - group: LinearSolvePETSc
+            version: "pre"
           # Ginkgo.jl is not available on Windows
           - group: LinearSolveGinkgo
             os: windows-latest


### PR DESCRIPTION
## Summary
- Adds `LinearSolveHYPRE` and `LinearSolvePETSc` to the matrix excludes for `version: "pre"` in `.github/workflows/Tests.yml`, mirroring the existing exclude for `LinearSolvePardiso`.

## Motivation
The HYPRE and PETSc binary stacks are not reliably built against Julia prerelease, so running these groups on `pre` produces noisy failures unrelated to LinearSolve itself. Skipping them keeps the "pre" matrix green while preserving full coverage on `1` and `lts`.

## Test plan
- [ ] CI: confirm `LinearSolveHYPRE` and `LinearSolvePETSc` jobs no longer appear under the `pre` Julia version, and that the corresponding `1` / `lts` jobs still run.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)