### PR TITLE
Qualify issuccess as LinearAlgebra.issuccess to fix QA ExplicitImports failure

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -571,7 +571,7 @@ function SciMLBase.solve!(cache::LinearCache, alg::GESVFactorization; kwargs...)
         # so a singular denominator is reported through the return code.
         luf = lu!(Atarget; check = false)
         cache.cacheval = luf
-        if !issuccess(luf)
+        if !LinearAlgebra.issuccess(luf)
             @SciMLMessage("Solver failed", cache.verbose, :solver_failure)
             return SciMLBase.build_linear_solution(
                 alg, cache.u, nothing, cache; retcode = ReturnCode.Failure


### PR DESCRIPTION
**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

## Problem

The QA test group (`GROUP=QA`) fails on `main` in ExplicitImports' `no_implicit_imports` check:

```
no_implicit_imports: Error During Test at .../SciMLTesting/y2DHi/src/SciMLTesting.jl:816
  Test threw exception
  Expression: check(pkg; get(ei_kwargs, name, (;))...) === nothing
  ImplicitImportsException
  Module `LinearSolve` is relying on the following implicit imports:
  * `issuccess` which is exported by `LinearAlgebra`

Test Summary:                                  | Pass  Error  Broken  Total   Time
Quality Assurance                              |   14      1       2     17  45.4s
...
    ExplicitImports                            |    4      1       1      6  18.2s
      no_implicit_imports                      |           1              1   4.5s
ERROR: Package LinearSolve errored during testing
```

## Cause

Commit c75997b6 (#1078, GESVFactorization + dense LU pivot-buffer reuse) added an unqualified `if !issuccess(luf)` in `SciMLBase.solve!(cache::LinearCache, alg::GESVFactorization)` in `src/factorization.jl`. `issuccess` is not explicitly imported, so ExplicitImports flags it as an implicit import from LinearAlgebra.

## Fix

One-line change: qualify the call as `LinearAlgebra.issuccess(luf)`, matching the existing qualified use earlier in the same file.

## Verification

`GROUP=QA` run with this fix, Julia 1.12 (the 2 broken entries are pre-existing):

```
Test Summary:     | Pass  Broken  Total   Time
Quality Assurance |   15       2     17  41.1s
Test Summary: | Pass  Broken  Total   Time
JET Tests     |   27       8     35  45.4s
     Testing LinearSolve tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)