### PR TITLE
ci: add centralized sublibrary downgrade CI

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -1,0 +1,26 @@
+name: Downgrade Sublibraries
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  downgrade-sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
+    secrets: "inherit"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,Random,Test,Base64,Dates,Printf,LinearSolve"
+      allow-reresolve: true


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What

Adds `.github/workflows/DowngradeSublibraries.yml`, a thin caller for the centralized SciML reusable workflow `SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1`. This runs downgrade tests (oldest-compatible dependency versions) for every `lib/*` subpackage, matching the approach used in OrdinaryDiffEq.jl.

Triggers on `push`/`pull_request` to `main` (with `docs/**` paths ignored), with a concurrency group to cancel superseded in-progress runs on branches.

## Sublibraries covered (auto-discovered)

The workflow leaves `projects` empty, so the reusable workflow auto-discovers all `lib/*` packages with a `Project.toml`:

- `lib/LinearSolveAutotune`
- `lib/LinearSolvePyAMG`

Both have `test/runtests.jl`.

## `skip` list and rationale

`skip` lists dependencies that should NOT have their compat bounds downgraded:

- **Standard libraries** (no meaningful downgrade; versioned with Julia itself): `Pkg`, `TOML`, `Statistics`, `LinearAlgebra`, `SparseArrays`, `InteractiveUtils`, `Random`, `Test`, `Base64`, `Dates`, `Printf`
- **In-repo core package**: `LinearSolve` — both sublibraries depend on the repo-root `LinearSolve` via `[sources] LinearSolve = {path = "../.."}`. Downgrading it would pull a registered/older version instead of the in-tree code under test.

`allow-reresolve: true` is kept (the default) so the resolver can relax when a downgraded set is otherwise unsatisfiable.

## Note

This adds new required-style status checks (one downgrade job per sublibrary). New checks will appear on PRs once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)