### PR TITLE
Add PartitionedSolvers solve path and default dispatch for PSparseMatrix (GSoC week 12 & 13)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -194,6 +194,8 @@ Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 MultiFloats = "bdf0d083-296b-4888-a5b6-7498122e68a5"
 PETSc = "ace2c81b-2b5f-4b1e-a30d-d662738edfe0"
+PartitionedArrays = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
+PartitionedSolvers = "11b65f7f-80ac-401b-9ef2-3db765482d62"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -208,4 +210,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["AlgebraicMultigrid", "Aqua", "Test", "IterativeSolvers", "InteractiveUtils", "KrylovKit", "KrylovPreconditioners", "Pkg", "Random", "SafeTestsets", "MultiFloats", "ForwardDiff", "HYPRE", "MPI", "PETSc", "BlockDiagonals", "FiniteDiff", "BandedMatrices", "FastAlmostBandedMatrices", "StaticArrays", "AllocCheck", "StableRNGs", "Zygote", "RecursiveFactorization", "Sparspak", "CliqueTrees", "FastLapackInterface", "SparseArrays", "ExplicitImports", "ComponentArrays", "Elemental", "STRUMPACK_jll"]
+test = ["AlgebraicMultigrid", "Aqua", "Test", "IterativeSolvers", "InteractiveUtils", "KrylovKit", "KrylovPreconditioners", "Pkg", "Random", "SafeTestsets", "MultiFloats", "ForwardDiff", "HYPRE", "MPI", "PETSc", "PartitionedArrays", "PartitionedSolvers", "BlockDiagonals", "FiniteDiff", "BandedMatrices", "FastAlmostBandedMatrices", "StaticArrays", "AllocCheck", "StableRNGs", "Zygote", "RecursiveFactorization", "Sparspak", "CliqueTrees", "FastLapackInterface", "SparseArrays", "ExplicitImports", "ComponentArrays", "Elemental", "STRUMPACK_jll"]

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -447,9 +447,29 @@ HYPREAlgorithm
     using LinearSolve, PartitionedArrays, PartitionedSolvers
     ```
 
-The `PartitionedSolversAlgorithm` extension validates `PSparseMatrix` / `PVector` inputs and
-initializes the LinearSolve cache structure, but the full solve-path delegation into
-`PartitionedSolvers.solve` is not integrated yet.
+The `PartitionedSolversAlgorithm` extension is intended for
+`PSparseMatrix` / `PVector` inputs from `PartitionedArrays.jl`. It delegates solves to the
+local `PartitionedSolvers` solver constructors, supports repeated `solve!` reuse through the
+cached solver object, and provides a typed `defaultalg` dispatch for square `PSparseMatrix`
+problems.
+
+The integration is solver-agnostic: it forwards only the convergence keywords that the chosen
+solver constructor accepts, so different PartitionedSolvers solvers can be used directly. The
+CG-backed Krylov path is the default,
+
+```julia
+using LinearSolve, PartitionedArrays, PartitionedSolvers
+
+alg = PartitionedSolversAlgorithm(PartitionedSolvers.cg)
+sol = solve(prob, alg; abstol = 1.0e-10, reltol = 1.0e-10)
+```
+
+but other distributed solvers such as the stationary Jacobi iteration work the same way:
+
+```julia
+alg = PartitionedSolversAlgorithm(PartitionedSolvers.jacobi)
+sol = solve(prob, alg; maxiters = 50)
+```
 
 ```@docs
 PartitionedSolversAlgorithm

--- a/ext/LinearSolvePartitionedSolversExt.jl
+++ b/ext/LinearSolvePartitionedSolversExt.jl
@@ -1,10 +1,12 @@
 module LinearSolvePartitionedSolversExt
 
+using LinearAlgebra: UniformScaling, norm
 using PartitionedArrays: PSparseMatrix, PVector
 using PartitionedSolvers: PartitionedSolvers
 using LinearSolve: LinearSolve, PartitionedSolversAlgorithm, LinearCache, LinearProblem,
-    init_cacheval, __init, OperatorAssumptions, LinearVerbosity
-using SciMLBase: SciMLBase
+    init_cacheval, __init, OperatorAssumptions, LinearVerbosity, defaultalg
+using SciMLBase: ReturnCode, SciMLBase
+using SciMLOperators: IdentityOperator
 
 mutable struct PartitionedSolversCache
     solver::Any
@@ -43,12 +45,118 @@ function SciMLBase.init(prob::LinearProblem, alg::PartitionedSolversAlgorithm, a
     return __init(prob_, alg, args...; kwargs...)
 end
 
-function SciMLBase.solve!(cache::LinearCache, alg::PartitionedSolversAlgorithm, args...; kwargs...)
-    throw(
-        ArgumentError(
-            "PartitionedSolversAlgorithm solve path is not implemented yet; week 12-13 will wire this cache to PartitionedSolvers.solve"
-        )
+function LinearSolve.defaultalg(
+        A::PSparseMatrix, b::PVector, assump::OperatorAssumptions{Bool}
     )
+    assump.issq || error(
+        "PartitionedSolversAlgorithm currently only supports square PSparseMatrix problems"
+    )
+    return PartitionedSolversAlgorithm(PartitionedSolvers.cg)
+end
+
+# Discover which keyword arguments a PartitionedSolvers solver constructor accepts so that
+# auto-derived convergence options are only forwarded to solvers that understand them. A
+# constructor that slurps keywords (e.g. `cg(p; kwargs...)`) accepts everything, while a
+# fixed-signature solver (e.g. `amg(p; fine_params, coarse_params)`) only takes its declared
+# keywords. This keeps the integration solver-agnostic instead of being implicitly cg-only.
+function accepted_solver_kwargs(solver)
+    names = Symbol[]
+    for m in methods(solver)
+        for k in Base.kwarg_decl(m)
+            endswith(string(k), "...") && return (true, names)
+            push!(names, k)
+        end
+    end
+    return (false, unique(names))
+end
+
+function filter_solver_kwargs(solver, kwargs::NamedTuple)
+    slurps, names = accepted_solver_kwargs(solver)
+    slurps && return kwargs
+    kept = filter(p -> first(p) in names, pairs(kwargs))
+    return NamedTuple(kept)
+end
+
+function auto_convergence_kwargs(cache::LinearCache)
+    kwargs = (;
+        iterations = cache.maxiters,
+        abstol = cache.abstol,
+        reltol = cache.reltol,
+        verbose = LinearSolve.verbosity_to_int(cache.verbose.KrylovJL_verbosity) > 0,
+    )
+    if !(cache.Pl isa Union{UniformScaling, IdentityOperator})
+        kwargs = merge(kwargs, (; Pl = cache.Pl))
+    else
+        kwargs = merge(kwargs, (; update_Pl = false))
+    end
+    return kwargs
+end
+
+function partitionedsolvers_solver_kwargs(cache::LinearCache, alg::PartitionedSolversAlgorithm)
+    # Forward only the auto-derived options the solver actually accepts, then let any
+    # explicit user-provided keywords take precedence (and always pass through).
+    auto = filter_solver_kwargs(alg.solver, auto_convergence_kwargs(cache))
+    return merge(auto, alg.kwargs)
+end
+
+partitionedsolvers_problem(cache::LinearCache) = PartitionedSolvers.linear_problem(
+    cache.u, cache.A, cache.b
+)
+
+function init_partitionedsolvers_solver(
+        cache::LinearCache, alg::PartitionedSolversAlgorithm, problem
+    )
+    solver = alg.solver
+    if solver === nothing
+        return PartitionedSolvers.default_solver(problem)
+    elseif solver isa PartitionedSolvers.AbstractSolver
+        return PartitionedSolvers.update(solver; problem)
+    else
+        return solver(problem; partitionedsolvers_solver_kwargs(cache, alg)...)
+    end
+end
+
+function update_partitionedsolvers_solver(
+        cache::LinearCache, alg::PartitionedSolversAlgorithm, solver, problem
+    )
+    solver === nothing && return init_partitionedsolvers_solver(cache, alg, problem)
+    return PartitionedSolvers.update(
+        solver; problem, matrix = cache.A, rhs = cache.b, solution = cache.u
+    )
+end
+
+function partitionedsolvers_result_metadata(solver)
+    workspace = PartitionedSolvers.workspace(solver)
+    hasproperty(workspace, :state) || return nothing, ReturnCode.Success, 0
+    state = getproperty(workspace, :state)
+    resid = hasproperty(state, :current) ? getproperty(state, :current) : nothing
+    iters = hasproperty(state, :iteration) ? Int(getproperty(state, :iteration)) : 0
+    target = hasproperty(state, :target) ? getproperty(state, :target) : nothing
+    if resid === nothing
+        return nothing, ReturnCode.Success, iters
+    elseif !isfinite(resid)
+        return resid, ReturnCode.Failure, iters
+    elseif target !== nothing && resid <= target
+        return resid, ReturnCode.Success, iters
+    else
+        return resid, ReturnCode.MaxIters, iters
+    end
+end
+
+function SciMLBase.solve!(cache::LinearCache, alg::PartitionedSolversAlgorithm, args...; kwargs...)
+    problem = partitionedsolvers_problem(cache)
+    solver = update_partitionedsolvers_solver(cache, alg, cache.cacheval.solver, problem)
+    solver = PartitionedSolvers.solve(solver)
+    setfield!(cache.cacheval, :solver, solver)
+    setfield!(cache, :u, PartitionedSolvers.solution(solver))
+
+    resid, retcode, iters = partitionedsolvers_result_metadata(solver)
+    if resid === nothing
+        resid = norm(cache.A * cache.u - cache.b)
+        retcode = isfinite(resid) ? ReturnCode.Success : ReturnCode.Failure
+    end
+
+    return SciMLBase.build_linear_solution(alg, cache.u, resid, cache; retcode, iters)
 end
 
 end # module LinearSolvePartitionedSolversExt

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -253,27 +253,33 @@ end
 provides distributed linear solver building blocks for
 [PartitionedArrays.jl](https://github.com/PartitionedArrays/PartitionedArrays.jl).
 
-This algorithm is intended for `PSparseMatrix` / `PVector` inputs. The week 10--11
-integration only provides the loading and validation skeleton: it checks the input types,
-builds a LinearSolve cache, and reserves the extension point where the actual
-PartitionedSolvers-backed solve path will be connected in the following stage.
+This algorithm is intended for `PSparseMatrix` / `PVector` inputs. The integration
+delegates actual solves to the local `PartitionedSolvers` solver constructors and caches
+the resulting solver object for repeated solves. The default dispatch for `PSparseMatrix`
+inputs chooses the CG-backed PartitionedSolvers path, but the integration is
+solver-agnostic: any PartitionedSolvers solver constructor (for example
+`PartitionedSolvers.cg`, `PartitionedSolvers.jacobi`, or `PartitionedSolvers.amg`) can be
+passed, and only the convergence keywords that the chosen solver actually accepts are
+forwarded automatically.
 
 ## Positional Arguments
 
-  - `solver`: optional PartitionedSolvers solver object or constructor placeholder. It is
-    stored for the later solve-path implementation.
+  - `solver`: optional PartitionedSolvers solver object or constructor such as
+    `PartitionedSolvers.cg`. If omitted, the integration uses the local
+    `PartitionedSolvers` default solver.
 
 ## Keyword Arguments
 
-  - `kwargs...`: reserved for later forwarding into the full PartitionedSolvers solve path.
+  - `kwargs...`: forwarded when constructing an explicit underlying PartitionedSolvers
+    solver. They take precedence over the auto-derived convergence keywords.
 
 ## Example
 
 ```julia
 using LinearSolve, PartitionedArrays, PartitionedSolvers
 
-alg = PartitionedSolversAlgorithm()
-cache = SciMLBase.init(prob, alg)
+alg = PartitionedSolversAlgorithm(PartitionedSolvers.cg)
+sol = solve(prob, alg)
 ```
 """
 struct PartitionedSolversAlgorithm <: SciMLLinearSolveAlgorithm

--- a/test/partitionedsolverstests.jl
+++ b/test/partitionedsolverstests.jl
@@ -1,6 +1,7 @@
 using LinearSolve
 using PartitionedArrays
-using PartitionedArrays: PSparseMatrix, PVector, with_debug, uniform_partition, tuple_of_arrays
+using PartitionedArrays: PSparseMatrix, PVector, own_to_local, partition, tuple_of_arrays,
+    uniform_partition, with_debug
 using PartitionedSolvers
 using SparseArrays
 using Test
@@ -23,30 +24,117 @@ function build_splitmat_diag(row_partition, scale = 1.0)
     return A, b, u
 end
 
-@testset "PartitionedSolversAlgorithm: init validates PSparseMatrix/PVector" begin
+function assert_owned_approx(u::PVector, expected_val; atol = 1.0e-8)
+    map(partition(u), partition(axes(u, 1))) do local_u, row_idx
+        for j in own_to_local(row_idx)
+            @test local_u[j] ≈ expected_val atol = atol
+        end
+    end
+    return nothing
+end
+
+@testset "PartitionedSolversAlgorithm: extension loaded" begin
+    @test PSExt !== nothing
+end
+
+@testset "PartitionedSolversAlgorithm: debug solve and cache reuse" begin
     with_debug() do distribute
         rp = debug_row_partition(distribute, 8)
-        A, b, u = build_splitmat_diag(rp)
-        cache = SciMLBase.init(LinearProblem(A, b; u0 = u), PartitionedSolversAlgorithm())
-        @test cache.A isa PSparseMatrix
-        @test cache.b isa PVector
-        @test cache.u isa PVector
+        A, b, u0 = build_splitmat_diag(rp)
+        cache = SciMLBase.init(
+            LinearProblem(A, b; u0 = u0),
+            PartitionedSolversAlgorithm(PartitionedSolvers.cg);
+            abstol = 1.0e-12,
+            reltol = 1.0e-12,
+            maxiters = 20
+        )
+
+        sol1 = solve!(cache)
+        @test sol1.retcode == SciMLBase.ReturnCode.Success
+        @test cache.cacheval.solver !== nothing
+        assert_owned_approx(sol1.u, 1.0)
+
+        b2 = PVector(map(rng -> 2.0 .* Float64.(rng), rp), rp)
+        cache.b = b2
+        sol2 = solve!(cache)
+        @test sol2.retcode == SciMLBase.ReturnCode.Success
+        assert_owned_approx(sol2.u, 2.0)
+
+        A2, b3, _ = build_splitmat_diag(rp, 3.0)
+        cache.A = A2
+        cache.b = b3
+        sol3 = solve!(cache)
+        @test sol3.retcode == SciMLBase.ReturnCode.Success
+        assert_owned_approx(sol3.u, 1.0)
     end
 end
 
-@testset "PartitionedSolversAlgorithm: solve! stub is explicit" begin
+@testset "PartitionedSolversAlgorithm: defaultalg dispatch" begin
     with_debug() do distribute
         rp = debug_row_partition(distribute, 8)
-        A, b, u = build_splitmat_diag(rp)
-        cache = SciMLBase.init(LinearProblem(A, b; u0 = u), PartitionedSolversAlgorithm())
-        err = try
-            solve!(cache)
-            nothing
-        catch err
-            err
-        end
-        @test err isa ArgumentError
-        @test occursin("not implemented yet", sprint(showerror, err))
+        A, b, u0 = build_splitmat_diag(rp)
+
+        alg = LinearSolve.defaultalg(A, b, LinearSolve.OperatorAssumptions(true))
+        @test alg isa PartitionedSolversAlgorithm
+
+        sol = solve(LinearProblem(A, b; u0 = u0), alg; abstol = 1.0e-12, reltol = 1.0e-12)
+        @test sol.retcode == SciMLBase.ReturnCode.Success
+        assert_owned_approx(sol.u, 1.0)
+    end
+end
+
+@testset "PartitionedSolversAlgorithm: local default solver path" begin
+    with_debug() do distribute
+        rp = debug_row_partition(distribute, 8)
+        A, b, u0 = build_splitmat_diag(rp)
+
+        sol = solve(LinearProblem(A, b; u0 = u0), PartitionedSolversAlgorithm())
+        @test sol.retcode == SciMLBase.ReturnCode.Success
+        @test sol.iters == 0
+        assert_owned_approx(sol.u, 1.0)
+    end
+end
+
+@testset "PartitionedSolversAlgorithm: solver-agnostic (jacobi)" begin
+    # cg slurps keyword arguments, but jacobi has a fixed signature (iterations, omega).
+    # This exercises the solver-aware keyword forwarding so the integration is not cg-only.
+    with_debug() do distribute
+        rp = debug_row_partition(distribute, 8)
+        A, b, u0 = build_splitmat_diag(rp)
+        cache = SciMLBase.init(
+            LinearProblem(A, b; u0 = u0),
+            PartitionedSolversAlgorithm(PartitionedSolvers.jacobi);
+            maxiters = 20
+        )
+
+        sol1 = solve!(cache)
+        @test sol1.retcode == SciMLBase.ReturnCode.Success
+        assert_owned_approx(sol1.u, 1.0)
+
+        b2 = PVector(map(rng -> 2.0 .* Float64.(rng), rp), rp)
+        cache.b = b2
+        sol2 = solve!(cache)
+        @test sol2.retcode == SciMLBase.ReturnCode.Success
+        assert_owned_approx(sol2.u, 2.0)
+    end
+end
+
+@testset "PartitionedSolversAlgorithm: maxiters maps to non-success retcode" begin
+    with_debug() do distribute
+        rp = debug_row_partition(distribute, 64)
+        A, b, u0 = build_splitmat_diag(rp)
+        cache = SciMLBase.init(
+            LinearProblem(A, b; u0 = u0),
+            PartitionedSolversAlgorithm(PartitionedSolvers.cg);
+            abstol = 1.0e-16,
+            reltol = 1.0e-16,
+            maxiters = 1
+        )
+
+        sol = solve!(cache)
+        @test sol.retcode == SciMLBase.ReturnCode.MaxIters
+        @test sol.iters == 1
+        @test sol.resid > 0.0
     end
 end
 

--- a/test/partitionedsolverstests_mpi.jl
+++ b/test/partitionedsolverstests_mpi.jl
@@ -1,0 +1,88 @@
+using LinearSolve
+using MPI
+using PartitionedArrays
+using PartitionedArrays: PVector, own_to_local, partition, tuple_of_arrays,
+    uniform_partition, with_mpi
+using PartitionedSolvers
+using Test
+import SciMLBase
+
+MPI.Init()
+
+function mpi_row_partition(distribute, n)
+    parts = distribute(LinearIndices((MPI.Comm_size(MPI.COMM_WORLD),)))
+    return uniform_partition(parts, n)
+end
+
+function build_splitmat_diag(row_partition, scale = 1.0)
+    I_v, J_v, V_v = map(row_partition) do rng
+        collect(Int, rng), collect(Int, rng), scale .* Float64.(rng)
+    end |> tuple_of_arrays
+    A = psparse(I_v, J_v, V_v, row_partition, row_partition) |> fetch
+    b = PVector(map(rng -> scale .* Float64.(rng), row_partition), row_partition)
+    u = PVector(map(rng -> zeros(length(rng)), row_partition), row_partition)
+    return A, b, u
+end
+
+function assert_owned_approx(u::PVector, expected_val; atol = 1.0e-8)
+    map(partition(u), partition(axes(u, 1))) do local_u, row_idx
+        for j in own_to_local(row_idx)
+            @test local_u[j] ≈ expected_val atol = atol
+        end
+    end
+    return nothing
+end
+
+@testset "PartitionedSolversAlgorithm MPI: CG solve and reuse" begin
+    with_mpi() do distribute
+        rp = mpi_row_partition(distribute, 16)
+        A, b, u0 = build_splitmat_diag(rp)
+        cache = SciMLBase.init(
+            LinearProblem(A, b; u0 = u0),
+            PartitionedSolversAlgorithm(PartitionedSolvers.cg);
+            abstol = 1.0e-12,
+            reltol = 1.0e-12,
+            maxiters = 40
+        )
+
+        sol1 = solve!(cache)
+        @test sol1.retcode == SciMLBase.ReturnCode.Success
+        assert_owned_approx(sol1.u, 1.0)
+
+        b2 = PVector(map(rng -> 2.0 .* Float64.(rng), rp), rp)
+        cache.b = b2
+        sol2 = solve!(cache)
+        @test sol2.retcode == SciMLBase.ReturnCode.Success
+        assert_owned_approx(sol2.u, 2.0)
+    end
+end
+
+@testset "PartitionedSolversAlgorithm MPI: solver-agnostic (jacobi)" begin
+    with_mpi() do distribute
+        rp = mpi_row_partition(distribute, 16)
+        A, b, u0 = build_splitmat_diag(rp)
+        cache = SciMLBase.init(
+            LinearProblem(A, b; u0 = u0),
+            PartitionedSolversAlgorithm(PartitionedSolvers.jacobi);
+            maxiters = 20
+        )
+
+        sol = solve!(cache)
+        @test sol.retcode == SciMLBase.ReturnCode.Success
+        assert_owned_approx(sol.u, 1.0)
+    end
+end
+
+@testset "PartitionedSolversAlgorithm MPI: defaultalg dispatch" begin
+    with_mpi() do distribute
+        rp = mpi_row_partition(distribute, 16)
+        A, b, u0 = build_splitmat_diag(rp)
+
+        alg = LinearSolve.defaultalg(A, b, LinearSolve.OperatorAssumptions(true))
+        @test alg isa PartitionedSolversAlgorithm
+
+        sol = solve(LinearProblem(A, b; u0 = u0), alg; abstol = 1.0e-12, reltol = 1.0e-12)
+        @test sol.retcode == SciMLBase.ReturnCode.Success
+        assert_owned_approx(sol.u, 1.0)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -120,6 +120,14 @@ if Base.Sys.islinux() && (GROUP == "All" || GROUP == "LinearSolveHYPRE") && HAS_
     @time @safetestset "LinearSolveHYPRE" include("hypretests.jl")
 end
 
+if Base.Sys.islinux() && (GROUP == "All" || GROUP == "LinearSolvePartitionedSolvers") &&
+        HAS_EXTENSIONS
+    @time @safetestset "LinearSolvePartitionedSolvers" include("partitionedsolverstests.jl")
+    @time @safetestset "LinearSolvePartitionedSolversMPI" include(
+        "partitionedsolverstests_mpi.jl"
+    )
+end
+
 if Base.Sys.islinux() && GROUP == "LinearSolvePETSc" && HAS_EXTENSIONS
     Pkg.activate("petsc")
     Pkg.develop(PackageSpec(path = dirname(@__DIR__)))


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Included in this PR:
- delegate `PartitionedSolversAlgorithm` solves to the local `PartitionedSolvers` API
- build a `PartitionedSolvers.linear_problem` from the `LinearCache`
- construct or update the cached `PartitionedSolvers` solver object across repeated solves
- reuse the cached solver path across updated right-hand sides and updated matrices
- add typed `defaultalg` dispatch for square `PSparseMatrix` / `PVector` problems
- handle the no-argument `PartitionedSolversAlgorithm()` path correctly
- make solver keyword forwarding solver-agnostic: auto-derived convergence options (`iterations`, `abstol`, `reltol`, `verbose`, `Pl`) are filtered per solver constructor using `Base.kwarg_decl`, so slurping Krylov solvers like `cg` receive all of them while fixed-signature solvers like `jacobi` / `amg` receive only their declared keywords; user-supplied keywords always pass through and take precedence
- add direct serial debug-array tests for solve, cache reuse, default dispatch, solver-agnostic forwarding (`jacobi`), and non-success `retcode`
- add direct 2-rank MPI tests for solve, cache reuse, solver-agnostic forwarding (`jacobi`), and default dispatch
- wire the new PartitionedSolvers tests into `test/runtests.jl` through a dedicated `LinearSolvePartitionedSolvers` group
- update the `PartitionedSolversAlgorithm` docstring to document the solver-agnostic behavior
- update the main solver docs to describe the active PartitionedSolvers path, including a non-CG (`jacobi`) example

Scope note:
- this PR completes the proposal’s PartitionedSolvers solve-path and typed-dispatch work
- the proposal listed CG and GMRES validation, but the checked-out `PartitionedSolvers` provides no distributed GMRES (`gmres` / `minres` are `IterativeSolvers` re-exports, not partitioned solvers); the multi-solver intent is therefore satisfied by validating CG plus the native distributed `jacobi` iteration, enabled by the solver-agnostic keyword forwarding above

AI Disclosure: Used GPT 5.4