### PR TITLE
Keep PureKLUFactorization off the direct dual AD path (fixes #1064)

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -393,15 +393,21 @@ end
 # Check if the algorithm should use the direct dual solve path
 # (algorithms that can work directly with Dual numbers without the primal/partials separation)
 function _use_direct_dual_solve(alg)
-    # NOTE: RFLUFactorization is intentionally *not* on the direct path. Even when
-    # A carries duals, its fast Float64 factorization is BLAS/SIMD-grade, and routing
-    # the Dual problem through it falls back to generic scalar dual arithmetic, losing
-    # that speedup entirely (~40x slower, see issue #1052). The split path keeps the
-    # fast primal factorization and reuses it across the partial back-solves.
+    # NOTE: RFLUFactorization and PureKLUFactorization are intentionally *not* on the
+    # direct path. The split path factorizes the *primal* A once (in fast Float64
+    # arithmetic) and reuses that factorization across the partial back-solves, instead
+    # of re-running the whole numeric factorization in (2N+1)-wide scalar dual
+    # arithmetic. For RFLU this is decisive because its Float64 factorization is
+    # BLAS/SIMD-grade (~40x slower on the direct path, see #1052). For PureKLU it wins
+    # whenever the factorization carries non-trivial fill (general sparse Jacobians,
+    # PDE stencils) and for the small-chunk AD-through-implicit-ODE workload these are
+    # actually used in — see #1064, where the direct path was ~2.4x slower with ~35x
+    # the allocation through a Rosenbrock solve, matching the trusted C-KLU split path
+    # once routed here. (For a single solve of a very-low-fill matrix with a large dual
+    # chunk the direct path can edge ahead, but that is not the regime PureKLU+AD hits.)
     return alg isa GenericLUFactorization ||
         alg isa LinearSolve.SpecializedLUFactorization ||
-        alg isa LinearSolve.SpecializedQRFactorization ||
-        alg isa LinearSolve.PureKLUFactorization
+        alg isa LinearSolve.SpecializedQRFactorization
 end
 
 function _use_direct_dual_solve(alg::DefaultLinearSolver)

--- a/test/Core/forwarddiff_overloads.jl
+++ b/test/Core/forwarddiff_overloads.jl
@@ -280,6 +280,16 @@ plain_A = ForwardDiff.value.(A)
 prob = LinearProblem(sparse(plain_A), b)
 @test ≈(solve(prob, PureKLUFactorization()), plain_A \ b, rtol = 1.0e-9)
 
+# Regression test for #1064: PureKLUFactorization must stay on the split
+# primal/partials path and NOT take the direct dual solve. Like RFLU (#1052),
+# its fast Float64 (KLU) factorization is far cheaper than factorizing the Dual
+# problem in generic scalar dual arithmetic; the direct path was much slower with
+# ~14x more allocation through an implicit ODE solve. Guard the routing decision.
+@testset "PureKLU stays off the direct dual path (#1064)" begin
+    ext = Base.get_extension(LinearSolve, :LinearSolveForwardDiffExt)
+    @test !ext._use_direct_dual_solve(PureKLUFactorization())
+end
+
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 
 prob = LinearProblem(sparse(A), sparse(b))


### PR DESCRIPTION
Fixes #1064.

## Problem

PR #1041 added `PureKLUFactorization` to the direct dual solve path (`_use_direct_dual_solve`), taken whenever `A` carries duals. For ForwardDiff over an implicit ODE solve (e.g. `Rodas5P`), the Rosenbrock `W` matrix carries duals, so every solve factorized `W` in dual arithmetic via PureKLU's pure-Julia KLU.

This is the **same** problem #1052/#1057 fixed for `RFLUFactorization`, which was opted out at the same time. PureKLU was explicitly left on the direct path ("PureKLU are unaffected"), but #1064 shows it is affected identically.

## Fix

Drop `PureKLUFactorization` from `_use_direct_dual_solve` so it stays on the split primal/partials path, which factorizes the primal `W` once in fast `Float64` arithmetic and reuses that factorization across the partial back-solves — instead of re-running the whole numeric factorization in `(2N+1)`-wide scalar dual arithmetic. Adds a regression test asserting PureKLU is not routed to the direct path (mirrors the #1052 RFLU test).

## Local verification (Julia 1.12, Linux)

Exact issue reproducer (tridiagonal heat equation, `N=20`, `Rodas5P`, single derivative):

| | time | alloc |
|---|---|---|
| PureKLU **direct** (before) | 3.79 ms | 7.93 MiB |
| PureKLU **split** (this PR) | 1.56 ms | 227 KiB |
| C-backed `KLUFactorization` (always split) | 1.49 ms | 222 KiB |

Identical derivatives; the split path matches the trusted C-KLU path. `test/Core/forwarddiff_overloads.jl` passes end-to-end (including the existing PureKLU correctness tests for duals in A / in b / both, and the new #1064 regression test). `Runic --check` clean.

## Scope note (the tradeoff is real, not universal)

The split path is the better **default** for the sparse-Jacobian / AD-through-implicit-ODE workload PureKLU+ForwardDiff is actually used in. I swept direct-vs-split across sparsity patterns and dual chunk sizes:

- **High fill** (general sparse / PDE stencils / random sparse): split wins, by a margin that *grows* with fill and chunk size (e.g. `rand-1%`, `n=500`, `chunk=8`: 27.9 ms → 7.7 ms).
- **Very low fill** (tridiagonal / narrow band) with a **large** dual chunk: the direct path can edge ahead in a single shot (~2×), because the factorization is so cheap the split path's per-solve overhead dominates. This is not the regime PureKLU+AD hits.

There is also a **separate latent inefficiency** I found while digging: `_solve_direct_dual!` calls `__init` on a fresh cache every `solve!`, re-doing KLU symbolic analysis and re-allocating the whole cache each time — that is the real source of the 7.93 MiB in the issue. Fixing that is out of scope here; I'll file it separately.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
