### PR TITLE
Add QA (Aqua/JET) groups to sublibraries (SciML/.github#77)

### DIFF
--- a/lib/LinearSolveAutotune/Project.toml
+++ b/lib/LinearSolveAutotune/Project.toml
@@ -64,8 +64,9 @@ gh_cli_jll = "2"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SafeTestsets", "Test"]
+test = ["Pkg", "SafeTestsets", "Test"]

--- a/lib/LinearSolveAutotune/test/qa/Project.toml
+++ b/lib/LinearSolveAutotune/test/qa/Project.toml
@@ -1,0 +1,18 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+LinearSolveAutotune = "67398393-80e8-4254-b7e4-1b9a36a3c5b6"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+LinearSolve = {path = "../../../.."}
+LinearSolveAutotune = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+LinearSolve = "3"
+LinearSolveAutotune = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/LinearSolveAutotune/test/qa/qa.jl
+++ b/lib/LinearSolveAutotune/test/qa/qa.jl
@@ -1,0 +1,4 @@
+using LinearSolveAutotune, Aqua, JET
+
+Aqua.test_all(LinearSolveAutotune)
+JET.test_package(LinearSolveAutotune; target_defined_modules = true)

--- a/lib/LinearSolveAutotune/test/runtests.jl
+++ b/lib/LinearSolveAutotune/test/runtests.jl
@@ -1,7 +1,32 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "LINEARSOLVE_TEST_GROUP", "All")
 
+# QA tooling (Aqua/JET) lives in an isolated sub-environment under test/qa so
+# its compat bounds don't constrain the main test resolve. Develop the in-repo
+# path deps so [sources] also works on Julia < 1.11 (where the Project.toml
+# [sources] table is ignored), then instantiate.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(
+            [
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", ".."))
+            ]
+        )
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "LinearSolveAutotune Tests" include("autotune_tests.jl")
+end
+
+# QA (Aqua/JET) is a dep-adding group: it runs in its own isolated sub-env
+# under test/qa (excluded from the Core/All run).
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Code quality (Aqua + JET)" include("qa/qa.jl")
 end

--- a/lib/LinearSolveAutotune/test/test_groups.toml
+++ b/lib/LinearSolveAutotune/test/test_groups.toml
@@ -1,4 +1,5 @@
-# LinearSolveAutotune's runtests recognizes only the Core group; it has no
-# QA group, so the default (Core + QA on 1) is overridden to declare Core only.
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/LinearSolvePyAMG/Project.toml
+++ b/lib/LinearSolvePyAMG/Project.toml
@@ -18,6 +18,7 @@ LinearSolve = {path = "../.."}
 CondaPkg = "0.2"
 LinearAlgebra = "1.10"
 LinearSolve = "3"
+Pkg = "1"
 PythonCall = "0.9"
 SafeTestsets = "0.1"
 SciMLBase = "2.148, 3"
@@ -26,8 +27,9 @@ Test = "<0.0.1, 1"
 julia = "1.10"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SafeTestsets", "Test"]
+test = ["Pkg", "SafeTestsets", "Test"]

--- a/lib/LinearSolvePyAMG/test/qa/Project.toml
+++ b/lib/LinearSolvePyAMG/test/qa/Project.toml
@@ -1,0 +1,18 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+LinearSolvePyAMG = "7a56c47d-7ab1-4e99-b0e3-2952e463d64a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+LinearSolve = {path = "../../../.."}
+LinearSolvePyAMG = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+JET = "0.9, 0.10, 0.11"
+LinearSolve = "3"
+LinearSolvePyAMG = "1"
+Test = "1"
+julia = "1.10"

--- a/lib/LinearSolvePyAMG/test/qa/qa.jl
+++ b/lib/LinearSolvePyAMG/test/qa/qa.jl
@@ -1,0 +1,4 @@
+using LinearSolvePyAMG, Aqua, JET
+
+Aqua.test_all(LinearSolvePyAMG)
+JET.test_package(LinearSolvePyAMG; target_defined_modules = true)

--- a/lib/LinearSolvePyAMG/test/runtests.jl
+++ b/lib/LinearSolvePyAMG/test/runtests.jl
@@ -1,7 +1,32 @@
+using Pkg
 using SafeTestsets
 
 const TEST_GROUP = get(ENV, "LINEARSOLVE_TEST_GROUP", "All")
 
+# QA tooling (Aqua/JET) lives in an isolated sub-environment under test/qa so
+# its compat bounds don't constrain the main test resolve. Develop the in-repo
+# path deps so [sources] also works on Julia < 1.11 (where the Project.toml
+# [sources] table is ignored), then instantiate.
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(
+            [
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", ".."))
+            ]
+        )
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @time @safetestset "LinearSolvePyAMG Tests" include("pyamg_tests.jl")
+end
+
+# QA (Aqua/JET) is a dep-adding group: it runs in its own isolated sub-env
+# under test/qa (excluded from the Core/All run).
+if TEST_GROUP == "QA"
+    activate_qa_env()
+    @safetestset "Code quality (Aqua + JET)" include("qa/qa.jl")
 end

--- a/lib/LinearSolvePyAMG/test/test_groups.toml
+++ b/lib/LinearSolvePyAMG/test/test_groups.toml
@@ -1,4 +1,5 @@
-# LinearSolvePyAMG's runtests recognizes only the Core group; it has no QA
-# group, so the default (Core + QA on 1) is overridden to declare Core only.
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
Adds the canonical QA (Aqua + JET) test group to the LinearSolve.jl sublibraries, part of SciML/.github#77.

Units in this batch:
- `lib/LinearSolveAutotune`: new `test/qa/` (Project.toml + qa.jl running `Aqua.test_all` + `JET.test_package(; target_defined_modules = true)`), QA dispatch in `test/runtests.jl` gated on `LINEARSOLVE_TEST_GROUP == "QA"`, `[QA]` group declared in `test/test_groups.toml` with `versions = ["lts", "1"]`, Pkg added to test extras/targets.
- `lib/LinearSolvePyAMG`: same.

The QA env is an isolated sub-environment (test/qa) so Aqua/JET compat bounds do not constrain the main test resolve; in-repo path deps are `Pkg.develop`ed on Julia < 1.11 where `[sources]` is ignored. QA runs on lts and 1 only (never pre), ubuntu-only.

Further batches may be pushed to this branch. Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)