### PR TITLE
ci: route CI through SciML/.github reusable workflows (@v1)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,25 +12,11 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        group:
-          - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1.7.0
-      - uses: julia-actions/julia-runtest@v1.11.2
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "Core"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,59 +7,23 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['lts']
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceII}
           - {user: SciML, repo: ModelingToolkit.jl, group: All}
           - {user: SciML, repo: SciMLSensitivity.jl, group: Core1}
           - {user: SciML, repo: BoundaryValueDiffEq.jl, group: All}
           - {user: SciML, repo: NonlinearSolve.jl, group: Core}
-    # Allow downstream failures that are not caused by LinearSolve.jl
-    # See: https://github.com/SciML/LinearSolve.jl/issues/880
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@v1.7.0
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-        env:
-          RETESTITEMS_NWORKERS: 4
-          RETESTITEMS_NWORKER_THREADS: 2
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          file: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+      julia-version: "lts"
+      # Allow downstream failures that are not caused by LinearSolve.jl
+      # See: https://github.com/SciML/LinearSolve.jl/issues/880
+      continue-on-error: true
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
 name: format-check
-
 on:
   push:
     branches:
@@ -8,15 +7,8 @@ on:
       - 'release-'
     tags: '*'
   pull_request:
-
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,13 +1,7 @@
 name: Spell Check
-
 on: [pull_request]
-
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR routes LinearSolve.jl's bespoke standard CI workflows through the centralized SciML reusable workflows in `SciML/.github/.github/workflows/*.yml@v1`, preserving each workflow's existing configuration (triggers, matrices, downstream package list, downgrade settings).

## Converted workflows

| File | Now calls | Preserved config |
|------|-----------|------------------|
| `Downgrade.yml` | `downgrade.yml@v1` | julia 1.10, group `Core`, skip `Pkg,TOML`, `allow-reresolve: false`, push/PR on `main` with `paths-ignore: docs/**` |
| `Downstream.yml` | `downstream.yml@v1` | Same 5-package matrix (OrdinaryDiffEq/InterfaceII, ModelingToolkit/All, SciMLSensitivity/Core1, BoundaryValueDiffEq/All, NonlinearSolve/Core), julia `lts`, `continue-on-error: true` |
| `FormatCheck.yml` | `runic.yml@v1` | SciML Runic standard; push on master/main/release-, tags, PR |
| `SpellCheck.yml` | `spellcheck.yml@v1` | PR trigger |

## Already reusable (left untouched)

- `Tests.yml` — already `uses: SciML/.github/.github/workflows/tests.yml@v1`.
- `Documentation.yml` — already `uses: SciML/.github/.github/workflows/documentation.yml@v1`.

## Intentionally left bespoke

- `GPU.yml` — self-hosted CUDA job (`runs-on: [self-hosted, gpu-v100]`, `GROUP=LinearSolveCUDA`, 180-min timeout). No reusable faithfully expresses this; not converting to avoid dropping GPU coverage.
- `TagBot.yml` — release automation (not CI).
- `CompatHelper.yml` — dependency automation (not CI).
- `DocsPreviewCleanup.yml` — gh-pages preview cleanup automation (not CI).

## Sublibrary handling

`lib/LinearSolveAutotune` and `lib/LinearSolvePyAMG` are real tested libraries, but they are **already tested through the main package's GROUP mechanism** (the root `test/runtests.jl` runs `Pkg.test` on the `LinearSolveAutotune` / `LinearSolvePyAMG` groups, which are part of the `Tests.yml` matrix). There is **no per-sublibrary CI** (`CI_*.yml` / `SublibraryCI.yml` / `DowngradeSublibraries.yml`) in this repo. Introducing `sublibrary-tests.yml@v1` would add new, duplicate coverage and change the existing model, so no sublibrary CI is added here. The repo is treated as single-package for CI routing.

## NOTE: required-status-check names change

Routing through the reusable workflows changes the **job names** that appear as status checks (they now match the reusable workflows' job names). Branch protection required-status-check names must be updated accordingly after merge, otherwise required checks will report as missing.

---

Please ignore until reviewed by @ChrisRackauckas.
