### PR TITLE
Fix Sparspak symbolic reuse invalidated by per-solve dropzeros

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -13,7 +13,7 @@ using ArrayInterface: ArrayInterface
 using LinearAlgebra: LinearAlgebra, I, Hermitian, Symmetric, cholesky, ldiv!, lu, lu!
 using SparseArrays: SparseArrays, AbstractSparseArray, AbstractSparseMatrixCSC,
     SparseMatrixCSC,
-    nonzeros, rowvals, getcolptr, sparse, sprand, dropzeros
+    nonzeros, rowvals, getcolptr, sparse, sprand, dropzeros, nnz
 using SciMLLogging: @SciMLMessage
 
 @static if Base.USE_GPL_LIBS
@@ -1025,6 +1025,14 @@ mutable struct SparseReduction{Tv, Ti}
     reduced::SparseMatrixCSC{Tv, Ti}
     nanalyze::Int
     nrefactor::Int
+    # Tracks whether the most recent per-solve dropzeros changed the structure
+    # of `reduced` (i.e. nnz changed). Set to `false` after the first per-solve
+    # dropzeros call so the first call never triggers a false "changed" signal.
+    # Used by the DefaultLinearSolver to decide whether to invalidate cached
+    # symbolic factorizations (Sparspak, KLU) whose symbolic reuse is only valid
+    # when the matrix structure is stable across calls.
+    reduced_nnz::Int
+    structure_changed::Bool
 end
 
 function _persistent_reduced(
@@ -1072,12 +1080,14 @@ function LinearSolve.init_sparse_reduction(
         nstart_zeros = count(iszero, nz)
         keep, reduced = _persistent_reduced(colptr, rowval, m, k, mask, nz)
         return SparseReduction{Tv, Ti}(
-            true, cache_union, auto, nstart_zeros, colptr, rowval, mask, keep, reduced, 1, 0
+            true, cache_union, auto, nstart_zeros, colptr, rowval, mask, keep, reduced,
+            1, 0, nnz(reduced), false
         )
     else
         empty = SparseMatrixCSC{Tv, Ti}(0, 0, Ti[1], Ti[], Tv[])
         return SparseReduction{Tv, Ti}(
-            false, cache_union, auto, 0, colptr, rowval, Bool[], Int[], empty, 0, 0
+            false, cache_union, auto, 0, colptr, rowval, Bool[], Int[], empty,
+            0, 0, 0, false
         )
     end
 end
@@ -1095,7 +1105,15 @@ function LinearSolve.reduce_operand!(red::SparseReduction, A)
     end
     # per-solve dropzeros: drop this matrix's own zeros and let the inner solver
     # re-analyze when the pattern changes (no cross-solve union assumed).
-    red.cache_union || (red.reduced = dropzeros(A); red.nrefactor += 1; return red.reduced)
+    if !red.cache_union
+        new_reduced = dropzeros(A)
+        new_nnz = nnz(new_reduced)
+        red.structure_changed = new_nnz != red.reduced_nnz
+        red.reduced_nnz = new_nnz
+        red.reduced = new_reduced
+        red.nrefactor += 1
+        return red.reduced
+    end
     grew = false
     @inbounds for i in eachindex(nz)
         if !red.mask[i] && !iszero(nz[i])
@@ -1117,6 +1135,10 @@ function LinearSolve.reduce_operand!(red::SparseReduction, A)
                 activated > LinearSolve.NONPERSISTENT_ZERO_FRACTION * red.nstart_zeros
             red.cache_union = false
             red.reduced = dropzeros(A)
+            # First per-solve reduction after switching from union caching.
+            # No "previous" per-solve result, so no structure change yet.
+            red.reduced_nnz = nnz(red.reduced)
+            red.structure_changed = false
         end
     else
         rnz = nonzeros(red.reduced)

--- a/ext/LinearSolveSparspakExt.jl
+++ b/ext/LinearSolveSparspakExt.jl
@@ -51,9 +51,24 @@ function SciMLBase.solve!(
     )
     A = cache.A
     if cache.isfresh
-        if !(cache.cacheval === PREALLOCATED_SPARSEPAK) && alg.reuse_symbolic
+        cached = LinearSolve.@get_cacheval(cache, :SparspakFactorization)
+        # When the DefaultLinearSolver applies per-solve dropzeros, the reduced
+        # matrix handed to us may have a different sparsity structure (nnz) than
+        # what the cached symbolic factorization was built for. In that case
+        # sparspaklu! (which reuses the symbolic ordering) would produce an invalid
+        # factorization, causing wrong linear-solve results and stalled nonlinear
+        # iterations. Detect this via the `structure_changed` flag on the
+        # SparseReduction state and fall back to a full sparspaklu in that case.
+        skip_symbolic_reuse = if cache.cacheval isa LinearSolve.DefaultLinearSolverInit
+            red = cache.cacheval.sparse_reduction
+            red !== nothing && !red.cache_union && red.active && red.structure_changed
+        else
+            false
+        end
+        if !skip_symbolic_reuse && !(cache.cacheval === PREALLOCATED_SPARSEPAK) &&
+                !(cached === PREALLOCATED_SPARSEPAK) && alg.reuse_symbolic
             fact = sparspaklu!(
-                LinearSolve.@get_cacheval(cache, :SparspakFactorization),
+                cached,
                 SparseMatrixCSC(
                     size(A)..., getcolptr(A), rowvals(A),
                     nonzeros(A)

--- a/test/core/resolve.jl
+++ b/test/core/resolve.jl
@@ -76,8 +76,8 @@ for alg in vcat(
         A = [1.0 2.0; 3.0 4.0]
         alg in [
             KLUFactorization, PureKLUFactorization, UMFPACKFactorization,
-            SparspakFactorization, ParUFactorization, STRUMPACKFactorization,
-            SparseColumnPivotedQRFactorization,
+            PureUMFPACKFactorization, SparspakFactorization, ParUFactorization,
+            STRUMPACKFactorization, SparseColumnPivotedQRFactorization,
         ] &&
             (A = sparse(A))
         A = A' * A
@@ -106,8 +106,8 @@ for alg in vcat(
         A = [1.0 2.0; 3.0 4.0]
         alg in [
             KLUFactorization, PureKLUFactorization, UMFPACKFactorization,
-            SparspakFactorization, ParUFactorization, STRUMPACKFactorization,
-            SparseColumnPivotedQRFactorization,
+            PureUMFPACKFactorization, SparspakFactorization, ParUFactorization,
+            STRUMPACKFactorization, SparseColumnPivotedQRFactorization,
         ] &&
             (A = sparse(A))
         A = A' * A


### PR DESCRIPTION
## Summary

The `nonstructural_zeros` feature introduced in v3.85 (per-solve `dropzeros` mode, `cache_union=false`) can return sparse matrices with different `nnz` counts across successive Newton iterations. Sparspak's `sparspaklu!` reuses the symbolic factorization from the previous call without checking whether the sparsity structure has changed — unlike KLU/UMFPACK, which both guard against this. When `nnz` changes, `sparspaklu!` produces a corrupt factorization, leading to wrong linear-solve results and stalled nonlinear (e.g. BVP) iterations.

- **`ext/LinearSolveSparseArraysExt.jl`**: Add `reduced_nnz::Int` and `structure_changed::Bool` to `SparseReduction`. Update `reduce_operand!` to track whether the per-solve dropzeros changed the matrix structure.
- **`ext/LinearSolveSparspakExt.jl`**: Before calling `sparspaklu!`, check `structure_changed` via the `DefaultLinearSolverInit` cache. If the structure is unstable, skip symbolic reuse and fall back to a full `sparspaklu`.

Fixes the BigFloat BVP stalling regression reported in SciML/BoundaryValueDiffEq.jl#509 (comment from @ChrisRackauckas identifying FIRK test failures).

## Test plan

- [x] `test/core/nonstructural_zeros.jl` — 122/122 pass
- [x] `BigFloat` + `SparspakFactorization` direct solve — correct results
- [x] `BigFloat` + `DefaultLinearSolver` (Sparspak path) — correct results
- [ ] CI on full test suite

> **Note**: Please ignore until reviewed by @ChrisRackauckas.