### PR TITLE
Fix direct dual solve path for PureKLU and non-dual b (fixes #1023 Core CI)

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -406,8 +406,12 @@ function SciMLBase.solve!(
         ForwardDiff.Dual,
     }
     # Check if this algorithm can work directly with Duals (e.g., GenericLUFactorization)
-    # In that case, we solve the dual problem directly without separating primal/partials
-    if _use_direct_dual_solve(getfield(cache, :linear_cache).alg)
+    # In that case, we solve the dual problem directly without separating primal/partials.
+    # Only worthwhile when A itself carries duals: with duals just in b, the split
+    # path (one primal factorization + partials back-solves) is strictly cheaper
+    # than factorizing in dual arithmetic.
+    if _use_direct_dual_solve(getfield(cache, :linear_cache).alg) &&
+            get_dual_type(getfield(cache, :dual_A)) !== nothing
         return _solve_direct_dual!(cache, alg, args...; kwargs...)
     end
 
@@ -437,6 +441,13 @@ function _solve_direct_dual!(
     # Get the dual A and b
     dual_A = getfield(cache, :dual_A)
     dual_b = getfield(cache, :dual_b)
+
+    # When the duals are only in A, b is stored as a plain array. Promote it to
+    # the dual type: `__init` takes the solution eltype from `b`, and the
+    # factorization/solve kernels need matching element types.
+    if eltype(dual_b) != DT
+        dual_b = DT.(dual_b)
+    end
 
     # Use __init to create a regular LinearCache (bypasses ForwardDiff extension)
     # then solve! on that cache directly with the dual values

--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -542,12 +542,14 @@ function LinearSolve.init_cacheval(
     return PREALLOCATED_PUREKLU
 end
 
+# PureKLU's kernels are pure Julia and generic over `Union{Real, Complex}`
+# (e.g. ForwardDiff duals via the direct dual solve path), not just BLAS types.
 function LinearSolve.init_cacheval(
         alg::PureKLUFactorization, A::AbstractSparseArray{T, Int64}, b, u, Pl, Pr,
         maxiters::Int, abstol,
         reltol,
         verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-    ) where {T <: Union{Float64, ComplexF64}}
+    ) where {T <: Union{Real, Complex}}
     return PureKLU.KLUFactorization(
         SparseMatrixCSC{T, Int64}(
             0, 0, [Int64(1)], Int64[], T[]
@@ -573,7 +575,7 @@ function LinearSolve.init_cacheval(
         maxiters::Int, abstol,
         reltol,
         verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-    ) where {T <: Union{Float64, ComplexF64}}
+    ) where {T <: Union{Real, Complex}}
     return PureKLU.KLUFactorization(
         SparseMatrixCSC{T, Int32}(
             0, 0, [Int32(1)], Int32[], T[]

--- a/test/core/forwarddiff_overloads.jl
+++ b/test/core/forwarddiff_overloads.jl
@@ -29,6 +29,18 @@ backslash_x_p = A \ b
 @test ≈(generic_x_p, backslash_x_p, rtol = 1.0e-9)
 @test ≈(rflu_x_p, backslash_x_p, rtol = 1.0e-9)
 
+# Opt-out path with duals only in A (plain b) and only in b (plain A)
+
+plain_b = ForwardDiff.value.(b)
+prob = LinearProblem(A, plain_b)
+@test ≈(solve(prob, GenericLUFactorization()), A \ plain_b, rtol = 1.0e-9)
+@test ≈(solve(prob, RFLUFactorization()), A \ plain_b, rtol = 1.0e-9)
+
+plain_A = ForwardDiff.value.(A)
+prob = LinearProblem(plain_A, b)
+@test ≈(solve(prob, GenericLUFactorization()), plain_A \ b, rtol = 1.0e-9)
+@test ≈(solve(prob, RFLUFactorization()), plain_A \ b, rtol = 1.0e-9)
+
 # Overload Dense
 
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
@@ -218,6 +230,16 @@ overload_x_p = solve(prob, PureKLUFactorization())
 backslash_x_p = A \ b
 
 @test ≈(overload_x_p, backslash_x_p, rtol = 1.0e-9)
+
+# Duals only in A, and only in b
+
+plain_b = ForwardDiff.value.(b)
+prob = LinearProblem(sparse(A), plain_b)
+@test ≈(solve(prob, PureKLUFactorization()), A \ plain_b, rtol = 1.0e-9)
+
+plain_A = ForwardDiff.value.(A)
+prob = LinearProblem(sparse(plain_A), b)
+@test ≈(solve(prob, PureKLUFactorization()), plain_A \ b, rtol = 1.0e-9)
 
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 


### PR DESCRIPTION
**Note: this PR should be ignored until reviewed by @ChrisRackauckas.**

Targets the `ChrisRackauckas-patch-1` branch — merge this into #1023 to fix its Core test failures.

## The two bugs

1. **`FieldError: type Nothing has no field nzval` (the Core CI crash in #1023).** `init_cacheval` for `PureKLUFactorization` only had sparse specializations for `Float64`/`ComplexF64` eltypes, so a Dual-eltype sparse matrix fell through to the `nothing` fallback and `solve!` crashed dereferencing `cacheval.nzval`. PureKLU's kernels are pure Julia and generic over `Union{Real, Complex}` (`KLUGenericTypes`), so the specializations are widened to that. The `Float64` preallocated fast paths are unaffected (more specific methods still win dispatch).

2. **The direct dual path mishandled non-dual `b`.** `__init` takes the solution eltype from `b`, so with duals only in `A` and a plain `b` the inner solve could not store the dual result (`MethodError: no method matching Float64(::ForwardDiff.Dual)`). This was broken for the pre-existing `GenericLUFactorization` opt-out too, not just the algorithms added in #1023. Fixes:
   - `_solve_direct_dual!` promotes `b` to the cache's dual type when needed.
   - The direct path is now only taken when `A` itself carries duals. With duals just in `b`, the split path (one primal factorization + partials back-solves) is strictly cheaper and works for every algorithm (it's also what KLU needs: its `ldiv!` requires matching element types).

## Verification (all run locally)

Before the fix, 5 of 8 dual/plain combinations failed on the #1023 branch:

```
=== PureKLU sparse, dual A dual b ===  FAIL: FieldError: type Nothing has no field `nzval`
=== PureKLU sparse, dual A plain b === FAIL: FieldError: type Nothing has no field `nzval`
=== PureKLU sparse, plain A dual b === FAIL: MethodError: no method matching ldiv!(::PureKLU.KLUFactorization{Float64, …}, ::Vector{Dual{…}})
=== GenericLU dense, dual A plain b == FAIL: MethodError: no method matching Float64(::Dual{…})
=== GenericLU dense, plain A dual b == OK
=== RFLU dense, dual A dual b ========= OK
=== RFLU dense, dual A plain b ======== FAIL: MethodError: no method matching Float64(::Dual{…})
=== RFLU dense, plain A dual b ======== OK
```

After the fix all 8 pass. Test coverage added for the duals-only-in-A and duals-only-in-b cases (GenericLU, RFLU, PureKLU sparse).

Full local runs on this branch:
- `test/core/forwarddiff_overloads.jl`: **76/76 pass** (this is the file that errored in CI)
- `GROUP=Core Pkg.test()`: **all pass** ("Testing LinearSolve tests passed", `ForwardDiff Overloads | 76 76`)

Runic run on the changed files (no further changes).

## Not from #1023 (checked against `main`)

- **Downgrade**: fails identically on `main` — ForwardDiff 1.4.0 (registered 2026-06-07) is the first version allowing LogExpFunctions 1.x, so the downgrade resolver pins LogExpFunctions 1.0.1, which conflicts with every Zygote 0.7.x in the test target. Separate fix coming as its own PR (verified `LogExpFunctions = "0.3"` compat + extras entry restores resolution).
- **BoundaryValueDiffEq / ModelingToolkit downstream, Documentation**: fail on `main` HEAD too.
- **GPU** ("Out of GPU memory" at CUDA context creation), **HYPRE** ("Package HYPRE not found in current path"), and the ~1h20m self-hosted job failures (QA, Preferences, DefaultsLoading, MUMPS, STRUMPACK): runner/environment issues, unrelated to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)