### PR TITLE
Document public API coverage

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,14 +2,17 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 LinearSolveAutotune = "67398393-80e8-4254-b7e4-1b9a36a3c5b6"
+LinearSolvePyAMG = "7a56c47d-7ab1-4e99-b0e3-2952e463d64a"
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
 
 [compat]
 Documenter = "1"
 LinearSolve = "4"
 LinearSolveAutotune = "1.1"
+LinearSolvePyAMG = "1"
 SciMLOperators = "1"
 
 [sources]
 LinearSolve = {path = ".."}
 LinearSolveAutotune = {path = "../lib/LinearSolveAutotune"}
+LinearSolvePyAMG = {path = "../lib/LinearSolvePyAMG"}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,10 @@
 using LinearSolve
+using LinearSolveAutotune
+using LinearSolvePyAMG
+using SparseArrays
 using Documenter
+
+const LinearSolveSparseArraysExt = Base.get_extension(LinearSolve, :LinearSolveSparseArraysExt)
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
 cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
@@ -11,7 +16,13 @@ include("pages.jl")
 makedocs(
     sitename = "LinearSolve.jl",
     authors = "Chris Rackauckas",
-    modules = [LinearSolve, LinearSolve.SciMLBase],
+    modules = [
+        LinearSolve,
+        LinearSolve.SciMLBase,
+        LinearSolveAutotune,
+        LinearSolvePyAMG,
+        LinearSolveSparseArraysExt.KLU,
+    ],
     clean = true, doctest = false, linkcheck = true,
     warnonly = [:docs_block, :missing_docs],
     linkcheck_ignore = [

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -149,6 +149,8 @@ LinearSolve.DefaultLinearSolver
 
 ```@docs
 RFLUFactorization
+ButterflyFactorization
+RF32MixedLUFactorization
 ```
 
 ### SpecializingFactorizations.jl
@@ -171,12 +173,14 @@ customized per-package, details given below describe a subset of important array
 
 ```@docs
 LUFactorization
+GenericFactorization
 GenericLUFactorization
 QRFactorization
 SVDFactorization
 CholeskyFactorization
 BunchKaufmanFactorization
 CHOLMODFactorization
+LDLtFactorization
 NormalCholeskyFactorization
 NormalBunchKaufmanFactorization
 ```
@@ -191,6 +195,7 @@ DiagonalFactorization
 SimpleGMRES
 DirectLdiv!
 LinearSolveFunction
+LinearSolveAdjoint
 ```
 
 ### FastLapackInterface.jl
@@ -220,7 +225,10 @@ FastQRFactorization
 
 ```@docs
 KLUFactorization
+LinearSolveSparseArraysExt.KLU.klu
+LinearSolveSparseArraysExt.KLU.klu!
 PureKLUFactorization
+PureUMFPACKFactorization
 UMFPACKFactorization
 SparseColumnPivotedQRFactorization
 ```
@@ -276,6 +284,29 @@ ParUFactorization
 MUMPSFactorization
 ```
 
+### SuperLUDIST.jl
+
+!!! note
+
+    Using this solver requires loading `SuperLUDIST.jl`, `SparseArrays`, and `MPI`,
+    and calling `MPI.Init()` before constructing the solver.
+
+```@docs
+SuperLUDISTFactorization
+```
+
+### HSL.jl
+
+!!! note
+
+    Using these solvers requires loading `HSL.jl` and `SparseArrays`.
+    `HSL.jl` requires a manual installation of `HSL_jll.jl`.
+
+```@docs
+HSLMA57Factorization
+HSLMA97Factorization
+```
+
 ### Sparspak.jl
 
 !!! note
@@ -324,9 +355,11 @@ CliqueTreesFactorization
 KrylovJL_CG
 KrylovJL_MINRES
 KrylovJL_GMRES
+KrylovJL_FGMRES
 KrylovJL_BICGSTAB
 KrylovJL_LSMR
 KrylovJL_CRAIGMR
+KrylovJL_MINARES
 KrylovJL
 ```
 
@@ -341,6 +374,7 @@ MKL32MixedLUFactorization
 
 ```@docs
 OpenBLASLUFactorization
+OpenBLAS32MixedLUFactorization
 ```
 
 ### AppleAccelerate.jl
@@ -374,6 +408,8 @@ MetalOffload32MixedLUFactorization
 ```@docs
 MKLPardisoFactorize
 MKLPardisoIterate
+PanuaPardisoFactorize
+PanuaPardisoIterate
 LinearSolve.PardisoJL
 ```
 
@@ -387,6 +423,7 @@ The following are non-standard GPU factorization routines.
     Using these solvers requires adding the package CUDA.jl, i.e. `using CUDA`
 
 ```@docs
+CudaOffloadFactorization
 CudaOffloadLUFactorization
 CudaOffloadQRFactorization
 CUDAOffload32MixedLUFactorization
@@ -413,6 +450,17 @@ AMDGPUOffloadQRFactorization
 
 ```@docs
 CUSOLVERRFFactorization
+```
+
+### AlgebraicMultigrid.jl
+
+!!! note
+
+    Using this solver requires adding the package AlgebraicMultigrid.jl, i.e.
+    `using AlgebraicMultigrid`
+
+```@docs
+AlgebraicMultigridJL
 ```
 
 ### IterativeSolvers.jl
@@ -528,6 +576,17 @@ PartitionedSolversAlgorithm
 GinkgoJL
 GinkgoJL_CG
 GinkgoJL_GMRES
+```
+
+### Elemental.jl
+
+!!! note
+
+    Using this solver requires adding the package Elemental.jl, i.e.
+    `using Elemental`
+
+```@docs
+ElementalJL
 ```
 
 ### PETSc.jl
@@ -904,3 +963,9 @@ solver. `method` can be `:RugeStuben` (default) or `:SmoothedAggregation`. The o
 `accel` keyword (`"cg"`, `"gmres"`, `"bicgstab"`, …) wraps the AMG cycle in a Krylov
 solver. Convenience constructors `PyAMG_RugeStuben` and `PyAMG_SmoothedAggregation`
 are also provided.
+
+```@docs
+LinearSolvePyAMG.PyAMG
+LinearSolvePyAMG.PyAMG_RugeStuben
+LinearSolvePyAMG.PyAMG_SmoothedAggregation
+```

--- a/docs/src/tutorials/autotune.md
+++ b/docs/src/tutorials/autotune.md
@@ -25,6 +25,15 @@ plot(results)
 share_results(results)
 ```
 
+## API
+
+```@docs
+LinearSolveAutotune.AutotuneResults
+LinearSolveAutotune.autotune_setup
+LinearSolveAutotune.share_results
+LinearSolveAutotune.plot(::LinearSolveAutotune.AutotuneResults)
+```
+
 This will:
 - Benchmark algorithms for `Float64` matrices by default
 - Test matrix sizes from tiny (5×5) through large (1000×1000) 

--- a/lib/LinearSolveAutotune/src/LinearSolveAutotune.jl
+++ b/lib/LinearSolveAutotune/src/LinearSolveAutotune.jl
@@ -54,7 +54,18 @@ include("plotting.jl")
 include("telemetry.jl")
 include("preferences.jl")
 
-# Define the AutotuneResults struct
+"""
+    AutotuneResults
+
+Benchmark results returned by [`autotune_setup`](@ref).
+
+## Fields
+
+  - `results_df`: table of benchmark measurements, tested algorithms, element
+    types, matrix sizes, success flags, and any recorded errors.
+  - `sysinfo`: dictionary of system information collected with the benchmark,
+    including Julia, operating system, CPU, GPU, and BLAS details when available.
+"""
 struct AutotuneResults
     results_df::DataFrame
     sysinfo::Dict
@@ -139,7 +150,14 @@ function Base.show(io::IO, results::AutotuneResults)
     return println(io, "="^60)
 end
 
-# Plot method for AutotuneResults
+"""
+    plot(results::AutotuneResults; kwargs...)
+
+Create performance plots from the benchmark data in `results`.
+
+Keyword arguments are forwarded to the underlying Plots.jl layout call used to
+assemble the per-element-type plots.
+"""
 function Plots.plot(results::AutotuneResults; kwargs...)
     # Generate plots from the results data
     plots_dict = create_benchmark_plots(results.results_df)

--- a/src/KLU/klu.jl
+++ b/src/KLU/klu.jl
@@ -599,7 +599,7 @@ The relation between `K` and `A` is
 !!! note
 
     `klu(A::SparseMatrixCSC)` uses the KLU[^ACM907] library that is part of
-    SuiteSparse. As this library only supports sparse matrices with [`Float64`](@ref) or
+    SuiteSparse. As this library only supports sparse matrices with `Float64` or
     `ComplexF64` elements, `lu` converts `A` into a copy that is of type
     `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
 
@@ -660,7 +660,7 @@ See also: [`klu`](@ref)
 !!! note
 
     `klu(A::SparseMatrixCSC)` uses the KLU[^ACM907] library that is part of
-    SuiteSparse. As this library only supports sparse matrices with [`Float64`](@ref) or
+    SuiteSparse. As this library only supports sparse matrices with `Float64` or
     `ComplexF64` elements, `lu` converts `A` into a copy that is of type
     `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
 

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -659,6 +659,15 @@ end
 
 ## LDLtFactorization
 
+"""
+    LDLtFactorization(shift = 0.0, perm = nothing)
+
+Julia's built-in LDLᵀ factorization. Dense inputs use `ldlt!`; sparse inputs
+use `ldlt!` with the supplied `shift` and `perm` keyword values.
+
+This method is intended for Hermitian or symmetric linear systems where an LDLᵀ
+factorization is appropriate.
+"""
 struct LDLtFactorization{T} <: AbstractDenseFactorization
     shift::Float64
     perm::T


### PR DESCRIPTION
## Summary

ignore until reviewed by @ChrisRackauckas

- adds rendered docs entries for exported LinearSolve algorithms, KLU extension exports, LinearSolveAutotune exports, and LinearSolvePyAMG exports
- adds missing source-site docstrings for `LDLtFactorization`, `AutotuneResults`, and the Autotune `plot(::AutotuneResults)` method
- fixes invalid KLU docstring `Float64` references that broke Documenter cross-reference resolution once `klu`/`klu!` were rendered

## Validation

- `~/.juliaup/bin/julia +1.10 -e 'import Runic; Runic.main(ARGS)' -- -c docs/make.jl src/factorization.jl src/KLU/klu.jl lib/LinearSolveAutotune/src/LinearSolveAutotune.jl`\n- inline public API audit for LinearSolve, LinearSolveSparseArraysExt.KLU, LinearSolveAutotune, and LinearSolvePyAMG: no missing source docstrings or docs entries\n- `timeout 3600 ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; ENV["GROUP"]="Core"; Pkg.test(; test_args=["Core"], julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"])'`\n- `timeout 3600 ~/.juliaup/bin/julia +1.10 --project=docs -e 'using Pkg; Pkg.develop(path="."); Pkg.develop(path="lib/LinearSolveAutotune"); Pkg.develop(path="lib/LinearSolvePyAMG"); Pkg.instantiate(); include("docs/make.jl")'`\n\nNote: the docs build emits existing warnings for duplicate/pre-existing missing docs and a non-fatal Metal-on-Linux dependency warning, but completed successfully with the local branch developed into the docs environment.