### PR TITLE
Release v3.86.2: ship SizedMatrix init_cacheval fix + regression test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "3.86.1"
+version = "3.86.2"
 authors = ["SciML"]
 
 [deps]

--- a/test/Core/sized_matrix.jl
+++ b/test/Core/sized_matrix.jl
@@ -1,0 +1,27 @@
+using LinearSolve, StaticArrays, RecursiveFactorization, LinearAlgebra, Test
+
+# A `SizedMatrix` (StaticArrays) is an in-place, dense matrix whose
+# `ArrayInterface.lu_instance` returns a `StaticArrays.LU` (fields `L`/`U`/`p`),
+# not a `LinearAlgebra.LU`. `init_cacheval` for `GenericLUFactorization` /
+# `RFLUFactorization` must not assume `lu_instance` yields a `LinearAlgebra.LU`
+# and reach for its `factors`/`info` fields. Regression for
+# SciML/LinearSolve.jl#1056: `init` used to throw
+# `type StaticArrays.LU has no field factors`, which broke the downstream
+# OrdinaryDiffEq "Sized Matrix Tests" (`Rodas4` over a `SizedMatrix` state, whose
+# default solver initializes the `GenericLU`/`RFLU` cachevals).
+
+A = SizedMatrix{9, 9}(rand(9, 9) + 9I)
+b = SizedVector{9}(rand(9))
+
+# `init` is where `init_cacheval` runs; this is the call that used to throw.
+@testset "init does not assume LinearAlgebra.LU for $(typeof(alg))" for alg in (
+        LinearSolve.GenericLUFactorization(), LinearSolve.RFLUFactorization(),
+    )
+    @test init(LinearProblem(A, b), alg) isa LinearSolve.LinearCache
+end
+
+@testset "default init/solve LinearProblem(SizedMatrix)" begin
+    cache = init(LinearProblem(A, b))
+    sol = solve!(cache)
+    @test sol.retcode == ReturnCode.Success
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,7 @@ else
             @time @safetestset "Nonstructural Zeros" include("Core/nonstructural_zeros.jl")
             @time @safetestset "Default Alg Tests" include("Core/default_algs.jl")
             @time @safetestset "FixedSizeArrays" include("Core/fixedsizearrays.jl")
+            @time @safetestset "SizedMatrix" include("Core/sized_matrix.jl")
             @time @safetestset "Adjoint Sensitivity" include("Core/adjoint.jl")
             @time @safetestset "ForwardDiff Overloads" include("Core/forwarddiff_overloads.jl")
             @time @safetestset "Traits" include("Core/traits.jl")


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What this fixes

OrdinaryDiffEq.jl master CI is failing in the `InterfaceIV` group (`sized_matrix_tests.jl`), e.g. [this run](https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/28243908502/job/83677725573):

```
FieldError: type StaticArrays.LU has no field `factors`, available fields: `L`, `U`, `p`
  @ LinearSolve src/factorization.jl  (init_cacheval, GenericLUFactorization)
```

### Root cause

PR #1038 changed `init_cacheval(::GenericLUFactorization)` and `init_cacheval(::RFLUFactorization)` to rebuild the cacheval via `LinearAlgebra.LU(luinst.factors, ipiv, luinst.info)` so the pivot slot type matches for non-`Array` dense containers (e.g. `FixedSizeArray`). But `ArrayInterface.lu_instance` returns a `StaticArrays.LU` (fields `L`/`U`/`p`, no `factors`/`info`) for a `SizedMatrix`, so the rebuild threw. `Rodas4` over a `SizedMatrix` state routes through the default solver, which initializes the `GenericLU`/`RFLU` cachevals — hence the downstream failure.

### Why it's still broken downstream

The **code fix already landed on `main`** (#1056, #1053: guard the rebuild with `luinst isa LinearAlgebra.LU || return luinst, ipiv`). The problem is purely a release one: `Project.toml` still read `version = "3.86.1"`, **identical to the latest registered release**, so no new version was ever cut. OrdinaryDiffEq CI keeps resolving the buggy registered v3.86.1.

## Changes

- Bump `3.86.1` → `3.86.2` so the already-merged fix actually ships.
- Add `test/Core/sized_matrix.jl` (and register it in `runtests.jl`) covering the `init_cacheval` path that threw: `init` of a `LinearProblem{SizedMatrix}` with the default solver and with explicit `GenericLUFactorization`/`RFLUFactorization`. There was no regression test for this in LinearSolve's own suite — only the downstream OrdinaryDiffEq test caught it.

## Verification (run locally, Julia 1.12)

- Reproduced the exact CI `FieldError` with registered **v3.86.1** via the OrdinaryDiffEq `sized_matrix_tests` problem (`Rodas4` over a `SizedMatrix`).
- The same problem returns `retcode=Success` with **`main`** dev'd in.
- New `test/Core/sized_matrix.jl` **errors on v3.86.1** with the exact `type StaticArrays.LU has no field factors` and **passes on `main`**.
- Ran Runic on the new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)