### PR TITLE
Handle dense, contiguous non-`Array` matrices (e.g. FixedSizeArray) in defaultalg / dense LU caches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -126,6 +126,7 @@ EnzymeCore = "0.8.5"
 FastAlmostBandedMatrices = "0.1.4"
 FastLapackInterface = "2.0.4"
 FiniteDiff = "2.26"
+FixedSizeArrays = "1"
 ForwardDiff = "0.10.38, 1"
 GPUArraysCore = "0.2"
 Ginkgo = "1"
@@ -188,6 +189,7 @@ ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
 FastLapackInterface = "29a986be-02c6-4525-aec4-84b980013641"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
+FixedSizeArrays = "3821ddf9-e5b5-40d5-8e25-6813ab96b5e2"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
@@ -208,4 +210,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["AlgebraicMultigrid", "BandedMatrices", "BlockDiagonals", "CliqueTrees", "ComponentArrays", "FastAlmostBandedMatrices", "FastLapackInterface", "FiniteDiff", "ForwardDiff", "InteractiveUtils", "IterativeSolvers", "KrylovKit", "KrylovPreconditioners", "MultiFloats", "Pkg", "PureUMFPACK", "Random", "RecursiveFactorization", "STRUMPACK_jll", "SafeTestsets", "SparseArrays", "Sparspak", "SpecializingFactorizations", "StaticArrays", "Test", "Zygote"]
+test = ["AlgebraicMultigrid", "BandedMatrices", "BlockDiagonals", "CliqueTrees", "ComponentArrays", "FastAlmostBandedMatrices", "FastLapackInterface", "FiniteDiff", "FixedSizeArrays", "ForwardDiff", "InteractiveUtils", "IterativeSolvers", "KrylovKit", "KrylovPreconditioners", "MultiFloats", "Pkg", "PureUMFPACK", "Random", "RecursiveFactorization", "STRUMPACK_jll", "SafeTestsets", "SparseArrays", "Sparspak", "SpecializingFactorizations", "StaticArrays", "Test", "Zygote"]

--- a/ext/LinearSolveBLISExt.jl
+++ b/ext/LinearSolveBLISExt.jl
@@ -263,12 +263,15 @@ function LinearSolve.init_cacheval(
 end
 
 function LinearSolve.init_cacheval(
-        alg::BLISLUFactorization, A::AbstractMatrix{<:Union{Float32, ComplexF32, ComplexF64}}, b, u, Pl, Pr,
+        alg::BLISLUFactorization,
+        A::DenseMatrix{<:Union{Float32, Float64, ComplexF32, ComplexF64}}, b, u, Pl, Pr,
         maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
         assumptions::OperatorAssumptions
     )
-    A = rand(eltype(A), 0, 0)
-    return ArrayInterface.lu_instance(A), Ref{BlasInt}()
+    # Build the instance from a 0×0 array of `A`'s own type so the cacheval slot
+    # matches the factorization `solve!` stores (built from `A`). This handles
+    # dense CPU arrays that aren't `Base.Array`, e.g. `FixedSizeArray`.
+    return ArrayInterface.lu_instance(similar(A, 0, 0)), Ref{BlasInt}()
 end
 
 function SciMLBase.solve!(

--- a/src/appleaccelerate.jl
+++ b/src/appleaccelerate.jl
@@ -296,13 +296,16 @@ end
 
 function LinearSolve.init_cacheval(
         alg::AppleAccelerateLUFactorization,
-        A::AbstractMatrix{<:Union{Float32, ComplexF32, ComplexF64}}, b, u, Pl, Pr,
+        A::DenseMatrix{<:BLASELTYPES}, b, u, Pl, Pr,
         maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
         assumptions::OperatorAssumptions
     )
-    A = rand(eltype(A), 0, 0)
-    luinst = ArrayInterface.lu_instance(A)
-    return LU(luinst.factors, similar(A, Cint, 0), luinst.info), Ref{Cint}()
+    # Build the instance from a 0×0 array of `A`'s own type so the cacheval slot
+    # matches the factorization `solve!` stores (built from `A`). This handles
+    # dense CPU arrays that aren't `Base.Array`, e.g. `FixedSizeArray`.
+    A0 = similar(A, 0, 0)
+    luinst = ArrayInterface.lu_instance(A0)
+    return LU(luinst.factors, similar(A0, Cint, 0), luinst.info), Ref{Cint}()
 end
 
 function SciMLBase.solve!(

--- a/src/default.jl
+++ b/src/default.jl
@@ -342,7 +342,7 @@ function defaultalg(A, b, assump::OperatorAssumptions{Bool})
         # Special case on Arrays: avoid BLAS for RecursiveFactorization.jl when
         # it makes sense according to the benchmarks, which is dependent on
         # whether MKL or OpenBLAS is being used
-        if (A === nothing && !(b isa GPUArraysCore.AnyGPUArray)) || A isa Matrix
+        if (A === nothing && !(b isa GPUArraysCore.AnyGPUArray)) || A isa DenseMatrix
             if (
                     A === nothing ||
                         eltype(A) <: BLASELTYPES
@@ -364,7 +364,8 @@ function defaultalg(A, b, assump::OperatorAssumptions{Bool})
 
                     if tuned_alg !== nothing
                         tuned_alg
-                    elseif appleaccelerate_isavailable() && b isa Array &&
+                    elseif appleaccelerate_isavailable() &&
+                            b isa DenseArray && !(b isa GPUArraysCore.AnyGPUArray) &&
                             eltype(b) <: Union{Float32, Float64, ComplexF32, ComplexF64}
                         DefaultAlgorithmChoice.AppleAccelerateLUFactorization
                     elseif (
@@ -379,7 +380,8 @@ function defaultalg(A, b, assump::OperatorAssumptions{Bool})
                         DefaultAlgorithmChoice.RFLUFactorization
                         #elseif A === nothing || A isa Matrix
                         #    alg = FastLUFactorization()
-                    elseif usemkl && b isa Array &&
+                    elseif usemkl &&
+                            b isa DenseArray && !(b isa GPUArraysCore.AnyGPUArray) &&
                             eltype(b) <: Union{Float32, Float64, ComplexF32, ComplexF64}
                         DefaultAlgorithmChoice.MKLLUFactorization
                     else
@@ -559,7 +561,7 @@ end
     caches = map(first.(EnumX.symbol_map(DefaultAlgorithmChoice.T))) do alg
         if alg === :KrylovJL_GMRES || alg === :KrylovJL_CRAIGMR || alg === :KrylovJL_LSMR
             quote
-                if A isa Matrix || issparsematrixcsc(A)
+                if A isa DenseMatrix || issparsematrixcsc(A)
                     nothing
                 else
                     init_cacheval(
@@ -1074,7 +1076,7 @@ end
     return quote
         if cache.cacheval isa DefaultLinearSolverInit &&
                 cache.cacheval.fell_back_to_qr && !cache.isfresh
-            if cache.A isa Array
+            if cache.A isa DenseMatrix
                 _reuse_qr_fallback(cache, alg)
             else
                 _reuse_sparse_qr_fallback(cache, alg)

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -179,7 +179,12 @@ function LinearSolve.init_cacheval(
         abstol, reltol, verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
     )
     ipiv = Vector{LinearAlgebra.BlasInt}(undef, min(size(A)...))
-    return ArrayInterface.lu_instance(convert(AbstractMatrix, A)), ipiv
+    # `solve!` stores `(RecursiveFactorization.lu!(A, ipiv, ...), ipiv)` with this
+    # `Vector{BlasInt}` pivot; rebuild the instance with it so the cacheval slot
+    # type matches for dense CPU arrays whose container isn't `Base.Array`
+    # (e.g. `FixedSizeArray`), whose `lu_instance` pivot would otherwise differ.
+    luinst = ArrayInterface.lu_instance(convert(AbstractMatrix, A))
+    return LinearAlgebra.LU(luinst.factors, ipiv, luinst.info), ipiv
 end
 
 function LinearSolve.init_cacheval(
@@ -333,7 +338,12 @@ function init_cacheval(
         assumptions::OperatorAssumptions
     )
     ipiv = Vector{LinearAlgebra.BlasInt}(undef, min(size(A)...))
-    return ArrayInterface.lu_instance(convert(AbstractMatrix, A)), ipiv
+    # `solve!` stores `(generic_lufact!(A, ...), ipiv)` where the pivot is this
+    # `Vector{BlasInt}`. `lu_instance` would type the pivot after `A`'s container
+    # (e.g. a `FixedSizeVector` for a `FixedSizeArray`), so rebuild the instance
+    # with the `Vector` pivot to keep the cacheval slot type matching.
+    luinst = ArrayInterface.lu_instance(convert(AbstractMatrix, A))
+    return LinearAlgebra.LU(luinst.factors, ipiv, luinst.info), ipiv
 end
 
 function init_cacheval(

--- a/src/mkl.jl
+++ b/src/mkl.jl
@@ -287,12 +287,14 @@ end
 
 function LinearSolve.init_cacheval(
         alg::MKLLUFactorization,
-        A::AbstractMatrix{<:Union{Float32, ComplexF32, ComplexF64}}, b, u, Pl, Pr,
+        A::DenseMatrix{<:BLASELTYPES}, b, u, Pl, Pr,
         maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
         assumptions::OperatorAssumptions
     )
-    A = rand(eltype(A), 0, 0)
-    return ArrayInterface.lu_instance(A), Ref{BlasInt}()
+    # Build the instance from a 0×0 array of `A`'s own type so the cacheval slot
+    # matches the factorization `solve!` stores (built from `A`). This handles
+    # dense CPU arrays that aren't `Base.Array`, e.g. `FixedSizeArray`.
+    return ArrayInterface.lu_instance(similar(A, 0, 0)), Ref{BlasInt}()
 end
 
 function SciMLBase.solve!(

--- a/src/openblas.jl
+++ b/src/openblas.jl
@@ -308,12 +308,14 @@ end
 
 function LinearSolve.init_cacheval(
         alg::OpenBLASLUFactorization,
-        A::AbstractMatrix{<:Union{Float32, ComplexF32, ComplexF64}}, b, u, Pl, Pr,
+        A::DenseMatrix{<:BLASELTYPES}, b, u, Pl, Pr,
         maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
         assumptions::OperatorAssumptions
     )
-    A = rand(eltype(A), 0, 0)
-    return ArrayInterface.lu_instance(A), Ref{BlasInt}()
+    # Build the instance from a 0×0 array of `A`'s own type so the cacheval slot
+    # matches the factorization `solve!` stores (built from `A`). This handles
+    # dense CPU arrays that aren't `Base.Array`, e.g. `FixedSizeArray`.
+    return ArrayInterface.lu_instance(similar(A, 0, 0)), Ref{BlasInt}()
 end
 
 function SciMLBase.solve!(

--- a/test/core/fixedsizearrays.jl
+++ b/test/core/fixedsizearrays.jl
@@ -1,0 +1,105 @@
+using LinearSolve, FixedSizeArrays, LinearAlgebra, Test
+using LinearSolve: defaultalg, OperatorAssumptions
+
+# A `FixedSizeArray` is a dense, contiguous, column-major CPU array
+# (`FixedSizeMatrix{T} <: DenseMatrix{T}`) that is not a `Base.Array`. It is
+# directly LAPACK/BLAS-eligible, so the dense default and the dense LU caches
+# should handle it like any other dense matrix. See SciML/LinearSolve.jl#1034.
+
+@testset "defaultalg routes dense FixedSizeMatrix to a direct factorization" begin
+    n = 100
+    M = rand(n, n) + n * I
+    b = rand(n)
+    A = FixedSizeArray(M)
+    v = FixedSizeArray(b)
+
+    alg = defaultalg(A, v, OperatorAssumptions(true)).alg
+    # Must be a dense direct factorization, never the matrix-free Krylov default.
+    @test alg !== LinearSolve.DefaultAlgorithmChoice.KrylovJL_GMRES
+
+    sol = solve(LinearProblem(A, v))
+    @test sol.u isa FixedSizeArray
+    # Direct LU accuracy, not the ~1e-8 of a matrix-free GMRES fallback.
+    @test norm(M * Array(sol.u) - b) < 1.0e-10
+end
+
+# The BLAS backends (`MKL`, `AppleAccelerate`, `OpenBLAS`) are picked by the
+# default for dense, pointer-addressable CPU memory — not specifically a
+# `Base.Array`. A `FixedSizeMatrix` is exactly that, so it must resolve to the
+# same algorithm a `Matrix` of the same size/eltype does, including MKL/Apple
+# where those binaries are present.
+@testset "defaultalg routing is container-agnostic for dense memory" begin
+    assump = OperatorAssumptions(true)
+    for n in (5, 100, 600), T in (Float32, Float64)
+        M = rand(T, n, n) + n * I
+        b = rand(T, n)
+        ref = defaultalg(M, b, assump).alg
+        fsa = defaultalg(FixedSizeArray(M), FixedSizeArray(b), assump).alg
+        @test fsa === ref
+        @test fsa !== LinearSolve.DefaultAlgorithmChoice.KrylovJL_GMRES
+    end
+end
+
+@testset "dense LU factorizations accept FixedSizeArray" begin
+    n = 100
+    algs = Any[
+        LUFactorization(),
+        GenericLUFactorization(),
+        QRFactorization(),
+        OpenBLASLUFactorization(),
+    ]
+
+    for T in (Float32, Float64, ComplexF64)
+        M = rand(T, n, n) + n * I
+        b = rand(T, n)
+        A = FixedSizeArray(M)
+        v = FixedSizeArray(b)
+        ref = M \ b
+        tol = real(T) == Float32 ? 1.0f-3 : 1.0e-8
+        for alg in algs
+            sol = solve(LinearProblem(A, v), alg)
+            @test sol.u isa FixedSizeArray
+            @test norm(Array(sol.u) - ref) < tol
+        end
+    end
+end
+
+@testset "default solve and re-solve with FixedSizeArray" begin
+    n = 60
+    M = rand(n, n) + n * I
+    b = rand(n)
+    A = FixedSizeArray(M)
+    v = FixedSizeArray(b)
+
+    cache = init(LinearProblem(A, v))
+    sol1 = solve!(cache)
+    @test norm(M * Array(sol1.u) - b) < 1.0e-10
+
+    # Re-solve with a new b reuses the cached factorization.
+    b2 = rand(n)
+    cache.b = FixedSizeArray(b2)
+    sol2 = solve!(cache)
+    @test norm(M * Array(sol2.u) - b2) < 1.0e-10
+end
+
+# The BLAS-direct LU caches (`MKL`, `OpenBLAS`, `AppleAccelerate`, `BLIS`) store
+# a factorization built from `A` into a type-parameterized `cacheval` slot, so
+# `init_cacheval` must produce a slot whose container matches `A`. This holds
+# regardless of whether the corresponding BLAS binary is present, so the type
+# check runs everywhere even when the solver itself can't.
+@testset "BLAS LU init_cacheval slot tracks the FixedSizeArray container" begin
+    n = 20
+    A = FixedSizeArray(rand(n, n) + n * I)
+    v = FixedSizeArray(rand(n))
+    assump = OperatorAssumptions(true)
+    for alg in (
+            MKLLUFactorization(), OpenBLASLUFactorization(),
+            AppleAccelerateLUFactorization(),
+        )
+        slot = LinearSolve.init_cacheval(
+            alg, A, v, v, nothing, nothing, 0, 0.0, 0.0, true, assump
+        )
+        @test slot[1].factors isa FixedSizeArray
+        @test slot[1].ipiv isa FixedSizeArray
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,7 @@ else
         @time @safetestset "SparseVector b Tests" include("core/sparse_vector.jl")
         @time @safetestset "Nonstructural Zeros" include("core/nonstructural_zeros.jl")
         @time @safetestset "Default Alg Tests" include("core/default_algs.jl")
+        @time @safetestset "FixedSizeArrays" include("core/fixedsizearrays.jl")
         @time @safetestset "Adjoint Sensitivity" include("core/adjoint.jl")
         @time @safetestset "ForwardDiff Overloads" include("core/forwarddiff_overloads.jl")
         @time @safetestset "Traits" include("core/traits.jl")


### PR DESCRIPTION
## Summary

Fixes #1034. A `FixedSizeArray` (and any other dense, contiguous, pointer-addressable CPU array that isn't a `Base.Array`) is `<: DenseMatrix` and directly LAPACK/BLAS-eligible, but several parts of LinearSolve assumed the dense operator/RHS is specifically a `Matrix`/`Array`, so such matrices were either routed to a matrix-free iterative solver or hit a `cacheval` `setfield!` `TypeError`.

## Problem 1 — `defaultalg` routing keyed on the concrete `Array` type

The selection logic is really about dense, pointer-addressable CPU memory, but it was written against `Array`:

- The dense direct-factorization branch, the Krylov-`cacheval` skip, and the dense-vs-sparse QR-fallback-reuse split were gated on `A isa Matrix` / `cache.A isa Array`. These are broadened to `DenseMatrix`, so a dense non-`Array` matrix routes to a direct factorization instead of falling through to `KrylovJL_GMRES` (with its accuracy loss).
- The `MKLLUFactorization` / `AppleAccelerateLUFactorization` default-selection guards were `b isa Array`. These are broadened to `b isa DenseArray && !(b isa GPUArraysCore.AnyGPUArray)` so those BLAS backends are used for dense CPU memory whenever they're faster, regardless of the concrete container. Routing is now **container-agnostic**: a `FixedSizeMatrix` resolves to the same algorithm a `Matrix` of the same size/eltype does (including MKL/Apple where present).

GPU arrays keep their own `defaultalg` dispatch and are unaffected.

## Problem 2 — some dense LU caches assumed `Array`-typed containers

The `cacheval` field is type-parameterized, so its type is fixed by `init_cacheval` and must match what `solve!` stores:

- `GenericLUFactorization` / `RFLUFactorization`: `solve!` stores a `Vector{BlasInt}` pivot, but `lu_instance(A)` types the pivot after `A`'s container (e.g. a `FixedSizeVector`). The instance is rebuilt with the `Vector` pivot. (`RFLUFactorization` is included because the broadened `defaultalg` can select it for these matrices; it had the same latent bug.)
- `MKLLUFactorization` / `OpenBLASLUFactorization` / `AppleAccelerateLUFactorization` / `BLISLUFactorization`: the preallocated cache was built from `rand(0,0)` (a `Matrix`), so a non-`Array` dense factorization was the wrong type for the slot. The instance is now built from a 0×0 array of `A`'s own type, and the dense BLAS-eltype method is extended to `DenseMatrix{<:BLASELTYPES}` (which also now covers `Float64` dense containers).

## Tests

Adds `test/core/fixedsizearrays.jl` (over `FixedSizeArrays`) covering:
- default routing of a dense `FixedSizeMatrix` to a direct factorization (not GMRES) with direct-LU accuracy;
- **container-agnostic routing**: `defaultalg` on a `FixedSizeMatrix` equals `defaultalg` on a `Matrix` of the same size/eltype, across sizes/eltypes (exercises the MKL/Apple guards wherever those binaries exist on CI);
- `LUFactorization`, `GenericLUFactorization`, `QRFactorization`, `OpenBLASLUFactorization` across `Float32`/`Float64`/`ComplexF64`;
- default solve + re-solve;
- a binary-independent check that the `MKL`/`OpenBLAS`/`AppleAccelerate` `cacheval` slot tracks `A`'s container (runs even where those binaries are absent).

## Local verification

On Julia 1.12 / Linux (OpenBLAS; MKL & AppleAccelerate binaries not present locally):
- The issue's reproducer routes to `LUFactorization` with `resid ≈ 2e-15` (was `KrylovJL_GMRES`, `resid ≈ 1.4e-8`).
- `GenericLUFactorization` and `RFLUFactorization` no longer throw; `OpenBLASLUFactorization` works through the real `getrf!` ccall on a `FixedSizeArray` — the same ccall pattern MKL/Apple/BLIS use.
- New tests pass (47/47); `core/basictests.jl` and `core/default_algs.jl` pass with no regressions.
- MKL/AppleAccelerate routing for `FixedSizeArray` is verified at the routing level (container-agnostic equality test) and the cache-type level (slot-container test) plus the analogous OpenBLAS end-to-end path; the MKL/Apple ccall itself isn't exercised locally for want of those binaries.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
