### PR TITLE
Fix DefaultsLoading test: sparse BigFloat defaults to PureKLU (not Sparspak) since #1037

### DIFF
--- a/test/defaultsloading/defaults_loading.jl
+++ b/test/defaultsloading/defaults_loading.jl
@@ -27,7 +27,13 @@ mat = sparse(rows, cols, vals, n, n)
 rhs = big.(zeros(n))
 rhs[begin] = rhs[end] = -2
 prob = LinearProblem(mat, rhs)
-@test_throws ["SparspakFactorization required", "using Sparspak"] sol = solve(prob).u
+# Generic-eltype (BigFloat) sparse LU defaults to PureKLU (a hard dependency)
+# since #1037, so this solves without `using Sparspak` being loaded first.
+@test Base.get_extension(LinearSolve, :LinearSolveSparspakExt) === nothing
+@test LinearSolve.defaultalg(mat, rhs).alg ===
+    LinearSolve.DefaultAlgorithmChoice.KLUFactorization
+sol = solve(prob).u
+@test sol isa Vector{BigFloat}
 
 STRUMPACKExt = Base.get_extension(LinearSolve, :LinearSolveSTRUMPACKExt)
 if STRUMPACKExt === nothing || !STRUMPACKExt.strumpack_isavailable()

--- a/test/defaultsloading/defaults_loading.jl
+++ b/test/defaultsloading/defaults_loading.jl
@@ -27,8 +27,6 @@ mat = sparse(rows, cols, vals, n, n)
 rhs = big.(zeros(n))
 rhs[begin] = rhs[end] = -2
 prob = LinearProblem(mat, rhs)
-# Generic-eltype (BigFloat) sparse LU defaults to PureKLU (a hard dependency)
-# since #1037, so this solves without `using Sparspak` being loaded first.
 @test Base.get_extension(LinearSolve, :LinearSolveSparspakExt) === nothing
 @test LinearSolve.defaultalg(mat, rhs).alg ===
     LinearSolve.DefaultAlgorithmChoice.KLUFactorization


### PR DESCRIPTION
Fixes #1042 — a stale test failing on `main`/CI in the `DefaultsLoading` group.

## Problem

`test/defaultsloading/defaults_loading.jl:30` asserted, via `@test_throws`, that solving a sparse `BigFloat` `LinearProblem` *before* `using Sparspak` raises `"SparspakFactorization required ... using Sparspak"`. That fails on `main` with **"No exception thrown"**:

```
Defaults Loading Tests: Test Failed at .../defaults_loading.jl:30
  Expression: sol = (solve(prob)).u
    Expected: ["SparspakFactorization required", "using Sparspak"]
  No exception thrown
```

## Cause

#1037 (`52ebf258`, "Default to PureKLU for generic-eltype sparse LU") intentionally changed the default sparse LU for generic (non-BLAS) element types from `SparspakFactorization` to PureKLU — a pure-Julia **hard** dependency — and removed the `"SparspakFactorization required"` error branch from `defaultalg`. So that error path is unreachable now, and the `@test_throws` never fires. The test simply wasn't updated alongside the routing change.

## Fix

Update the test to the new intended behavior: a generic-eltype (BigFloat) sparse problem routes to `KLUFactorization` and solves **without** `using Sparspak`.

```julia
@test Base.get_extension(LinearSolve, :LinearSolveSparspakExt) === nothing
@test LinearSolve.defaultalg(mat, rhs).alg ===
    LinearSolve.DefaultAlgorithmChoice.KLUFactorization
sol = solve(prob).u
@test sol isa Vector{BigFloat}
```

## Verification

Ran the full `test/defaultsloading/defaults_loading.jl` locally (Julia 1.12 / Linux, with `Sparspak` + `STRUMPACK_jll` available) — passes, no failures. `Runic --check` clean.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
