### PR TITLE
Fix fatal docs cross-reference: include NonstructuralZeros docstrings

### DIFF
--- a/docs/src/basics/OperatorAssumptions.md
+++ b/docs/src/basics/OperatorAssumptions.md
@@ -3,6 +3,7 @@
 ```@docs
 OperatorAssumptions
 OperatorCondition
+NonstructuralZeros
 ```
 
 ## Condition Number Specifications
@@ -12,4 +13,13 @@ OperatorCondition.IllConditioned
 OperatorCondition.VeryIllConditioned
 OperatorCondition.SuperIllConditioned
 OperatorCondition.WellConditioned
+```
+
+## Nonstructural Zero Specifications
+
+```@docs
+NonstructuralZeros.Auto
+NonstructuralZeros.None
+NonstructuralZeros.Persistent
+NonstructuralZeros.Present
 ```


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The Documentation workflow fails on `main` with:

```
Cannot resolve @ref for md"[`NonstructuralZeros`](@ref)" in docs/src/basics/OperatorAssumptions.md
ERROR: `makedocs` encountered an error [:cross_references] -- terminating build before rendering.
```

Introduced by cdb6f776 (#1017), which added the `NonstructuralZeros` enum whose `@ref` is linked from the `OperatorAssumptions` docstring, without including the `NonstructuralZeros` docstring in any `@docs` block.

## Fix

Add `NonstructuralZeros` to the `@docs` block in `docs/src/basics/OperatorAssumptions.md`, plus a "Nonstructural Zero Specifications" section with the four variant docstrings (`Auto`/`None`/`Persistent`/`Present`), mirroring the existing `OperatorCondition` layout.

## Verification

Reproduced the failure locally on unmodified `main` (docs env with `Pkg.develop` of the parent + LinearSolveAutotune, `julia docs/make.jl`): same fatal `:cross_references` error. With this change the build completes and renders successfully; remaining warnings (`:docs_block`, `:missing_docs`, including the `SciMLBase.*` docstrings) are pre-existing and covered by `warnonly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)