### PR TITLE
Guard JLL is_available() against old builds lacking the API

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -66,7 +66,12 @@ end
         # In particular, the `_64` APIs do not exist
         # https://www.intel.com/content/www/us/en/developer/articles/release-notes/onemkl-release-notes-2022.html
         using MKL_jll: MKL_jll
-        const usemkl = MKL_jll.is_available() && pkgversion(MKL_jll) >= v"2022.2"
+        # Check the version before `is_available`: MKL_jll builds older than the
+        # one carrying the JLLWrappers `is_available` API don't define it, and
+        # those are exactly the < 2022.2 builds rejected here anyway. Calling
+        # `is_available` first would throw an UndefVarError on such old builds
+        # (e.g. under `]up`-downgrade resolution).
+        const usemkl = pkgversion(MKL_jll) >= v"2022.2" && MKL_jll.is_available()
     else
         const usemkl = false
     end
@@ -84,7 +89,7 @@ end
 # OpenBLAS_jll is a standard library, but allow users to disable it via preferences
 if Preferences.@load_preference("LoadOpenBLAS_JLL", true)
     using OpenBLAS_jll: OpenBLAS_jll, libopenblas
-    const useopenblas = OpenBLAS_jll.is_available()
+    const useopenblas = isdefined(OpenBLAS_jll, :is_available) && OpenBLAS_jll.is_available()
 else
     const useopenblas = false
     global libopenblas

--- a/src/mkl.jl
+++ b/src/mkl.jl
@@ -16,8 +16,8 @@ MKLLUFactorization(; residualsafety::Bool = false) = MKLLUFactorization(residual
 # MKL_jll < 2022.2 doesn't support the mixed LP64 and ILP64 interfaces that we make use of in LinearSolve
 # In particular, the `_64` APIs do not exist
 # https://www.intel.com/content/www/us/en/developer/articles/release-notes/onemkl-release-notes-2022.html
-@static if !@isdefined(MKL_jll) || !MKL_jll.is_available() ||
-        pkgversion(MKL_jll) < v"2022.2"
+@static if !@isdefined(MKL_jll) || pkgversion(MKL_jll) < v"2022.2" ||
+        !MKL_jll.is_available()
     __mkl_isavailable() = false
 else
     __mkl_isavailable() = true

--- a/src/openblas.jl
+++ b/src/openblas.jl
@@ -41,7 +41,8 @@ OpenBLASLUFactorization(; residualsafety::Bool = false) = OpenBLASLUFactorizatio
 @static if !@isdefined(OpenBLAS_jll)
     __openblas_isavailable() = false
 else
-    __openblas_isavailable() = OpenBLAS_jll.is_available()
+    __openblas_isavailable() = isdefined(OpenBLAS_jll, :is_available) &&
+        OpenBLAS_jll.is_available()
 end
 
 function openblas_getrf!(


### PR DESCRIPTION
## Summary

Guards the `MKL_jll.is_available()` / `OpenBLAS_jll.is_available()` calls so LinearSolve precompiles even when an old JLL build lacking the JLLWrappers `is_available` API is resolved.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

## Problem

`is_available()` is a JLLWrappers API; JLL builds older than its introduction don't define it. LinearSolve called it unconditionally in four places:

- `src/LinearSolve.jl:69` — `const usemkl = MKL_jll.is_available() && pkgversion(MKL_jll) >= v"2022.2"`
- `src/LinearSolve.jl:87` — `const useopenblas = OpenBLAS_jll.is_available()`
- `src/mkl.jl:19` — `@static if !@isdefined(MKL_jll) || !MKL_jll.is_available() || pkgversion(MKL_jll) < v"2022.2"`
- `src/openblas.jl:44` — `__openblas_isavailable() = OpenBLAS_jll.is_available()`

Under downgrade-compat resolution (the `Downgrade.yml` "alldeps" job), MKL_jll can be pinned to the 2019 series, whose build does **not** define `is_available`, so precompilation fails with:

```
ERROR: LoadError: UndefVarError: `is_available` not defined
 [2] top-level scope @ src/LinearSolve.jl:69
```

This is pre-existing and independent of any particular feature branch; it surfaces whenever such an old MKL_jll build is resolved (confirmed locally: MKL_jll 2019.0.117 + JLLWrappers 1.8.0 → `isdefined(MKL_jll, :is_available) == false`).

## Fix

- **MKL** (`LinearSolve.jl:69`, `mkl.jl:19`): reorder so the existing `pkgversion(MKL_jll) >= v"2022.2"` check short-circuits *before* `is_available()`. MKL_jll < 2022.2 is rejected on version anyway, so `is_available` is only evaluated on builds new enough to define it.
- **OpenBLAS** (`LinearSolve.jl:87`, `openblas.jl:44`): guard with `isdefined(OpenBLAS_jll, :is_available)`.

## Testing (local, Julia 1.10)

With MKL_jll pinned to `2019.0.117` (`isdefined(MKL_jll, :is_available) == false`):

- **Before:** `using LinearSolve` → `UndefVarError: is_available` at `src/LinearSolve.jl:69`.
- **After:** `using LinearSolve` loads cleanly with `usemkl=false`, `useopenblas=true`.

Runic formatting passes on all three touched files.

## Context

Split out of #995 (PureKLU default) to keep that PR focused; this is the second of the two distinct failures the `Downgrade.yml` job was hitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
