### PR TITLE
Fix LinearSolveHYPRE CI: pass active project to MPI worker processes

### DIFF
--- a/test/hypre/hypretests.jl
+++ b/test/hypre/hypretests.jl
@@ -230,6 +230,9 @@ test_interface(HYPREAlgorithm(HYPRE.PCG(comm)), Pl = HYPRE.BoomerAMG())
 test_retcode_failure()
 
 # Test MPI execution
+# Pass the active project explicitly: the group env (test/hypre) is activated
+# in-process by Pkg.activate, which child processes do not inherit — without
+# --project the workers resolve packages from Pkg.test's sandbox, which has no HYPRE.
 mpitestfile = joinpath(@__DIR__, "hypretests_mpi.jl")
-r = run(ignorestatus(`$(mpiexec()) -n 2 $(Base.julia_cmd()) $(mpitestfile)`))
+r = run(ignorestatus(`$(mpiexec()) -n 2 $(Base.julia_cmd()) --project=$(Base.active_project()) $(mpitestfile)`))
 @test r.exitcode == 0


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The `tests / LinearSolveHYPRE` jobs (julia 1 and lts, self-hosted) fail on `main` (e.g. run [27135554785](https://github.com/SciML/LinearSolve.jl/actions/runs/27135554785)):

```
ERROR: LoadError: ArgumentError: Package HYPRE not found in current path.
in expression starting at .../test/hypre/hypretests_mpi.jl:1
LinearSolveHYPRE: Test Failed at .../test/hypre/hypretests.jl:235
  Expression: r.exitcode == 0
   Evaluated: 1 == 0
```

## Root cause

Introduced by the monorepo test restructure in 8abeaf5c (#1018). Before it, HYPRE was a root `[targets]` test dep, so `Pkg.test`'s sandbox env contained HYPRE and the `mpiexec`-spawned workers found it through the inherited `JULIA_LOAD_PATH` (`Pkg.test` sets `JULIA_LOAD_PATH="@:<sandbox>"` for the test process and its children).

After the restructure, HYPRE lives in the `test/hypre/Project.toml` group env, which `activate_group_env("hypre")` activates **in-process** via `Pkg.activate` — child processes don't inherit that, so the MPI workers resolved packages from the sandbox env, which no longer has HYPRE.

## Fix

Pass the active project explicitly to the spawned workers:

```julia
r = run(ignorestatus(`$(mpiexec()) -n 2 $(Base.julia_cmd()) --project=$(Base.active_project()) $(mpitestfile)`))
```

## Verification (local, linux, Julia 1.12.4)

Baseline on unmodified `main` (e38930c0) reproduces the CI failure exactly:

```
GROUP=LinearSolveHYPRE julia --project=. -e 'using Pkg; Pkg.test()'
ERROR: LoadError: ArgumentError: Package HYPRE not found in current path.
LinearSolveHYPRE | 1453     1       2   1456
exit: 1
```

With this fix:

```
Test Summary:    | Pass  Broken  Total   Time
LinearSolveHYPRE | 1454       2   1456  26.5s
     Testing LinearSolve tests passed
exit: 0
```

(The 2 broken are the pre-existing ParaSails LP64 skips.) Runic was run on the changed file (no further changes).

The failing `LinearSolvePETSc` jobs on main have a different root cause (PETSc.jl v0.4.10 API change) and are fixed in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)