### PR TITLE
Allow AlgebraicMultigrid v2 in the AMG extension compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "3.85.1"
+version = "3.85.2"
 authors = ["SciML"]
 
 [deps]
@@ -108,7 +108,7 @@ LinearSolveSpecializingFactorizationsExt = "SpecializingFactorizations"
 [compat]
 AMD = "0.5"
 AMDGPU = "1.2, 2"
-AlgebraicMultigrid = "1"
+AlgebraicMultigrid = "1, 2"
 ArrayInterface = "7.19"
 BandedMatrices = "1.8"
 BlockDiagonals = "0.2"


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

## What

One-line `[compat]` bump for the `LinearSolveAlgebraicMultigridExt` weak dependency:

```diff
-AlgebraicMultigrid = "1"
+AlgebraicMultigrid = "1, 2"
```

(plus a patch version bump `3.85.1` → `3.85.2` so it can be released).

## Why

The AMG extension's weak-dependency compat was pinned to `AlgebraicMultigrid = "1"`, which **excludes AMG v2.0**. Because the modern stack (e.g. **OrdinaryDiffEq v7**) requires `LinearSolve >= 3.60` — exactly the LinearSolve versions that carry this weakdep — AMG 2.0 becomes **unsatisfiable** alongside it, even though AMG 2.0's *own* `LinearSolve` compat is `"2 - 3"` (which includes the current 3.85.x).

The Julia resolver hides the real edge, reporting things like:

```
AlgebraicMultigrid restricted by compatibility requirements with LinearSolve to versions: 1.0.0 - 1.2.0 — no versions left
```

with no transitive explanation. The give-away: replicating AMG 2.0's *exact* declared dependencies as a top-level project resolves fine with LinearSolve 3.85.1, while the AMG package itself does not — isolating the constraint to **this weak-compat edge** in LinearSolve.

This was surfaced while fixing the DiffEqDocs.jl build on the OrdinaryDiffEq v7 migration (SciML/DiffEqDocs.jl#869/#870), where AMG 2.0 could not be installed next to the v7 stack.

## Extension code is unchanged / already compatible

`ext/LinearSolveAlgebraicMultigridExt.jl` uses only `RugeStubenAMG()`, `SciMLBase.init(amg_alg, A, b)`, `solve!(solver; maxiter, reltol)` and `solver.b` — all identical between AMG 1.x and 2.0 (`AMGSolver{T}` still has a `.b::Vector{T}` field; AMG re-exports `CommonSolve.{init, solve!}`). No source change is required.

## Verification (local, Julia 1.12.6, current General registry)

- `OrdinaryDiffEq 7.0.0 + LinearSolve 3.85.x + AlgebraicMultigrid 2.0.0 + SciMLBase 3.21.0` now resolve together (fails without this bump).
- The existing `AlgebraicMultigridJL` test block in `test/Core/basictests.jl` passes **verbatim against AMG 2.0.0** — default Ruge-Stuben, `SmoothedAggregationAMG`, tight-tolerance solve, and the rectangular-matrix `AssertionError` (4/4 pass).
- A 1600×1600 SPD Poisson solve via `solve(LinearProblem(A,b), AlgebraicMultigridJL())` on AMG 2.0.0 converges (rel. residual 1.3e-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)