### PR TITLE
ParU: add max_threads to cap OpenMP threads (fix small-matrix slowness)

### DIFF
--- a/ext/LinearSolveParUExt.jl
+++ b/ext/LinearSolveParUExt.jl
@@ -20,6 +20,9 @@ const PARU_INVALID = Int32(-2)
 const PARU_SINGULAR = Int32(-3)
 const PARU_TOO_LARGE = Int32(-4)
 
+# ParU_Control_enum key for the max OpenMP thread count (see ParU.h)
+const PARU_CONTROL_MAX_THREADS = Cint(1001)
+
 #-------------------------------------------------------------------------------
 # ParUCache — holds the symbolic and numeric factorization objects plus the
 # ParU control struct.  A finalizer ensures the ParU/CHOLMOD memory is freed.
@@ -38,7 +41,7 @@ mutable struct ParUCache
     # passed to ParU_C_Solve_Axb after a failed factorization.
     last_factorize_info::Int32
 
-    function ParUCache()
+    function ParUCache(max_threads::Union{Int, Nothing} = nothing)
         @static if !Base.USE_GPL_LIBS
             error(
                 "ParUFactorization requires GPL libraries (CHOLMOD/UMFPACK). " *
@@ -54,7 +57,23 @@ mutable struct ParUCache
         if info != PARU_SUCCESS
             error("ParU_C_InitControl failed with code $info")
         end
-        cache = new(C_NULL, C_NULL, ctrl_ref[], Int64[], Int64[], 0, PARU_INVALID)
+        ctrl = ctrl_ref[]
+        # By default ParU uses *all* OpenMP threads, which is counter-productive
+        # for small/medium problems on many-core machines (thread-pool overhead
+        # dominates). Honor a user-supplied cap via PARU_CONTROL_MAX_THREADS.
+        if max_threads !== nothing
+            info = ccall(
+                (:ParU_C_Set_Control_INT64, libparu), Int32,
+                (Cint, Int64, Ptr{Cvoid}),
+                PARU_CONTROL_MAX_THREADS, Int64(max_threads), ctrl
+            )
+            if info != PARU_SUCCESS
+                ctrl_free = Ref(ctrl)
+                ccall((:ParU_C_FreeControl, libparu), Int32, (Ref{Ptr{Cvoid}},), ctrl_free)
+                error("ParU_C_Set_Control_INT64(MAX_THREADS) failed with code $info")
+            end
+        end
+        cache = new(C_NULL, C_NULL, ctrl, Int64[], Int64[], 0, PARU_INVALID)
         finalizer(_paru_free_cache!, cache)
         return cache
     end
@@ -146,7 +165,7 @@ function LinearSolve.init_cacheval(
         maxiters::Int, abstol, reltol,
         verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
     )
-    return ParUCache()
+    return ParUCache(alg.max_threads)
 end
 
 # Generic fallback for type mismatches

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -1287,7 +1287,7 @@ end
 needs_concrete_A(::AlgebraicMultigridJL) = true
 
 """
-`ParUFactorization(;reuse_symbolic=true)`
+`ParUFactorization(;reuse_symbolic=true, max_threads=nothing)`
 
 A parallel sparse LU factorization from SuiteSparse's
 [ParU](https://github.com/DrTimothyAldenDavis/SuiteSparse) library.
@@ -1305,6 +1305,15 @@ Only supports `Float64` element type.
 
   - `reuse_symbolic`: Cache and reuse the symbolic factorization across solves
     when the sparsity pattern of `A` does not change. Defaults to `true`.
+  - `max_threads`: Cap the number of OpenMP threads ParU uses for the numeric
+    factorization, set via ParU's `PARU_CONTROL_MAX_THREADS`. `nothing` (the
+    default) leaves ParU's own default, which is to use *all* available OpenMP
+    threads. On machines with many cores this default is counter-productive for
+    small and medium problems: spinning up the OpenMP task pool costs far more
+    than the factorization itself (e.g. on a 128-core host a 200×200 system
+    takes ~16 ms with all threads versus ~1 ms capped to a few). ParU only pays
+    off its parallel overhead on large systems, so set a modest `max_threads`
+    (or cap `OMP_NUM_THREADS`) unless the problem is large.
 
 !!! note
 
@@ -1328,12 +1337,18 @@ sol = solve(prob, ParUFactorization())
 """
 struct ParUFactorization <: AbstractSparseFactorization
     reuse_symbolic::Bool
-    function ParUFactorization(; reuse_symbolic::Bool = true)
+    max_threads::Union{Int, Nothing}
+    function ParUFactorization(;
+            reuse_symbolic::Bool = true, max_threads::Union{Int, Nothing} = nothing
+        )
         ext = Base.get_extension(@__MODULE__, :LinearSolveParUExt)
         if ext === nothing
             error("ParUFactorization requires that ParU_jll and SparseArrays are loaded, i.e. `import ParU_jll; using SparseArrays`")
         end
-        return new(reuse_symbolic)
+        if max_threads !== nothing && max_threads < 1
+            throw(ArgumentError("ParUFactorization max_threads must be ≥ 1 (or `nothing` to use ParU's default)"))
+        end
+        return new(reuse_symbolic, max_threads)
     end
 end
 

--- a/test/paru/paru.jl
+++ b/test/paru/paru.jl
@@ -44,4 +44,14 @@ end
         cache.A = A2
         @test A2 * solve!(cache) ≈ b1
     end
+
+    @testset "max_threads control" begin
+        # max_threads caps ParU's OpenMP threads (PARU_CONTROL_MAX_THREADS) and
+        # must not affect the result.
+        @test ParUFactorization(max_threads = 1).max_threads == 1
+        @test ParUFactorization().max_threads === nothing
+        @test_throws ArgumentError ParUFactorization(max_threads = 0)
+        test_interface(ParUFactorization(max_threads = 1), prob1, prob2)
+        test_interface(ParUFactorization(max_threads = 2), prob1, prob2)
+    end
 end


### PR DESCRIPTION
## Problem

`ParUFactorization` looked dramatically slow on small/medium sparse systems. The cause is **OpenMP thread over-subscription**: the extension initializes the ParU control with `ParU_C_InitControl` and never sets a thread limit, so ParU uses its default `MAX_THREADS = 0` = *all* available OpenMP threads. On a many-core machine, spinning up and coordinating that thread pool (plus nested parallel BLAS) costs far more than the factorization itself for a small matrix.

Measured on a 128-core host with the SparsePDE benchmark matrix (a 200×200 SPD finite-difference system), profiling the raw `libparu` calls:

| configuration | time |
| --- | --- |
| ParU, all OpenMP threads (current behavior) | ~16 ms (raw) / ~9.8 ms (via LinearSolve) |
| ParU, `MAX_THREADS` capped to 4 (or 1) | ~1.2 ms |
| KLU (reference) | ~0.4 ms |

So the uncapped default made ParU ~8–14× slower than it should be, and an order of magnitude slower than KLU/UMFPACK — entirely from thread oversubscription on a tiny problem. (Per-phase breakdown confirms it's pool overhead, not the analyze/factorize work, which is ~1 ms total.)

## Fix

Add a `max_threads` keyword to `ParUFactorization`, forwarded to ParU via `ParU_C_Set_Control_INT64(PARU_CONTROL_MAX_THREADS, n, control)` before analyze/factorize.

- `max_threads = nothing` (default) **preserves current behavior** — large problems still use all OpenMP threads.
- Users on many-core machines can cap it (e.g. `ParUFactorization(max_threads = 4)`) to avoid the oversubscription penalty on small/medium systems.

## Verification

Locally (Julia 1.12, ParU_jll 1.0): the capped solve returns the identical solution (rel. residual ~8e-14, same as the default) and is **~8× faster** than the uncapped default when OpenMP would otherwise grab all cores. The `max_threads` argument is validated (`< 1` throws `ArgumentError`). Extended `test/paru/paru.jl`; the `ParU Factorization` testset passes **14/14** locally. Runic-formatted.

Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>