### PR TITLE
Opt PureKLU and RFLU out of split dual AD path (rebase of #1023)

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -394,7 +394,9 @@ end
 function _use_direct_dual_solve(alg)
     return alg isa GenericLUFactorization ||
         alg isa LinearSolve.SpecializedLUFactorization ||
-        alg isa LinearSolve.SpecializedQRFactorization
+        alg isa LinearSolve.SpecializedQRFactorization ||
+        alg isa LinearSolve.PureKLUFactorization ||
+        alg isa LinearSolve.RFLUFactorization
 end
 
 function _use_direct_dual_solve(alg::DefaultLinearSolver)

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -410,8 +410,12 @@ function SciMLBase.solve!(
         ForwardDiff.Dual,
     }
     # Check if this algorithm can work directly with Duals (e.g., GenericLUFactorization)
-    # In that case, we solve the dual problem directly without separating primal/partials
-    if _use_direct_dual_solve(getfield(cache, :linear_cache).alg)
+    # In that case, we solve the dual problem directly without separating primal/partials.
+    # Only worthwhile when A itself carries duals: with duals just in b, the split
+    # path (one primal factorization + partials back-solves) is strictly cheaper
+    # than factorizing in dual arithmetic.
+    if _use_direct_dual_solve(getfield(cache, :linear_cache).alg) &&
+            get_dual_type(getfield(cache, :dual_A)) !== nothing
         return _solve_direct_dual!(cache, alg, args...; kwargs...)
     end
 
@@ -441,6 +445,13 @@ function _solve_direct_dual!(
     # Get the dual A and b
     dual_A = getfield(cache, :dual_A)
     dual_b = getfield(cache, :dual_b)
+
+    # When the duals are only in A, b is stored as a plain array. Promote it to
+    # the dual type: `__init` takes the solution eltype from `b`, and the
+    # factorization/solve kernels need matching element types.
+    if eltype(dual_b) != DT
+        dual_b = DT.(dual_b)
+    end
 
     # Use __init to create a regular LinearCache (bypasses ForwardDiff extension)
     # then solve! on that cache directly with the dual values

--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -545,14 +545,12 @@ function LinearSolve.init_cacheval(
     return PREALLOCATED_PUREKLU
 end
 
-# PureKLU's kernels are pure Julia and generic over `Union{Real, Complex}`
-# (e.g. ForwardDiff duals via the direct dual solve path), not just BLAS types.
 function LinearSolve.init_cacheval(
         alg::PureKLUFactorization, A::AbstractSparseArray{T, Int64}, b, u, Pl, Pr,
         maxiters::Int, abstol,
         reltol,
         verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-    ) where {T <: Union{Real, Complex}}
+    ) where {T <: Union{Float64, ComplexF64}}
     return PureKLU.KLUFactorization(
         SparseMatrixCSC{T, Int64}(
             0, 0, [Int64(1)], Int64[], T[]
@@ -578,7 +576,7 @@ function LinearSolve.init_cacheval(
         maxiters::Int, abstol,
         reltol,
         verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-    ) where {T <: Union{Real, Complex}}
+    ) where {T <: Union{Float64, ComplexF64}}
     return PureKLU.KLUFactorization(
         SparseMatrixCSC{T, Int32}(
             0, 0, [Int32(1)], Int32[], T[]

--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -545,12 +545,14 @@ function LinearSolve.init_cacheval(
     return PREALLOCATED_PUREKLU
 end
 
+# PureKLU's kernels are pure Julia and generic over `Union{Real, Complex}`
+# (e.g. ForwardDiff duals via the direct dual solve path), not just BLAS types.
 function LinearSolve.init_cacheval(
         alg::PureKLUFactorization, A::AbstractSparseArray{T, Int64}, b, u, Pl, Pr,
         maxiters::Int, abstol,
         reltol,
         verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-    ) where {T <: Union{Float64, ComplexF64}}
+    ) where {T <: Union{Real, Complex}}
     return PureKLU.KLUFactorization(
         SparseMatrixCSC{T, Int64}(
             0, 0, [Int64(1)], Int64[], T[]
@@ -576,7 +578,7 @@ function LinearSolve.init_cacheval(
         maxiters::Int, abstol,
         reltol,
         verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-    ) where {T <: Union{Float64, ComplexF64}}
+    ) where {T <: Union{Real, Complex}}
     return PureKLU.KLUFactorization(
         SparseMatrixCSC{T, Int32}(
             0, 0, [Int32(1)], Int32[], T[]

--- a/test/core/forwarddiff_overloads.jl
+++ b/test/core/forwarddiff_overloads.jl
@@ -55,6 +55,18 @@ b_ls = [p_ls[1] + 1, p_ls[2] * 2, p_ls[1] * p_ls[2]]
 qr_ls_x_p = solve(LinearProblem(A_ls, b_ls), SpecializedQRFactorization())
 @test dual_isapprox(qr_ls_x_p.u, qr(A_ls) \ b_ls, rtol = 1.0e-9)
 
+# Opt-out path with duals only in A (plain b) and only in b (plain A)
+
+plain_b = ForwardDiff.value.(b)
+prob = LinearProblem(A, plain_b)
+@test ≈(solve(prob, GenericLUFactorization()), A \ plain_b, rtol = 1.0e-9)
+@test ≈(solve(prob, RFLUFactorization()), A \ plain_b, rtol = 1.0e-9)
+
+plain_A = ForwardDiff.value.(A)
+prob = LinearProblem(plain_A, b)
+@test ≈(solve(prob, GenericLUFactorization()), plain_A \ b, rtol = 1.0e-9)
+@test ≈(solve(prob, RFLUFactorization()), plain_A \ b, rtol = 1.0e-9)
+
 # Overload Dense
 
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
@@ -244,6 +256,16 @@ overload_x_p = solve(prob, PureKLUFactorization())
 backslash_x_p = A \ b
 
 @test ≈(overload_x_p, backslash_x_p, rtol = 1.0e-9)
+
+# Duals only in A, and only in b
+
+plain_b = ForwardDiff.value.(b)
+prob = LinearProblem(sparse(A), plain_b)
+@test ≈(solve(prob, PureKLUFactorization()), A \ plain_b, rtol = 1.0e-9)
+
+plain_A = ForwardDiff.value.(A)
+prob = LinearProblem(sparse(plain_A), b)
+@test ≈(solve(prob, PureKLUFactorization()), plain_A \ b, rtol = 1.0e-9)
 
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 

--- a/test/core/forwarddiff_overloads.jl
+++ b/test/core/forwarddiff_overloads.jl
@@ -6,6 +6,7 @@ using SparseArrays
 using ComponentArrays
 using Sparspak
 using SpecializingFactorizations
+using RecursiveFactorization
 
 function h(p)
     return (
@@ -18,10 +19,11 @@ function h(p)
     )
 end
 
-# Opt-out dense methods: SpecializedLU/QR solve the Dual problem directly
-# (no primal/partials splitting). The partials can differ from `\` by an ulp,
-# and isapprox over Dual vectors NaNs when the primal diff is exactly zero
-# (sqrt has infinite slope at 0), so compare values and partials separately.
+# Opt-out dense methods: SpecializedLU/QR, GenericLU and RFLU solve the Dual
+# problem directly (no primal/partials splitting). The partials can differ from
+# `\` by an ulp, and isapprox over Dual vectors NaNs when the primal diff is
+# exactly zero (sqrt has infinite slope at 0), so compare values and partials
+# separately.
 function dual_isapprox(x, y; rtol)
     isapprox(ForwardDiff.value.(x), ForwardDiff.value.(y); rtol) || return false
     return isapprox(
@@ -38,6 +40,12 @@ backslash_x_p = A \ b
 )
 @test dual_isapprox(
     solve(prob, SpecializedQRFactorization()).u, backslash_x_p, rtol = 1.0e-9
+)
+@test dual_isapprox(
+    solve(prob, GenericLUFactorization()).u, backslash_x_p, rtol = 1.0e-9
+)
+@test dual_isapprox(
+    solve(prob, RFLUFactorization()).u, backslash_x_p, rtol = 1.0e-9
 )
 
 # Rectangular least-squares with Duals through the direct dual path
@@ -227,12 +235,36 @@ backslash_x_p = new_A \ new_b
 
 @test linu == cache.u
 
+# Test Pure Julia Sparse Linear Algebra
+
+A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
+
+prob = LinearProblem(sparse(A), sparse(b))
+overload_x_p = solve(prob, PureKLUFactorization())
+backslash_x_p = A \ b
+
+@test ≈(overload_x_p, backslash_x_p, rtol = 1.0e-9)
+
+A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
+
+prob = LinearProblem(sparse(A), sparse(b))
+overload_x_p = solve(prob, SparseColumnPivotedQRFactorization())
+backslash_x_p = A \ b
+
+@test ≈(overload_x_p, backslash_x_p, rtol = 1.0e-9)
+
 # Test Float Only solvers
 
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
 prob = LinearProblem(sparse(A), sparse(b))
 overload_x_p = solve(prob, KLUFactorization())
+backslash_x_p = A \ b
+
+@test ≈(overload_x_p, backslash_x_p, rtol = 1.0e-9)
+
+prob = LinearProblem(sparse(A), sparse(b))
+overload_x_p = solve(prob, PureKLUFactorization())
 backslash_x_p = A \ b
 
 @test ≈(overload_x_p, backslash_x_p, rtol = 1.0e-9)

--- a/test/core/forwarddiff_overloads.jl
+++ b/test/core/forwarddiff_overloads.jl
@@ -263,12 +263,6 @@ backslash_x_p = A \ b
 
 @test ≈(overload_x_p, backslash_x_p, rtol = 1.0e-9)
 
-prob = LinearProblem(sparse(A), sparse(b))
-overload_x_p = solve(prob, PureKLUFactorization())
-backslash_x_p = A \ b
-
-@test ≈(overload_x_p, backslash_x_p, rtol = 1.0e-9)
-
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
 prob = LinearProblem(sparse(A), sparse(b))


### PR DESCRIPTION
Rebases and finalizes #1023 (branch `ChrisRackauckas-patch-1`) onto the current `main`. The original PR went stale (`mergeable_state: dirty`); I couldn't push to the SciML-owned branch, so this is the rebased version from a fork. It carries the same commits (authored by @ChrisRackauckas), now conflict-free on `main`. **Supersedes #1023** — close that one in favor of this.

## What it does (unchanged intent)

Opt `PureKLUFactorization` and `RFLUFactorization` out of the split primal/partials dual-AD path so they solve the Dual problem directly, and only take the direct path when `A` itself carries duals (with duals only in `b`, the split path — one primal factorization + partials back-solves — is cheaper than factorizing in dual arithmetic). Also promotes a plain `b` to the dual eltype on the direct path.

## Net change is now just `LinearSolveForwardDiffExt.jl` + the test

The original PR also widened two PureKLU `init_cacheval` methods in `LinearSolveSparseArraysExt.jl` from `Union{Float64, ComplexF64}` to `Union{Real, Complex}`. **That is dropped here** — after rebasing onto `main`, it's redundant: #1037 ("Default to PureKLU for generic-eltype sparse LU") added a catch-all `where {T <: Number, Ti <: Integer}` method that already builds the correct empty cache for any number eltype, duals included. The widened specializations only duplicated it, so that file is left identical to `main`. (The last commit reverts it, with the reasoning; verified the PureKLU sparse-dual tests still pass.)

## Conflicts resolved during rebase

`main` independently evolved both touched spots:

- `ext/LinearSolveForwardDiffExt.jl` — `_use_direct_dual_solve` had gained `SpecializedLUFactorization`/`SpecializedQRFactorization` on `main`. Resolved as the **union**: `GenericLU || SpecializedLU || SpecializedQR || PureKLU || RFLU`.
- `test/core/forwarddiff_overloads.jl` — `main` switched the direct-path comparison to a robust `dual_isapprox` helper (plain `≈` over Dual vectors NaNs when a primal diff is exactly zero). Kept that helper and the `Specialized*` + least-squares tests, and re-expressed the PR's `GenericLU`/`RFLU` checks through `dual_isapprox` (they take the same direct path, so the same ulp/NaN concern applies). Unioned the `using SpecializingFactorizations` / `using RecursiveFactorization` imports.

## Local verification

Julia 1.12 / Linux. `Runic --check` clean. `test/core/forwarddiff_overloads.jl` runs green end-to-end (all testsets, including the merged `dual_isapprox` checks for `SpecializedLU`/`SpecializedQR`/`GenericLU`/`RFLU`, the least-squares case, the plain-`A`/plain-`b` opt-out cases, and the `PureKLU` sparse-dual tests) — both with and without the now-dropped ext change.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
