### PR TITLE
Import PureUMFPACK in the re-solve tests

### DIFF
--- a/test/core/resolve.jl
+++ b/test/core/resolve.jl
@@ -1,5 +1,7 @@
 using LinearSolve, LinearAlgebra, SparseArrays, InteractiveUtils, Test
 using SpecializingFactorizations
+# Load PureUMFPACK so its package extension is loaded for the tests
+using PureUMFPACK: PureUMFPACK
 using LinearSolve: AbstractDenseFactorization, AbstractSparseFactorization,
     BLISLUFactorization, CliqueTreesFactorization,
     AMDGPUOffloadLUFactorization, AMDGPUOffloadQRFactorization,

--- a/test/core/resolve.jl
+++ b/test/core/resolve.jl
@@ -1,6 +1,5 @@
 using LinearSolve, LinearAlgebra, SparseArrays, InteractiveUtils, Test
 using SpecializingFactorizations
-# Load PureUMFPACK so its package extension is loaded for the tests
 using PureUMFPACK: PureUMFPACK
 using LinearSolve: AbstractDenseFactorization, AbstractSparseFactorization,
     BLISLUFactorization, CliqueTreesFactorization,


### PR DESCRIPTION
Otherwise its package extension is not loaded and we get MethodError's.

Fixes these errors seen in https://github.com/SciML/SciMLBase.jl/pull/1386:
```julia
Re-solve: Error During Test at /home/james/git/LinearSolve.jl/test/core/resolve.jl:101                                                                                                                                                                                                                                         
  Test threw exception                                                                                                                                                                                                                                                                                                         
  Expression: (solve!(linsolve)).u ≈ expected                                                                                                                                                                                                                                                                                  
  MethodError: no method matching do_factorization(::LinearSolve.PureUMFPACKFactorization, ::SparseArrays.SparseMatrixCSC{Float64, Int64}, ::Vector{Float64}, ::Vector{Float64})                                                                                                                                               
  The function `do_factorization` exists, but no method is defined for this combination of argument types.                                                                                                                                                                                                                     
  Closest candidates are:                                                                                                                                                                                                                                                                                                      
    do_factorization(::LinearSolve.BunchKaufmanFactorization, ::Any, ::Any, ::Any)                                                                                                                                                                                                                                             
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:749                                                                                                                                                                                                                                                               
    do_factorization(::LinearSolve.LUFactorization, ::Any, ::Any, ::Any)                                                                                                                                                                                                                                                       
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:315                                                                                                                                                                                                                                                               
    do_factorization(::LinearSolve.QRFactorization, ::Any, ::Any, ::Any)                                                                                                                                                                                                                                                       
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:469                                                                                                                                                                                                                                                               
    ...                                                                                                                                                                                                                                                                                                                        
  Stacktrace:                                                                                                                                                                                                                                                                                                                  
   [1] macro expansion                                                                                                                                                                                                                                                                                                         
     @ ~/git/LinearSolve.jl/src/factorization.jl:16 [inlined]                                                                                                                                                                                                                                                                  
   [2] solve!(cache::LinearSolve.LinearCache{SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.PureUMFPACKFactorization, Nothing, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{true}, Bool, LinearSolve.LinearSolveAdjoint{Missing}, LinearSolveSparseArraysExt.SparseReduction{Float64, Int64}}, alg::LinearSolve.PureUMFPACKFactorization; kwargs::@Kwargs{})
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:1                                                                                                                                                                                                                                                                 
   [3] solve!(::LinearSolve.LinearCache{SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.PureUMFPACKFactorization, Nothing, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{true}, Bool, LinearSolve.LinearSolveAdjoint{Missing}, LinearSolveSparseArraysExt.SparseReduction{Float64, Int64}}; kwargs::@Kwargs{})
     @ LinearSolve ~/git/LinearSolve.jl/src/common.jl:619                                                                                                                                                                                                                                                                                                                                      
   [4] solve!(::LinearSolve.LinearCache{SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.PureUMFPACKFactorization, Nothing, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{true}, Bool, LinearSolve.LinearSolveAdjoint{Missing}, LinearSolveSparseArraysExt.SparseReduction{Float64, Int64}})
     @ LinearSolve ~/git/LinearSolve.jl/src/common.jl:618                                                                                                                                                                                                                                                                      
   [5] macro expansion                                                                                                                                                                                                                                                                                                                                                                         
     @ ~/.julia/juliaup/julia-1.13-nightly/share/julia/stdlib/v1.13/Test/src/Test.jl:750 [inlined]
   [6] top-level scope                                                                         
     @ ~/git/LinearSolve.jl/test/core/resolve.jl:101                                           
                                                                                                                                                                                               
Re-solve: Test Failed at /home/james/git/LinearSolve.jl/test/core/resolve.jl:102
  Expression: !(linsolve.isfresh)                                                                                      
  Stacktrace:                                                                                                          
   [1] macro expansion                                                                                                 
     @ ~/.julia/juliaup/julia-1.13-nightly/share/julia/stdlib/v1.13/Test/src/Test.jl:753 [inlined]
   [2] top-level scope                                                                                                 
     @ ~/git/LinearSolve.jl/test/core/resolve.jl:102                                                                   
   [3] include(mapexpr::Function, mod::Module, _path::String)
     @ Base ./Base.jl:310                                                                                              
   [4] top-level scope                                                                                                                                         
     @ ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:24                                                                                             
   [5] macro expansion                                                                                                                                         
     @ ~/.julia/juliaup/julia-1.13-nightly/share/julia/stdlib/v1.13/Test/src/Test.jl:1961 [inlined]                                                            
   [6] macro expansion                                                                                                                                         
     @ ~/.julia/packages/SafeTestsets/raUNr/src/SafeTestsets.jl:24 [inlined]                                                                                   

Re-solve: Error During Test at /home/james/git/LinearSolve.jl/test/core/resolve.jl:103                                                                         
  Test threw exception                                                                                                                                         
  Expression: (solve!(linsolve)).u ≈ expected                                                                                                                  
  MethodError: no method matching do_factorization(::LinearSolve.PureUMFPACKFactorization, ::SparseArrays.SparseMatrixCSC{Float64, Int64}, ::Vector{Float64}, ::Vector{Float64})                                                                                                                                               
  The function `do_factorization` exists, but no method is defined for this combination of argument types.                                                     
  Closest candidates are:                                                                                                                                      
    do_factorization(::LinearSolve.BunchKaufmanFactorization, ::Any, ::Any, ::Any)                                                                             
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:749                                                                                               
    do_factorization(::LinearSolve.LUFactorization, ::Any, ::Any, ::Any)                                                                                       
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:315                                                                                               
    do_factorization(::LinearSolve.QRFactorization, ::Any, ::Any, ::Any)                                                                                       
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:469                                                                                               
    ...                                                                                                                                                        
  Stacktrace:                                                                                                                                                  
   [1] macro expansion                                                                                                                                         
     @ ~/git/LinearSolve.jl/src/factorization.jl:16 [inlined]                                                                                                  
   [2] solve!(cache::LinearSolve.LinearCache{SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.PureUMFPACKFactorization, Nothing, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{true}, Bool, LinearSolve.LinearSolveAdjoint{Missing}, LinearSolveSparseArraysExt.SparseReduction{Float64, Int64}}, alg::LinearSolve.PureUMFPACKFactorization; kwargs::@Kwargs{})                                                                                                                                                                  
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:1                                                                                                 
   [3] solve!(::LinearSolve.LinearCache{SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.PureUMFPACKFactorization, Nothing, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{true}, Bool, LinearSolve.LinearSolveAdjoint{Missing}, LinearSolveSparseArraysExt.SparseReduction{Float64, Int64}}; kwargs::@Kwargs{})                                                                                                                                                                                                                  
     @ LinearSolve ~/git/LinearSolve.jl/src/common.jl:619                                                                                                      
   [4] solve!(::LinearSolve.LinearCache{SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.PureUMFPACKFactorization, Nothing, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{true}, Bool, LinearSolve.LinearSolveAdjoint{Missing}, LinearSolveSparseArraysExt.SparseReduction{Float64, Int64}})                                                                                                                                                                                                                                     
     @ LinearSolve ~/git/LinearSolve.jl/src/common.jl:618                                                                                                      
   [5] macro expansion                                                                                                                                         
     @ ~/.julia/juliaup/julia-1.13-nightly/share/julia/stdlib/v1.13/Test/src/Test.jl:750 [inlined]                                                             
   [6] top-level scope                                                                                                                                         
     @ ~/git/LinearSolve.jl/test/core/resolve.jl:103                                                                                                           

Re-solve: Error During Test at /home/james/git/LinearSolve.jl/test/core/resolve.jl:124                                                                         
  Test threw exception                                                                                                                                         
  Expression: (solve!(linsolve)).u ≈ expected                                                                                                                  
  MethodError: no method matching do_factorization(::LinearSolve.PureUMFPACKFactorization, ::SparseArrays.SparseMatrixCSC{Float64, Int64}, ::Vector{Float64}, ::Vector{Float64})                                                                                                                                               
  The function `do_factorization` exists, but no method is defined for this combination of argument types.                                                     
  Closest candidates are:                                                                                                                                      
    do_factorization(::LinearSolve.BunchKaufmanFactorization, ::Any, ::Any, ::Any)                                                                             
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:749                                                                                               
    do_factorization(::LinearSolve.LUFactorization, ::Any, ::Any, ::Any)                                                                                       
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:315                                                                                               
    do_factorization(::LinearSolve.QRFactorization, ::Any, ::Any, ::Any)                                                                                       
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:469                                                                                               
    ...                                                                                                                                                        
  Stacktrace:                                                                                                                                                  
   [1] macro expansion                                                                                                                                         
     @ ~/git/LinearSolve.jl/src/factorization.jl:16 [inlined]                                                                                                  
   [2] solve!(cache::LinearSolve.LinearCache{SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.PureUMFPACKFactorization, Nothing, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{true}, Bool, LinearSolve.LinearSolveAdjoint{Missing}, LinearSolveSparseArraysExt.SparseReduction{Float64, Int64}}, alg::LinearSolve.PureUMFPACKFactorization; kwargs::@Kwargs{})                                                                                                                                                                  
     @ LinearSolve ~/git/LinearSolve.jl/src/factorization.jl:1                                                                                                 
   [3] solve!(::LinearSolve.LinearCache{SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.PureUMFPACKFactorization, Nothing, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{true}, Bool, LinearSolve.LinearSolveAdjoint{Missing}, LinearSolveSparseArraysExt.SparseReduction{Float64, Int64}}; kwargs::@Kwargs{})                                                                                                                                                                                                                  
     @ LinearSolve ~/git/LinearSolve.jl/src/common.jl:619                                                                                                      
   [4] solve!(::LinearSolve.LinearCache{SparseArrays.SparseMatrixCSC{Float64, Int64}, Vector{Float64}, Vector{Float64}, SciMLBase.NullParameters, LinearSolve.PureUMFPACKFactorization, Nothing, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{true}, Bool, LinearSolve.LinearSolveAdjoint{Missing}, LinearSolveSparseArraysExt.SparseReduction{Float64, Int64}})                                                                                                                                                                                                                                     
     @ LinearSolve ~/git/LinearSolve.jl/src/common.jl:618                                                                                                      
   [5] macro expansion                                                                                                                                         
     @ ~/.julia/juliaup/julia-1.13-nightly/share/julia/stdlib/v1.13/Test/src/Test.jl:750 [inlined]                                                             
   [6] top-level scope                                                                                                                                         
     @ ~/git/LinearSolve.jl/test/core/resolve.jl:124
```

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
