### PR TITLE
Default to PureKLU for generic-eltype sparse LU (e.g. BigFloat)

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -86,15 +86,18 @@ function LinearSolve.defaultalg(
         A::AbstractSparseMatrixCSC{Tv, Ti}, b,
         assump::OperatorAssumptions{Bool}
     ) where {Tv, Ti}
-    ext = Base.get_extension(LinearSolve, :LinearSolveSparspakExt)
-    return if assump.issq && ext !== nothing
-        LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.SparspakFactorization)
-    elseif !assump.issq
-        error("Generic number sparse factorization for non-square is not currently handled")
-    elseif ext === nothing
-        error("SparspakFactorization required for general sparse matrix types and with general Julia number types. Do `using Sparspak` in order to enable this functionality")
+    # PureKLU is a pure-Julia, hard dependency that factors any `Number` element
+    # type, so it is the default sparse LU for generic (non-BLAS) eltypes such as
+    # BigFloat — no `using Sparspak` required. Unlike Sparspak's symbolic reuse,
+    # PureKLU re-analyzes when the sparsity pattern changes across solves (e.g. the
+    # per-solve dropzeros of the nonstructural_zeros path), which previously
+    # produced invalid factorizations and stalled BVP Newton iterations. A
+    # (near-)singular matrix falls back to the generic column-pivoted sparse QR via
+    # the default polyalgorithm's sparse-LU fallback chain.
+    return if assump.issq
+        LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.KLUFactorization)
     else
-        error("Unreachable reached. Please report this error with a reproducer.")
+        error("Generic number sparse factorization for non-square is not currently handled")
     end
 end
 
@@ -581,6 +584,23 @@ function LinearSolve.init_cacheval(
     )
 end
 
+# Generic element types (e.g. BigFloat): PureKLU is pure-Julia and factors any
+# `Number` element type, so it serves as the default sparse LU for non-BLAS
+# eltypes too (replacing Sparspak in the default polyalgorithm). The empty
+# cacheval carries the correct element type so `klu!`/`klu` dispatch is concrete.
+function LinearSolve.init_cacheval(
+        alg::PureKLUFactorization, A::AbstractSparseArray{T, Ti}, b, u, Pl, Pr,
+        maxiters::Int, abstol,
+        reltol,
+        verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
+    ) where {T <: Number, Ti <: Integer}
+    return PureKLU.KLUFactorization(
+        SparseMatrixCSC{T, Ti}(
+            0, 0, [one(Ti)], Ti[], T[]
+        )
+    )
+end
+
 function LinearSolve.init_cacheval(
         alg::PureKLUFactorization, A::AbstractSciMLOperator, b, u, Pl, Pr,
         maxiters::Int, abstol, reltol,
@@ -704,6 +724,20 @@ function LinearSolve.init_cacheval(
         verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
     )
     return PREALLOCATED_SCPQR_C64
+end
+
+# Generic element types (e.g. BigFloat): SparseColumnPivotedQR is pure-Julia and
+# factors any `Number` element type. Returning a matching-eltype placeholder
+# (rather than `nothing`) keeps the default polyalgorithm's
+# `:SparseColumnPivotedQRFactorization` slot concretely typed so the sparse-LU
+# singular fallback (`_do_sparse_qr_fallback`) can `setfield!` a real
+# factorization into it for non-BLAS eltypes.
+function LinearSolve.init_cacheval(
+        alg::SparseColumnPivotedQRFactorization, A::AbstractSparseArray{T, <:Integer},
+        b, u, Pl, Pr, maxiters::Int, abstol, reltol,
+        verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
+    ) where {T <: Number}
+    return SCPQR.scpqr(sparse(reshape([one(T)], 1, 1)))
 end
 
 function LinearSolve.init_cacheval(

--- a/test/core/default_algs.jl
+++ b/test/core/default_algs.jl
@@ -85,6 +85,36 @@ let A_ez = sparse([1, 2], [1, 2], [1.0, 0.0], 2, 2), b_ez = ones(2)
         ReturnCode.Infeasible
 end
 
+# Generic (non-BLAS) element types such as BigFloat use the pure-Julia PureKLU as
+# the default sparse LU — no `using Sparspak` required. This is the path BVP
+# solvers hit for BigFloat problems.
+let n = 20
+    A_bf = sprand(BigFloat, n, n, 0.3) + (n * one(BigFloat)) * I
+    b_bf = rand(BigFloat, n)
+    @test LinearSolve.defaultalg(A_bf, b_bf, LinearSolve.OperatorAssumptions(true)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.KLUFactorization
+    sol_bf = solve(LinearProblem(A_bf, b_bf))
+    @test SciMLBase.successful_retcode(sol_bf.retcode)
+    @test eltype(sol_bf.u) === BigFloat
+    @test norm(A_bf * sol_bf.u - b_bf) / norm(b_bf) < 1.0e-30
+    # Re-solve with a same-pattern numeric update (mimics Newton iterations):
+    # PureKLU must refactor rather than reuse a stale factorization.
+    cache_bf = init(LinearProblem(A_bf, b_bf))
+    solve!(cache_bf)
+    A_bf2 = copy(A_bf)
+    A_bf2.nzval .*= 3
+    cache_bf.A = A_bf2
+    sol_bf2 = solve!(cache_bf)
+    @test norm(A_bf2 * sol_bf2.u - b_bf) / norm(b_bf) < 1.0e-30
+end
+# Square sparse BigFloat singular system falls back to the generic column-pivoted
+# sparse QR and succeeds.
+let As_bf = sparse(BigFloat.([1 2 3; 2 4 6; 1 1 1])), bs_bf = BigFloat.([1, 2, 3])
+    sol = solve(LinearProblem(As_bf, bs_bf))
+    @test SciMLBase.successful_retcode(sol.retcode)
+    @test all(isfinite, sol.u)
+end
+
 @test LinearSolve.defaultalg(sprand(10^4, 10^4, 1.0e-5) + I, zeros(1000)).alg ===
     LinearSolve.DefaultAlgorithmChoice.KLUFactorization
 prob = LinearProblem(sprand(1000, 1000, 0.5), zeros(1000))

--- a/test/core/resolve.jl
+++ b/test/core/resolve.jl
@@ -76,8 +76,8 @@ for alg in vcat(
         A = [1.0 2.0; 3.0 4.0]
         alg in [
             KLUFactorization, PureKLUFactorization, UMFPACKFactorization,
-            SparspakFactorization, ParUFactorization, STRUMPACKFactorization,
-            SparseColumnPivotedQRFactorization,
+            PureUMFPACKFactorization, SparspakFactorization, ParUFactorization,
+            STRUMPACKFactorization, SparseColumnPivotedQRFactorization,
         ] &&
             (A = sparse(A))
         A = A' * A
@@ -106,8 +106,8 @@ for alg in vcat(
         A = [1.0 2.0; 3.0 4.0]
         alg in [
             KLUFactorization, PureKLUFactorization, UMFPACKFactorization,
-            SparspakFactorization, ParUFactorization, STRUMPACKFactorization,
-            SparseColumnPivotedQRFactorization,
+            PureUMFPACKFactorization, SparspakFactorization, ParUFactorization,
+            STRUMPACKFactorization, SparseColumnPivotedQRFactorization,
         ] &&
             (A = sparse(A))
         A = A' * A


### PR DESCRIPTION
## Summary

For non-BLAS sparse element types (e.g. `BigFloat`), the default sparse LU was `SparspakFactorization`. That has two problems:

1. It requires the user to `using Sparspak` (otherwise the default errors).
2. Sparspak's symbolic-factorization reuse produces **invalid** factorizations when the sparsity pattern changes between solves — exactly what the `nonstructural_zeros` per-solve `dropzeros` path does. This manifested as **stalled BVP Newton iterations** for BigFloat problems (SciML/BoundaryValueDiffEq.jl#509).

This PR makes **PureKLU** (a pure-Julia, hard dependency that factors any `Number` element type and correctly re-analyzes on pattern changes) the default sparse LU for generic eltypes.

### Changes
- Generic-eltype `init_cacheval` for `PureKLUFactorization` and `SparseColumnPivotedQRFactorization`, so the default polyalgorithm's KLU and SPQR slots are concretely typed for non-BLAS eltypes (the SPQR one is required so the singular-LU → column-pivoted-QR fallback can `setfield!` a real factorization into its slot).
- `defaultalg(::AbstractSparseMatrixCSC)` for square systems now selects the KLU (PureKLU) slot instead of Sparspak. No `using Sparspak` required.
- Test (`test/core/default_algs.jl`): BigFloat sparse default chooses KLU, solves accurately, re-solves correctly across numeric updates, and falls back to QR on a singular system.
- Also includes the resolve.jl `PureUMFPACKFactorization` test fix (pre-existing master failure; shared with #1036).

### Benchmark (BigFloat, PureKLU vs Sparspak)

Single solve (factorize+solve) and 5× same-pattern resolve, seconds:

| n   | density | alg      | single(s) | resolve5(s) | rel.res |
|-----|---------|----------|-----------|-------------|---------|
| 10  | 0.5     | PureKLU  | 1.39e-4   | 6.21e-4     | 9e-78   |
| 10  | 0.5     | Sparspak | 1.06e-4   | 4.93e-4     | 1e-77   |
| 50  | 0.2     | PureKLU  | 4.58e-3   | 2.24e-2     | 2e-77   |
| 50  | 0.2     | Sparspak | 4.90e-3   | 2.55e-2     | 2e-77   |
| 100 | 0.1     | PureKLU  | 3.20e-2   | 0.194       | 3e-77   |
| 100 | 0.1     | Sparspak | 3.52e-2   | 0.223       | 2e-77   |
| 200 | 0.05    | PureKLU  | 0.219     | 1.20        | 5e-77   |
| 200 | 0.05    | Sparspak | 0.307     | 1.17        | 2e-77   |

PureKLU is competitive-to-faster (notably faster at larger sizes) with comparable accuracy, and needs no extra `using`.

## Test plan

- [x] `test/core/default_algs.jl` passes (incl. new BigFloat tests)
- [x] `test/core/resolve.jl` passes
- [x] BigFloat default `solve`, caching re-solve, and singular→QR fallback verified
- [x] End-to-end: the `MIRKN4` BigFloat `SecondOrderBVProblem` from BoundaryValueDiffEq.jl#509 now returns `Success` (was Stalled) with this change
- [ ] Full CI

## Relationship to #1036

#1036 hardens `SparspakFactorization` itself against the same pattern-change bug (defense-in-depth for users who explicitly request Sparspak). This PR addresses the **root cause** for the default path by not selecting Sparspak for generic eltypes at all. They are complementary; this PR is the more fundamental fix for the BVP issue.

> **Note**: Please ignore until reviewed by @ChrisRackauckas.