### PR TITLE
Add SpecializingFactorizations.jl package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -63,6 +63,7 @@ STRUMPACK_jll = "86fbd0b9-476f-557c-b766-62c724b42d8c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseMatricesCSR = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
 Sparspak = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
+SpecializingFactorizations = "fa08b7a1-13d3-4faf-875d-5cbc1520e3f3"
 blis_jll = "6136c539-28a5-5bf0-87cc-b183200dce32"
 
 [extensions]
@@ -98,6 +99,7 @@ LinearSolveRecursiveFactorizationExt = "RecursiveFactorization"
 LinearSolveSTRUMPACKExt = ["SparseArrays", "STRUMPACK_jll"]
 LinearSolveSparseArraysExt = "SparseArrays"
 LinearSolveSparspakExt = ["SparseArrays", "Sparspak"]
+LinearSolveSpecializingFactorizationsExt = "SpecializingFactorizations"
 
 [compat]
 AMD = "0.5"
@@ -163,6 +165,7 @@ SparseArrays = "1.10"
 SparseColumnPivotedQR = "2"
 SparseMatricesCSR = "0.6"
 Sparspak = "0.3.9"
+SpecializingFactorizations = "0.1"
 StaticArrays = "1.9"
 StaticArraysCore = "1.4.3"
 Test = "1.10"
@@ -192,9 +195,10 @@ STRUMPACK_jll = "86fbd0b9-476f-557c-b766-62c724b42d8c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Sparspak = "e56a9233-b9d6-4f03-8d0f-1825330902ac"
+SpecializingFactorizations = "fa08b7a1-13d3-4faf-875d-5cbc1520e3f3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["AlgebraicMultigrid", "BandedMatrices", "BlockDiagonals", "CliqueTrees", "ComponentArrays", "FastAlmostBandedMatrices", "FastLapackInterface", "FiniteDiff", "ForwardDiff", "InteractiveUtils", "IterativeSolvers", "KrylovKit", "KrylovPreconditioners", "MultiFloats", "Pkg", "Random", "RecursiveFactorization", "STRUMPACK_jll", "SafeTestsets", "SparseArrays", "Sparspak", "StaticArrays", "Test", "Zygote"]
+test = ["AlgebraicMultigrid", "BandedMatrices", "BlockDiagonals", "CliqueTrees", "ComponentArrays", "FastAlmostBandedMatrices", "FastLapackInterface", "FiniteDiff", "ForwardDiff", "InteractiveUtils", "IterativeSolvers", "KrylovKit", "KrylovPreconditioners", "MultiFloats", "Pkg", "Random", "RecursiveFactorization", "STRUMPACK_jll", "SafeTestsets", "SparseArrays", "Sparspak", "SpecializingFactorizations", "StaticArrays", "Test", "Zygote"]

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -151,6 +151,17 @@ LinearSolve.DefaultLinearSolver
 RFLUFactorization
 ```
 
+### SpecializingFactorizations.jl
+
+!!! note
+    
+    Using this solver requires adding the package SpecializingFactorizations.jl, i.e. `using SpecializingFactorizations`
+
+```@docs
+SpecializedLUFactorization
+SpecializedQRFactorization
+```
+
 ### Base.LinearAlgebra
 
 These overloads tend to work for many array types, such as `CuArrays` for GPU-accelerated

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -392,7 +392,9 @@ end
 # Check if the algorithm should use the direct dual solve path
 # (algorithms that can work directly with Dual numbers without the primal/partials separation)
 function _use_direct_dual_solve(alg)
-    return alg isa GenericLUFactorization
+    return alg isa GenericLUFactorization ||
+        alg isa LinearSolve.SpecializedLUFactorization ||
+        alg isa LinearSolve.SpecializedQRFactorization
 end
 
 function _use_direct_dual_solve(alg::DefaultLinearSolver)

--- a/ext/LinearSolveSpecializingFactorizationsExt.jl
+++ b/ext/LinearSolveSpecializingFactorizationsExt.jl
@@ -1,0 +1,79 @@
+module LinearSolveSpecializingFactorizationsExt
+
+using LinearSolve, LinearAlgebra
+using LinearSolve: LinearCache, OperatorAssumptions, LinearVerbosity, @get_cacheval
+using SciMLBase: SciMLBase, ReturnCode
+using SpecializingFactorizations: specializinglu, specializinglu!,
+    specializingqr, specializingqr!
+
+function LinearSolve.init_cacheval(
+        ::SpecializedLUFactorization, A, b, u, Pl, Pr, maxiters::Int, abstol,
+        reltol, verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
+    )
+    A isa AbstractMatrix || return nothing
+    return specializinglu(convert(AbstractMatrix, A))
+end
+
+function SciMLBase.solve!(
+        cache::LinearCache, alg::SpecializedLUFactorization; kwargs...
+    )
+    A = convert(AbstractMatrix, cache.A)
+    F = @get_cacheval(cache, :SpecializedLUFactorization)
+    if cache.isfresh
+        if F === nothing
+            F = specializinglu(A)
+        else
+            specializinglu!(F, A)
+        end
+        cache.cacheval = F
+        cache.isfresh = false
+    end
+    F = @get_cacheval(cache, :SpecializedLUFactorization)
+    if !LinearAlgebra.issuccess(F)
+        return SciMLBase.build_linear_solution(
+            alg, cache.u, nothing, cache; retcode = ReturnCode.Failure
+        )
+    end
+    ldiv!(cache.u, F, cache.b)
+    return SciMLBase.build_linear_solution(
+        alg, cache.u, nothing, cache; retcode = ReturnCode.Success
+    )
+end
+
+function LinearSolve.init_cacheval(
+        ::SpecializedQRFactorization, A, b, u, Pl, Pr, maxiters::Int, abstol,
+        reltol, verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
+    )
+    A isa AbstractMatrix || return nothing
+    return specializingqr(convert(AbstractMatrix, A))
+end
+
+function SciMLBase.solve!(
+        cache::LinearCache, alg::SpecializedQRFactorization; kwargs...
+    )
+    A = convert(AbstractMatrix, cache.A)
+    F = @get_cacheval(cache, :SpecializedQRFactorization)
+    if cache.isfresh
+        if F === nothing
+            F = specializingqr(A)
+        else
+            specializingqr!(F, A)
+        end
+        cache.cacheval = F
+        cache.isfresh = false
+    end
+    F = @get_cacheval(cache, :SpecializedQRFactorization)
+    # SpecializedQR is rank-safe and never reports failure for rank deficiency;
+    # issuccess only guards genuine numerical breakdown.
+    if !LinearAlgebra.issuccess(F)
+        return SciMLBase.build_linear_solution(
+            alg, cache.u, nothing, cache; retcode = ReturnCode.Failure
+        )
+    end
+    ldiv!(cache.u, F, cache.b)
+    return SciMLBase.build_linear_solution(
+        alg, cache.u, nothing, cache; retcode = ReturnCode.Success
+    )
+end
+
+end

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -525,7 +525,8 @@ export LUFactorization, SVDFactorization, QRFactorization, GenericFactorization,
     SparspakFactorization, DiagonalFactorization, CholeskyFactorization,
     BunchKaufmanFactorization, CHOLMODFactorization, LDLtFactorization,
     CUSOLVERRFFactorization, CliqueTreesFactorization, ParUFactorization,
-    STRUMPACKFactorization, MUMPSFactorization
+    STRUMPACKFactorization, MUMPSFactorization,
+    SpecializedLUFactorization, SpecializedQRFactorization
 
 export LinearSolveFunction, DirectLdiv!, show_algorithm_choices
 

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -1529,3 +1529,66 @@ end
 function ElementalJL(; method::Symbol = :LU)
     return ElementalJL(method)
 end
+
+"""
+    SpecializedLUFactorization()
+
+A type-stable, structure-detecting dense LU-style solver from
+SpecializingFactorizations.jl. It cheaply scans the (dense) matrix `A` to detect
+whether it actually has special structure (diagonal, bidiagonal, tridiagonal,
+banded, triangular, symmetric positive definite, symmetric/Hermitian indefinite)
+and dispatches to the matching specialized factorization instead of always using
+a general `O(n^3)` LU. Detection is tracked by a runtime enum stored in a single
+concrete workspace type, so the whole detect -> factor -> solve pipeline is
+type-stable and allocation-free on the warm path.
+
+This is for **square** systems only; use [`SpecializedQRFactorization`](@ref) for
+rectangular / rank-deficient least-squares problems.
+
+!!! note
+
+    Using this solver requires that SpecializingFactorizations.jl is loaded:
+    `using SpecializingFactorizations`.
+
+## Example
+
+```julia
+using SpecializingFactorizations
+A = Matrix(Tridiagonal(rand(99), rand(100) .+ 4, rand(99)))
+b = rand(100)
+prob = LinearProblem(A, b)
+sol = solve(prob, SpecializedLUFactorization())
+```
+"""
+struct SpecializedLUFactorization <: AbstractDenseFactorization end
+
+"""
+    SpecializedQRFactorization()
+
+A type-stable, rank-revealing dense QR least-squares solver from
+SpecializingFactorizations.jl. It uses a column-pivoted, rank-revealing QR
+(LAPACK `geqp3`) to reveal the numerical rank of a possibly **rectangular** or
+**rank-deficient** matrix and returns the least-squares solution for any shape,
+**including singular and rank-deficient** matrices, without ever throwing. For a
+rank-deficient system it returns the minimum-norm least-squares solution
+(matching `pinv(A) * b`). For square `BlasFloat` inputs it reuses the same
+structure-detection scan as [`SpecializedLUFactorization`](@ref) to take cheaper
+structured paths when doing so provably reproduces the dense rank-revealing
+result.
+
+!!! note
+
+    Using this solver requires that SpecializingFactorizations.jl is loaded:
+    `using SpecializingFactorizations`.
+
+## Example
+
+```julia
+using SpecializingFactorizations
+A = randn(100, 40)  # overdetermined least-squares
+b = randn(100)
+prob = LinearProblem(A, b)
+sol = solve(prob, SpecializedQRFactorization())
+```
+"""
+struct SpecializedQRFactorization <: AbstractDenseFactorization end

--- a/test/core/forwarddiff_overloads.jl
+++ b/test/core/forwarddiff_overloads.jl
@@ -5,6 +5,7 @@ using LinearAlgebra
 using SparseArrays
 using ComponentArrays
 using Sparspak
+using SpecializingFactorizations
 
 function h(p)
     return (
@@ -16,6 +17,37 @@ function h(p)
         b = [p[1] + 1, p[2] * 2, p[1]^2],
     )
 end
+
+# Opt-out dense methods: SpecializedLU/QR solve the Dual problem directly
+# (no primal/partials splitting). The partials can differ from `\` by an ulp,
+# and isapprox over Dual vectors NaNs when the primal diff is exactly zero
+# (sqrt has infinite slope at 0), so compare values and partials separately.
+function dual_isapprox(x, y; rtol)
+    isapprox(ForwardDiff.value.(x), ForwardDiff.value.(y); rtol) || return false
+    return isapprox(
+        reduce(hcat, collect.(ForwardDiff.partials.(x))),
+        reduce(hcat, collect.(ForwardDiff.partials.(y))); rtol
+    )
+end
+
+A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
+prob = LinearProblem(A, b)
+backslash_x_p = A \ b
+@test dual_isapprox(
+    solve(prob, SpecializedLUFactorization()).u, backslash_x_p, rtol = 1.0e-9
+)
+@test dual_isapprox(
+    solve(prob, SpecializedQRFactorization()).u, backslash_x_p, rtol = 1.0e-9
+)
+
+# Rectangular least-squares with Duals through the direct dual path
+p_ls = [ForwardDiff.Dual(2.0, 1.0, 0.0), ForwardDiff.Dual(3.0, 0.0, 1.0)]
+A_ls = [p_ls[1] 1.0; 1.0 p_ls[2]; p_ls[1] p_ls[2]]
+b_ls = [p_ls[1] + 1, p_ls[2] * 2, p_ls[1] * p_ls[2]]
+qr_ls_x_p = solve(LinearProblem(A_ls, b_ls), SpecializedQRFactorization())
+@test dual_isapprox(qr_ls_x_p.u, qr(A_ls) \ b_ls, rtol = 1.0e-9)
+
+# Overload Dense
 
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 

--- a/test/core/resolve.jl
+++ b/test/core/resolve.jl
@@ -1,4 +1,5 @@
 using LinearSolve, LinearAlgebra, SparseArrays, InteractiveUtils, Test
+using SpecializingFactorizations
 using LinearSolve: AbstractDenseFactorization, AbstractSparseFactorization,
     BLISLUFactorization, CliqueTreesFactorization,
     AMDGPUOffloadLUFactorization, AMDGPUOffloadQRFactorization,

--- a/test/core/specializing_factorizations.jl
+++ b/test/core/specializing_factorizations.jl
@@ -43,8 +43,8 @@ end
     # Float32 and Complex eltypes
     Af = Matrix{Float32}(I, n, n) + 0.1f0 * rand(rng, Float32, n, n)
     bf = rand(rng, Float32, n)
-    solf = solve(LinearProblem(Af, bf), SpecializedLUFactorization())
-    @test Af * solf.u ≈ bf atol = 1.0f-4
+    sol32 = solve(LinearProblem(Af, bf), SpecializedLUFactorization())
+    @test Af * sol32.u ≈ bf atol = 1.0f-4
 
     Ac = Matrix{ComplexF64}(I, n, n) + 0.1 * (rand(rng, n, n) + im * rand(rng, n, n))
     bc = rand(rng, ComplexF64, n)

--- a/test/core/specializing_factorizations.jl
+++ b/test/core/specializing_factorizations.jl
@@ -1,0 +1,90 @@
+using LinearSolve, LinearAlgebra, Test, Random, SciMLBase
+using SpecializingFactorizations
+
+@testset "SpecializingFactorizations extension loads" begin
+    ext = Base.get_extension(LinearSolve, :LinearSolveSpecializingFactorizationsExt)
+    @test ext isa Module
+end
+
+@testset "SpecializedLUFactorization" begin
+    rng = Random.MersenneTwister(42)
+    n = 100
+
+    # General dense system
+    A = Matrix{Float64}(I, n, n) + 0.1 * rand(rng, n, n)
+    b = rand(rng, n)
+    sol = solve(LinearProblem(A, b), SpecializedLUFactorization())
+    @test sol.retcode == ReturnCode.Success
+    @test A * sol.u ≈ b atol = 1.0e-8
+
+    # Structured (tridiagonal) dense matrix should still solve correctly
+    T = Matrix(Tridiagonal(rand(rng, n - 1), rand(rng, n) .+ 4, rand(rng, n - 1)))
+    bt = rand(rng, n)
+    solt = solve(LinearProblem(T, bt), SpecializedLUFactorization())
+    @test solt.retcode == ReturnCode.Success
+    @test T * solt.u ≈ bt atol = 1.0e-8
+
+    # Caching: reuse the cache across a new A of the same size
+    prob = LinearProblem(copy(A), copy(b))
+    cache = init(prob, SpecializedLUFactorization())
+    s1 = solve!(cache)
+    @test A * s1.u ≈ b atol = 1.0e-8
+
+    A2 = Matrix{Float64}(I, n, n) + 0.2 * rand(rng, n, n)
+    cache.A = A2
+    s2 = solve!(cache)
+    @test A2 * s2.u ≈ b atol = 1.0e-8
+
+    b2 = rand(rng, n)
+    cache.b = b2
+    s3 = solve!(cache)
+    @test A2 * s3.u ≈ b2 atol = 1.0e-8
+
+    # Float32 and Complex eltypes
+    Af = Matrix{Float32}(I, n, n) + 0.1f0 * rand(rng, Float32, n, n)
+    bf = rand(rng, Float32, n)
+    solf = solve(LinearProblem(Af, bf), SpecializedLUFactorization())
+    @test Af * solf.u ≈ bf atol = 1.0f-4
+
+    Ac = Matrix{ComplexF64}(I, n, n) + 0.1 * (rand(rng, n, n) + im * rand(rng, n, n))
+    bc = rand(rng, ComplexF64, n)
+    solc = solve(LinearProblem(Ac, bc), SpecializedLUFactorization())
+    @test Ac * solc.u ≈ bc atol = 1.0e-8
+end
+
+@testset "SpecializedQRFactorization" begin
+    rng = Random.MersenneTwister(7)
+
+    # Square system
+    n = 60
+    A = Matrix{Float64}(I, n, n) + 0.1 * rand(rng, n, n)
+    b = rand(rng, n)
+    sol = solve(LinearProblem(A, b), SpecializedQRFactorization())
+    @test sol.retcode == ReturnCode.Success
+    @test A * sol.u ≈ b atol = 1.0e-8
+
+    # Overdetermined least-squares
+    m, k = 100, 40
+    M = randn(rng, m, k)
+    c = randn(rng, m)
+    solls = solve(LinearProblem(M, c), SpecializedQRFactorization())
+    @test solls.retcode == ReturnCode.Success
+    @test solls.u ≈ M \ c atol = 1.0e-8
+
+    # Rank-deficient: minimum-norm least-squares (== pinv * b), never throws
+    As = randn(rng, 50, 3) * randn(rng, 3, 50)
+    d = randn(rng, 50)
+    soldef = solve(LinearProblem(As, d), SpecializedQRFactorization())
+    @test soldef.retcode == ReturnCode.Success
+    @test soldef.u ≈ pinv(As) * d atol = 1.0e-6
+
+    # Caching across a re-factor of the same shape
+    prob = LinearProblem(copy(M), copy(c))
+    cache = init(prob, SpecializedQRFactorization())
+    s1 = solve!(cache)
+    @test s1.u ≈ M \ c atol = 1.0e-8
+    M2 = randn(rng, m, k)
+    cache.A = M2
+    s2 = solve!(cache)
+    @test s2.u ≈ M2 \ c atol = 1.0e-8
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,6 +102,7 @@ else
         @time @safetestset "Butterfly Factorization" include("core/butterfly.jl")
         @time @safetestset "Mixed Precision" include("core/test_mixed_precision.jl")
         @time @safetestset "Resize" include("core/resize.jl")
+        @time @safetestset "SpecializingFactorizations" include("core/specializing_factorizations.jl")
     end
 
     # STRUMPACK runs in the base env: STRUMPACK_jll is a base test dep (the Core


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Adds an opt-in package extension wrapping [SpecializingFactorizations.jl](https://github.com/SciML/SpecializingFactorizations.jl) as two LinearSolve algorithms. This is a weakdep extension only — no hard dependency and no change to any default algorithm.

## What SpecializingFactorizations.jl provides

It exposes two type-stable, single-workspace dense factorizations that detect the property a matrix actually has and dispatch to the specialized solve, all behind one concrete workspace type (the structure/rank choice is a runtime enum field, not a Julia type, so the pipeline infers and the warm path is allocation-free):

- `specializinglu` / `SpecializedLU` — a **square** solver that cheaply scans `A` for structure (diagonal, bidiagonal, tridiagonal, banded, triangular, symmetric PD, symmetric/Hermitian indefinite) and uses the matching specialized factorization instead of a general `O(n^3)` LU.
- `specializingqr` / `SpecializedQR` — a **rectangular / rank-deficient** least-squares solver. Column-pivoted rank-revealing QR (`geqp3`) that returns the least-squares / minimum-norm solution for any shape including singular/rank-deficient, never throwing.

## Wrapped algorithms

- `SpecializedLUFactorization` — wraps `specializinglu`; for square systems.
- `SpecializedQRFactorization` — wraps `specializingqr`; for rectangular / rank-deficient least-squares.

Both wrapped because they cover complementary problem classes (square structured solves vs. rectangular/rank-deficient least-squares) and both expose the `ldiv!` + in-place re-factor (`specializinglu!` / `specializingqr!`) interface the `LinearCache` warm-solve path wants.

## Implementation

- `src/extension_algs.jl`: two `AbstractDenseFactorization` structs with docstrings + examples; exported from `src/LinearSolve.jl`.
- `ext/LinearSolveSpecializingFactorizationsExt.jl`: `init_cacheval` builds the factorization; `SciMLBase.solve!` re-factors in place on `cache.isfresh` (reusing the workspace via `specializing*!`), guards `issuccess`, and returns `build_linear_solution` with the appropriate `ReturnCode`.
- `Project.toml`: `SpecializingFactorizations` added to `[weakdeps]`, `[extensions]`, `[compat]` (`"0.1"`), `[extras]`, and the `test` target. No `SparseArrays` trigger — it operates on dense matrices only.
- `test/specializing_factorizations.jl`: focused test set (extension load, square/structured/complex/float32 LU, overdetermined and rank-deficient QR, cache reuse across re-factor for both), wired into the Core test group.

## Registration

SpecializingFactorizations.jl is registered in the General registry (v0.1.0).

## Caveats

- `SpecializedLUFactorization` is square-only by construction; rectangular systems should use `SpecializedQRFactorization`.
- Structure detection is structural (`!iszero`), not numerical/tolerant.
- Cache reuse re-factors into the existing workspace; a different matrix *size* on a warm cache regrows buffers (handled by `specializing*!`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)