### PR TITLE
Fix PureKLU Dual-A dispatch stolen by DualBLinearProblem opt-out

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -299,6 +299,14 @@ function SciMLBase.init(prob::DualBLinearProblem, alg::PureKLUFactorization, arg
     return __init(prob, alg, args...; kwargs...)
 end
 
+# DualBLinearProblem's A slot is `Union{Number, AbstractArray}`, which a Dual-eltype A
+# also matches, so the b-only opt-out above would otherwise capture both-Dual problems
+# (`DualLinearProblem <: DualBLinearProblem`). Restore the direct dual path for them: a
+# Dual A needs the DualLinearCache machinery, the mixed-type ldiv! only covers primal A.
+function SciMLBase.init(prob::DualLinearProblem, alg::PureKLUFactorization, args...; kwargs...)
+    return __dual_init(prob, alg, args...; kwargs...)
+end
+
 # NOTE: Removed the runtime conditional for DefaultLinearSolver that checked for
 # GenericLUFactorization. Now always use __dual_init for type stability.
 function SciMLBase.init(prob::DualAbstractLinearProblem, alg::DefaultLinearSolver, args...; kwargs...)


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft; opened by an agent.

Fixes a test failure present on unmodified `main` (found while testing #1072, verified pre-existing by reverting and rerunning): `test/Core/forwarddiff_overloads.jl` "PureKLU direct dual path reuses inner LinearCache" errors.

**Bisected to aabf007 (#1069, 2026-06-30):** `DualBLinearProblem`'s `A` slot is `Union{Number, AbstractArray}`, so Dual-A problems also match it, and the b-only PureKLU opt-out steals the both-Dual dispatch, returning a plain `LinearCache` instead of routing through `__dual_init`.

Fix restores the `DualLinearProblem → __dual_init` route for PureKLU. Verified: 119/119 in `forwarddiff_overloads.jl` on Julia 1.12.4 and 1.10.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)