### PR TITLE
Auto-fall-back nonstructural_zeros reduction on stored-pattern changes

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -1084,13 +1084,18 @@ end
 
 function LinearSolve.reduce_operand!(red::SparseReduction, A)
     red.active || return A
+    nz = nonzeros(A)
+    # A change in the stored nnz breaks union caching: an explicit `Persistent`
+    # assumption promised a constant pattern (error), while `Auto` drops the union
+    # and falls back to per-solve dropzeros, handled like the non-union case below.
+    if red.cache_union && length(nz) != length(red.mask)
+        red.auto || throw(ArgumentError("nonstructural_zeros reduction requires a constant \
+                             stored sparsity pattern across solves (stored nnz changed)"))
+        red.cache_union = false
+    end
     # per-solve dropzeros: drop this matrix's own zeros and let the inner solver
     # re-analyze when the pattern changes (no cross-solve union assumed).
     red.cache_union || (red.reduced = dropzeros(A); red.nrefactor += 1; return red.reduced)
-    nz = nonzeros(A)
-    length(nz) == length(red.mask) ||
-        throw(ArgumentError("nonstructural_zeros reduction requires a constant \
-                             stored sparsity pattern across solves (stored nnz changed)"))
     grew = false
     @inbounds for i in eachindex(nz)
         if !red.mask[i] && !iszero(nz[i])

--- a/test/nonstructural_zeros.jl
+++ b/test/nonstructural_zeros.jl
@@ -250,4 +250,36 @@ reduction(cache) = cache.cacheval.sparse_reduction
         cache.A = sparse(2.0I, n, n)   # different stored pattern
         @test_throws ArgumentError solve!(cache)
     end
+
+    @testset "auto falls back to per-solve on a structural pattern change" begin
+        base = copy(mats[1])
+        # rebuild base's full stored triple (explicit zeros included) so we can add
+        # one entry without going through findnz, which would drop the stored zeros.
+        cp = SparseArrays.getcolptr(base)
+        rv = rowvals(base)
+        nzv = nonzeros(base)
+        Ir = collect(rv)
+        Jr = reduce(vcat, [fill(j, cp[j + 1] - cp[j]) for j in 1:n])
+        Vr = collect(nzv)
+        A_new = sparse(vcat(Ir, n), vcat(Jr, 1), vcat(Vr, 0.7), n, n)   # one added stored entry
+        @test nnz(A_new) == nnz(base) + 1
+
+        cache = init(LinearProblem(copy(base), copy(b)))   # auto
+        solve!(cache)
+        @test reduction(cache).active && reduction(cache).cache_union
+        # a stored-nnz change under auto drops the cached union and switches to
+        # per-solve dropzeros rather than throwing; the result stays correct.
+        cache.A = copy(A_new)
+        sol = solve!(cache)
+        @test sol.retcode == ReturnCode.Success
+        @test sol.u ≈ Matrix(A_new) \ b rtol = 1.0e-8
+        @test !reduction(cache).cache_union                 # no longer union caching
+        # it stays in per-solve mode and keeps solving correctly across the new pattern
+        A_new2 = sparse(vcat(Ir, n), vcat(Jr, 1), vcat(Vr, 1.3), n, n)
+        cache.A = copy(A_new2)
+        sol2 = solve!(cache)
+        @test sol2.retcode == ReturnCode.Success
+        @test sol2.u ≈ Matrix(A_new2) \ b rtol = 1.0e-8
+        @test !reduction(cache).cache_union
+    end
 end


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until reviewed by @ChrisRackauckas. Opened as a draft.

## Motivation

On 3.85.0, once the cached-union nonstructural-zeros reduction is active, reassigning `cache.A` to a sparse matrix with a **different stored nnz** throws an `ArgumentError` — *unconditionally*, including under the default `Auto` assumption:

```julia
using LinearSolve, SparseArrays
A1 = sparse([1,1,2,2,3,4],[1,2,2,3,3,4],[4.0,0.0,4.0,0.0,4.0,4.0],4,4)  # >10% stored zeros => Auto activates
cache = init(LinearProblem(A1, ones(4)))
solve!(cache)                                   # ok
cache.A = sparse([1,2,3,4,1],[1,2,3,4,2],[5.0,5.0,5.0,5.0,0.0],4,4)  # different stored nnz
solve!(cache)                                   # ERROR: nonstructural_zeros reduction requires a constant stored sparsity pattern
```

`Auto`'s contract is to *detect and adapt* — it already silently downgrades union-caching to per-solve `dropzeros` on the value-based signal (`NONPERSISTENT_ZERO_FRACTION`, when too many of the starting zeros activate). A structural pattern change is just as clear a non-persistence signal, and the per-solve path already handles varying patterns, so `Auto` should fall back rather than error. `Auto` is the default, so the most common usage currently hits a hard error on a case the per-solve path handles.

## Change

Under `Auto`, a stored-nnz change abandons the cached union and switches to per-solve `dropzeros` — the same non-caching mode `Auto` already falls back to on the value-based signal.

`NonstructuralZeros.Persistent` is **unchanged**: it promises a constant stored pattern, so any structural change still throws (contract enforcement).

## Verification

Run locally on Julia 1.11 against this branch:

- Original example now returns `[0.2,0.2,0.2,0.2]`, with `cache_union` downgraded to per-solve; further changes to the new pattern keep solving correctly.
- `Persistent` + nnz change still throws.
- `test/nonstructural_zeros.jl`: **114 -> 122 passing** (8 new regression assertions). Runic-clean.

## Note (out of scope)

A same-nnz *permuted* pattern under explicit `Persistent` can still silently produce wrong results — no length change to catch it, no `Auto` downgrade. Detecting it needs a per-solve full pattern comparison, which taxes the hot path (`W = I - gamma*J`). Left as a documented contract precondition rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
