### PR TITLE
Mark RecursiveFactorization Enzyme tests broken (Enzyme >= 0.13.155 regression)

### DIFF
--- a/test/nopre/Project.toml
+++ b/test/nopre/Project.toml
@@ -19,10 +19,7 @@ LinearSolve = {path = "../.."}
 
 [compat]
 AllocCheck = "0.2"
-# Enzyme 0.13.155 (PR EnzymeAD/Enzyme.jl#3154) errors with
-# `MethodError: no method matching LLVM.ConstantInt(::LLVM.VectorType, ::Int64)`
-# in abs_typeof (src/absint.jl:857) on Julia 1.10. Lift the cap once fixed upstream.
-Enzyme = "0.13.0 - 0.13.154"
+Enzyme = "0.13"
 FiniteDiff = "2.26"
 ForwardDiff = "0.10.38, 1"
 InteractiveUtils = "1.10"

--- a/test/nopre/Project.toml
+++ b/test/nopre/Project.toml
@@ -19,7 +19,10 @@ LinearSolve = {path = "../.."}
 
 [compat]
 AllocCheck = "0.2"
-Enzyme = "0.13"
+# Enzyme 0.13.155 (PR EnzymeAD/Enzyme.jl#3154) errors with
+# `MethodError: no method matching LLVM.ConstantInt(::LLVM.VectorType, ::Int64)`
+# in abs_typeof (src/absint.jl:857) on Julia 1.10. Lift the cap once fixed upstream.
+Enzyme = "0.13.0 - 0.13.154"
 FiniteDiff = "2.26"
 ForwardDiff = "0.10.38, 1"
 InteractiveUtils = "1.10"

--- a/test/nopre/enzyme.jl
+++ b/test/nopre/enzyme.jl
@@ -42,25 +42,32 @@ _ff = (
 )
 _ff(copy(A), copy(b1))
 
-Enzyme.autodiff(
-    Reverse,
-    (
-        x,
-        y,
-    ) -> f(
-        x,
-        y;
-        alg = LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.LUFactorization)
-    ),
-    Duplicated(copy(A), dA),
-    Duplicated(copy(b1), db1)
-)
+# Enzyme >= 0.13.155 crashes compiling any primal containing
+# RecursiveFactorization's explicit-SIMD kernels (vector GEP MethodError in
+# abs_typeof, https://github.com/EnzymeAD/Enzyme.jl/issues/3164). With
+# RecursiveFactorization loaded, DefaultLinearSolver compiles the RFLU branch,
+# so this site is affected. The @test_broken flips to an unexpected-pass error
+# when a fixed Enzyme release lands — unbreak this and the other #3164 sites.
+@test_broken begin
+    Enzyme.autodiff(
+        Reverse,
+        (
+            x,
+            y,
+        ) -> f(
+            x,
+            y;
+            alg = LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.LUFactorization)
+        ),
+        Duplicated(copy(A), dA),
+        Duplicated(copy(b1), db1)
+    )
 
-dA2 = ForwardDiff.gradient(x -> f(x, eltype(x).(b1)), copy(A))
-db12 = ForwardDiff.gradient(x -> f(eltype(x).(A), x), copy(b1))
+    dA2 = ForwardDiff.gradient(x -> f(x, eltype(x).(b1)), copy(A))
+    db12 = ForwardDiff.gradient(x -> f(eltype(x).(A), x), copy(b1))
 
-@test dA ≈ dA2
-@test db1 ≈ db12
+    dA ≈ dA2 && db1 ≈ db12
+end
 
 A = rand(n, n);
 dA = zeros(n, n);
@@ -167,14 +174,16 @@ f2(A, b1, b2)
 dA = zeros(n, n);
 db1 = zeros(n);
 db2 = zeros(n);
-Enzyme.autodiff(
-    Reverse, f2, Duplicated(copy(A), dA),
-    Duplicated(copy(b1), db1), Duplicated(copy(b2), db2)
-)
+# Broken by the Enzyme >= 0.13.155 RecursiveFactorization regression
+# (https://github.com/EnzymeAD/Enzyme.jl/issues/3164)
+@test_broken begin
+    Enzyme.autodiff(
+        Reverse, f2, Duplicated(copy(A), dA),
+        Duplicated(copy(b1), db1), Duplicated(copy(b2), db2)
+    )
 
-@test dA ≈ dA2
-@test db1 ≈ db12
-@test db2 ≈ db22
+    dA ≈ dA2 && db1 ≈ db12 && db2 ≈ db22
+end
 
 function f3(A, b1, b2; alg = KrylovJL_GMRES())
     prob = LinearProblem(A, b1)
@@ -245,6 +254,25 @@ end
         LUFactorization(),
         RFLUFactorization(),    # KrylovJL_GMRES(), fails
     )
+    # Forward mode over RFLU also hits the Enzyme >= 0.13.155 regression
+    # (https://github.com/EnzymeAD/Enzyme.jl/issues/3164)
+    if alg isa RFLUFactorization
+        @test_broken begin
+            en_jac = map(onehot(b1)) do db1
+                return only(
+                    Enzyme.autodiff(
+                        set_runtime_activity(Forward), fnice,
+                        Const(A), Duplicated(b1, db1), Const(alg)
+                    )
+                )
+            end |> collect
+            fd_jac = FiniteDiff.finite_difference_jacobian(b -> fnice(A, b, alg), b1) |>
+                vec
+            isapprox(en_jac, fd_jac, rtol = 1.0e-4)
+        end
+        continue
+    end
+
     fb_closure = b -> fnice(A, b, alg)
 
     fd_jac = FiniteDiff.finite_difference_jacobian(fb_closure, b1) |> vec


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

The `tests / NoPre (julia lts, self-hosted)` job fails on `main` and all PR branches since ~2026-06-10 05:00 UTC. Culprit: **Enzyme v0.13.155** (released 04:41 UTC that day; the only package delta between the last passing and first failing runs). It crashes at compile time —

```
MethodError: no method matching LLVM.ConstantInt(::LLVM.VectorType, ::Int64)
  in abs_typeof at src/absint.jl:857
```

— whenever the **primal** call graph contains VectorizationBase explicit-SIMD gathers (single-index vector GEPs), even behind custom EnzymeRules. For LinearSolve that means RecursiveFactorization's TriangularSolve kernels. Upstream issue with an Enzyme-only MWE (verified crash on 0.13.155, clean on 0.13.154): **EnzymeAD/Enzyme.jl#3164**.

## Fix (per review: mark broken, don't cap)

The original cap of Enzyme to 0.13.154 is reverted. Instead, the three — and only three — affected call sites in `test/nopre/enzyme.jl` are marked `@test_broken`, each commented with the upstream issue link:

1. The `DefaultLinearSolver` reverse-mode call (with RecursiveFactorization loaded, the default solver compiles the RFLU branch);
2. The explicit `RFLUFactorization` reverse-mode cache-reuse test (`f2`);
3. The Forward-mode RFLU jacobian in the alg-loop testset.

Every other site was probed individually on 0.13.155 (plain `LUFactorization` even with RF loaded, `DefaultLinearSolver` without RF, cache `init`/`solve!` paths, `KrylovJL_GMRES`, `BunchKaufman`, and all the structured-wrapper testsets) and passes — those keep running on latest Enzyme. When a fixed Enzyme release lands, the `@test_broken`s flip to unexpected-pass errors, flagging them for removal.

## Verification

Julia 1.10.11, Enzyme **0.13.155**, full `test/nopre/enzyme.jl`:

```
Test Summary:           | Pass  Broken  Total     Time
Enzyme Derivative Rules |   40       3     43  5m32.5s
```

(exit 0; on the previous capped approach see the earlier comments — the cap verification also passed, but capping hides the regression instead of tracking it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)