### PR TITLE
Bump version to 4.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "4.2.0"
+version = "4.2.1"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (4.2.0 -> 4.2.1) to release unreleased commits on `main` via JuliaRegistrator.