### PR TITLE
Guard KLU/PureKLU solve! against non-finite (masked-singular) results

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -468,9 +468,24 @@ function SciMLBase.solve!(cache::LinearSolve.LinearCache, alg::KLUFactorization;
     F = LinearSolve.@get_cacheval(cache, :KLUFactorization)
     return if F.common.status == KLU.KLU_OK
         y = ldiv!(cache.u, F, cache.b)
-        SciMLBase.build_linear_solution(
-            alg, y, nothing, cache; retcode = ReturnCode.Success
-        )
+        if all(isfinite, y)
+            SciMLBase.build_linear_solution(
+                alg, y, nothing, cache; retcode = ReturnCode.Success
+            )
+        else
+            # KLU can report `KLU_OK` on a numerically singular matrix (a
+            # tiny-but-nonzero pivot, common when explicit stored zeros mask a
+            # rank deficiency) yet produce non-finite output. Surface that as a
+            # failure instead of a silent NaN `Success`, matching the default
+            # solver's finiteness check.
+            @SciMLMessage(
+                "Solver produced non-finite values; matrix is likely singular",
+                cache.verbose, :solver_failure
+            )
+            SciMLBase.build_linear_solution(
+                alg, cache.u, nothing, cache; retcode = ReturnCode.Infeasible
+            )
+        end
     else
         @SciMLMessage("Solver failed", cache.verbose, :solver_failure)
         SciMLBase.build_linear_solution(
@@ -611,9 +626,24 @@ function SciMLBase.solve!(
     F = LinearSolve.@get_cacheval(cache, :KLUFactorization)
     return if F.common.status == PureKLU.KLU_OK
         y = ldiv!(cache.u, F, cache.b)
-        SciMLBase.build_linear_solution(
-            alg, y, nothing, cache; retcode = ReturnCode.Success
-        )
+        if all(isfinite, y)
+            SciMLBase.build_linear_solution(
+                alg, y, nothing, cache; retcode = ReturnCode.Success
+            )
+        else
+            # PureKLU (like SuiteSparse KLU) can report `KLU_OK` on a numerically
+            # singular matrix (a tiny-but-nonzero pivot, common when explicit
+            # stored zeros mask a rank deficiency) yet produce non-finite output.
+            # Surface that as a failure instead of a silent NaN `Success`,
+            # matching the default solver's finiteness check.
+            @SciMLMessage(
+                "Solver produced non-finite values; matrix is likely singular",
+                cache.verbose, :solver_failure
+            )
+            SciMLBase.build_linear_solution(
+                alg, cache.u, nothing, cache; retcode = ReturnCode.Infeasible
+            )
+        end
     else
         @SciMLMessage("Solver failed", cache.verbose, :solver_failure)
         SciMLBase.build_linear_solution(

--- a/test/default_algs.jl
+++ b/test/default_algs.jl
@@ -44,6 +44,17 @@ prob = LinearProblem(A, ones(2))
 @test solve(prob, KLUFactorization()).retcode == ReturnCode.Infeasible
 @test solve(prob, PureKLUFactorization()).retcode == ReturnCode.Infeasible
 
+# Singular matrix with an *explicit stored zero* pivot: KLU/PureKLU report
+# `KLU_OK` but produce a non-finite solution. The finiteness guard must surface
+# that as `Infeasible` rather than a silent `Success` with NaNs.
+let A_ez = sparse([1, 2], [1, 2], [1.0, 0.0], 2, 2), b_ez = ones(2)
+    klu_sol = solve(LinearProblem(A_ez, b_ez), KLUFactorization())
+    @test klu_sol.retcode == ReturnCode.Infeasible
+    @test !any(isnan, klu_sol.u)  # not a silent NaN Success
+    @test solve(LinearProblem(A_ez, b_ez), PureKLUFactorization()).retcode ==
+        ReturnCode.Infeasible
+end
+
 @test LinearSolve.defaultalg(sprand(10^4, 10^4, 1.0e-5) + I, zeros(1000)).alg ===
     LinearSolve.DefaultAlgorithmChoice.KLUFactorization
 prob = LinearProblem(sprand(1000, 1000, 0.5), zeros(1000))


### PR DESCRIPTION
## Summary

The bare `KLUFactorization` / `PureKLUFactorization` solves can return `ReturnCode.Success` with a **NaN/Inf solution** on numerically singular matrices, because SuiteSparse KLU (and PureKLU) report `KLU_OK` when the singular pivot is tiny-but-nonzero — which is exactly what happens when **explicit stored zeros mask a rank deficiency** (common in MTK-generated Jacobians).

This adds a finiteness guard: after the solve, if the status is `KLU_OK` but `!all(isfinite, y)`, return `ReturnCode.Infeasible` (with a `solver_failure` log) instead of a silent NaN `Success`. It mirrors the robustness the **default** solver already has (its `any(!isfinite, u)` → QR-fallback), and the default keeps working — it now sees `Infeasible` rather than a NaN `Success` and falls back the same way. O(n), no effect on well-conditioned solves.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

## How it was found

Running the 7 PureKLU test matrices from SciML/PureKLU.jl#1 (comment) through the LinearSolve interface: each stores ~1/3 explicit zeros, and matrices 0–3 are rank-(n−1). `solve(prob, KLUFactorization())` / `PureKLUFactorization()` returned `Success` with NaN solutions on those; the default solver was the only path that handled them (NaN → QR fallback → finite least-squares). Confirmed the same `KLU_OK`+NaN behavior with direct `KLU.jl`, so this is the wrapper surfacing KLU's behavior — the guard makes the bare path as honest as the default.

## Test

`test/default_algs.jl`: a singular matrix with an explicit stored-zero pivot (`sparse([1,2],[1,2],[1.0,0.0],2,2)`) now returns `Infeasible` (no NaN) for both `KLUFactorization` and `PureKLUFactorization`. Verified locally on Julia 1.10: `default_algs.jl` passes; Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
