### PR TITLE
Fix init_cacheval for SizedMatrix (StaticArrays.LU has no field factors)

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -184,6 +184,10 @@ function LinearSolve.init_cacheval(
     # type matches for dense CPU arrays whose container isn't `Base.Array`
     # (e.g. `FixedSizeArray`), whose `lu_instance` pivot would otherwise differ.
     luinst = ArrayInterface.lu_instance(convert(AbstractMatrix, A))
+    # `lu_instance` may return a non-`LinearAlgebra.LU` (e.g. `StaticArrays.LU`
+    # for a `SizedMatrix`, with fields `L`/`U`/`p` rather than `factors`/`info`);
+    # those already carry a `Vector` pivot, so use them as-is.
+    luinst isa LinearAlgebra.LU || return luinst, ipiv
     return LinearAlgebra.LU(luinst.factors, ipiv, luinst.info), ipiv
 end
 
@@ -343,6 +347,10 @@ function init_cacheval(
     # (e.g. a `FixedSizeVector` for a `FixedSizeArray`), so rebuild the instance
     # with the `Vector` pivot to keep the cacheval slot type matching.
     luinst = ArrayInterface.lu_instance(convert(AbstractMatrix, A))
+    # `lu_instance` may return a non-`LinearAlgebra.LU` (e.g. `StaticArrays.LU`
+    # for a `SizedMatrix`, with fields `L`/`U`/`p` rather than `factors`/`info`);
+    # those already carry a `Vector` pivot, so use them as-is.
+    luinst isa LinearAlgebra.LU || return luinst, ipiv
     return LinearAlgebra.LU(luinst.factors, ipiv, luinst.info), ipiv
 end
 


### PR DESCRIPTION
## Problem

`init(LinearProblem(A, b))` with a `SizedMatrix` (StaticArrays) throws on `GenericLUFactorization` (the default for small dense systems):

```
FieldError: type StaticArrays.LU has no field `factors`, available fields: `L`, `U`, `p`
  @ StaticArrays/src/lu.jl:20
init_cacheval(::GenericLUFactorization, A::SizedMatrix{9,9}, ...) @ LinearSolve/src/factorization.jl:346
```

#1038 ("Handle dense, contiguous non-`Array` matrices (e.g. FixedSizeArray)") changed `init_cacheval(::GenericLUFactorization, ...)` and `init_cacheval(::RFLUFactorization, ...)` from

```julia
return ArrayInterface.lu_instance(convert(AbstractMatrix, A)), ipiv
```

to

```julia
luinst = ArrayInterface.lu_instance(convert(AbstractMatrix, A))
return LinearAlgebra.LU(luinst.factors, ipiv, luinst.info), ipiv
```

This assumes `lu_instance` always returns a `LinearAlgebra.LU` (fields `factors`/`ipiv`/`info`). For a `SizedMatrix`, `ArrayInterface.lu_instance` returns a `StaticArrays.LU` (fields `L`/`U`/`p`), so `luinst.factors` errors.

## Fix

Guard the `LinearAlgebra.LU` rebuild: when `lu_instance` returns something that is not a `LinearAlgebra.LU` (e.g. a `StaticArrays.LU`), return it as-is — the pre-#1038 behavior, which already carried a `Vector` pivot for these containers. The `FixedSizeArray` case from #1038 (where `lu_instance` does return a `LinearAlgebra.LU` but with a container-typed pivot) still takes the rebuild path, so its fix is preserved.

```julia
luinst = ArrayInterface.lu_instance(convert(AbstractMatrix, A))
luinst isa LinearAlgebra.LU || return luinst, ipiv
return LinearAlgebra.LU(luinst.factors, ipiv, luinst.info), ipiv
```

## Verification (local, Julia 1.10 and 1.12)

- Before: `init(LinearProblem(SizedMatrix{9,9}, b))` throws `type LU has no field factors` on 3.85.2.
- After (this branch, dev'd): `init(LinearProblem(SizedMatrix, b))` succeeds; a normal `Matrix` `solve` still returns the correct result.
- Runic clean on `src/factorization.jl`.

This is the root cause of SciML/OrdinaryDiffEq.jl's `InterfaceIV` master CI failure (`sized_matrix_tests.jl`, Rodas4 on a SizedMatrix), which OrdinaryDiffEq is temporarily working around by capping LinearSolve at 3.85.1.

Please ignore until reviewed by @ChrisRackauckas
