### PR TITLE
Use SparseArrays' in-place ldiv!() on 1.13+

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -881,18 +881,20 @@ end
         end
     end
 
-    # ldiv!() for SPQR should be in Julia 1.13: https://github.com/JuliaSparse/SparseArrays.jl/pull/676
-    function LinearSolve._ldiv!(
-            x::Vector,
-            A::SparseArrays.SPQR.QRSparse, b::Vector
-        )
-        x .= A \ b
-    end
-    function LinearSolve._ldiv!(
-            x::AbstractVector,
-            A::SparseArrays.SPQR.QRSparse, b::AbstractVector
-        )
-        x .= A \ b
+    # ldiv!() for SPQR was added in 1.13: https://github.com/JuliaSparse/SparseArrays.jl/pull/676
+    @static if VERSION < v"1.13"
+        function LinearSolve._ldiv!(
+                x::Vector,
+                A::SparseArrays.SPQR.QRSparse, b::Vector
+            )
+            x .= A \ b
+        end
+        function LinearSolve._ldiv!(
+                x::AbstractVector,
+                A::SparseArrays.SPQR.QRSparse, b::AbstractVector
+            )
+            x .= A \ b
+        end
     end
 
     function LinearSolve._ldiv!(


### PR DESCRIPTION
The in-place `ldiv!()` has been backported now.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
