### PR TITLE
Keep RFLUFactorization off the direct dual AD path (fixes #1052)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "3.86.0"
+version = "3.86.1"
 authors = ["SciML"]
 
 [deps]

--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -393,11 +393,15 @@ end
 # Check if the algorithm should use the direct dual solve path
 # (algorithms that can work directly with Dual numbers without the primal/partials separation)
 function _use_direct_dual_solve(alg)
+    # NOTE: RFLUFactorization is intentionally *not* on the direct path. Even when
+    # A carries duals, its fast Float64 factorization is BLAS/SIMD-grade, and routing
+    # the Dual problem through it falls back to generic scalar dual arithmetic, losing
+    # that speedup entirely (~40x slower, see issue #1052). The split path keeps the
+    # fast primal factorization and reuses it across the partial back-solves.
     return alg isa GenericLUFactorization ||
         alg isa LinearSolve.SpecializedLUFactorization ||
         alg isa LinearSolve.SpecializedQRFactorization ||
-        alg isa LinearSolve.PureKLUFactorization ||
-        alg isa LinearSolve.RFLUFactorization
+        alg isa LinearSolve.PureKLUFactorization
 end
 
 function _use_direct_dual_solve(alg::DefaultLinearSolver)

--- a/test/Core/forwarddiff_overloads.jl
+++ b/test/Core/forwarddiff_overloads.jl
@@ -67,6 +67,19 @@ prob = LinearProblem(plain_A, b)
 @test ≈(solve(prob, GenericLUFactorization()), plain_A \ b, rtol = 1.0e-9)
 @test ≈(solve(prob, RFLUFactorization()), plain_A \ b, rtol = 1.0e-9)
 
+# Regression test for #1052: RFLUFactorization must stay on the split
+# primal/partials path and NOT take the direct dual solve. Its fast Float64
+# factorization is BLAS/SIMD-grade; routing the Dual problem through it falls
+# back to generic scalar dual arithmetic (~40x slower). Guard the routing
+# decision directly so RFLU is never re-added to the direct path.
+@testset "RFLU stays off the direct dual path (#1052)" begin
+    ext = Base.get_extension(LinearSolve, :LinearSolveForwardDiffExt)
+    @test !ext._use_direct_dual_solve(RFLUFactorization())
+    # Sanity: the genuinely-cheap-in-dual algorithms are still on the direct path.
+    @test ext._use_direct_dual_solve(GenericLUFactorization())
+    @test ext._use_direct_dual_solve(SpecializedLUFactorization())
+end
+
 # Overload Dense
 
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])


### PR DESCRIPTION
Fixes #1052.

## What happened

PR #1041 added `RFLUFactorization` (and `PureKLUFactorization`) to `_use_direct_dual_solve`, taken whenever `A` carries duals. For `ForwardDiff` over an ODE solve (the issue's `Rodas5P` case), the Rosenbrock `W` matrix is the linear-solve `A` and carries duals, so every Newton solve was routed to factorize `W` **in Dual arithmetic** via RecursiveFactorization instead of the split primal/partials path.

`RFLUFactorization`'s `Float64` factorization is BLAS/SIMD-grade (cache-blocked, vectorized). Routing the Dual problem through it falls back to generic scalar dual arithmetic and loses that speedup entirely. The split path — which 3.85.1 used — factorizes the primal `W` once and reuses that factorization across the partial back-solves, and is both correct and far cheaper for `A`-carrying-duals.

## This PR

Drops only `RFLUFactorization` from `_use_direct_dual_solve`. `GenericLU`/`SpecializedLU`/`SpecializedQR` (genuinely cheap in dual arithmetic) and `PureKLUFactorization` are left on the direct path unchanged.

## Verification (local, Julia 1.10)

Reproduced the issue's benchmark on the same seeded problem, identical base commit:

| | RFLU time | RFLU alloc | derivative ‖d‖ |
|---|---|---|---|
| current `main` (regressed) | 2.87 s | 199.9 MiB | 2.96590019544838**46** |
| this PR | **0.071 s** | **15.6 MiB** | 2.96590019544838**37** |

~40× faster, ~13× less allocation, derivative identical to 1e-15.

Correctness: RFLU (split path) vs GenericLU (direct path) derivative rel diff `2.3e-15`; vs default linsolve `0.0`.

`test/Core/forwarddiff_overloads.jl` runs green end-to-end, including the existing RFLU duals-in-`A` / duals-in-`b` correctness checks and the new regression test (`RFLU stays off the direct dual path (#1052)`), which asserts `_use_direct_dual_solve(RFLUFactorization()) == false`.

`Runic --check` clean on the changed files.

## Note on PureKLU

I measured `PureKLUFactorization` on the direct path too: the penalty is small (~10–25%, no BLAS-grade fast path to lose), so it is intentionally left unchanged here to keep the PR surgical.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)