### PR TITLE
Re-enable Enzyme AD tests on Julia 1.12+

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,8 +109,8 @@ else
             # activation as well as the test body). GPU, Pardiso, and HSL have no such
             # guard in the old dispatch, so they activate unconditionally via `env =`.
 
-            # Don't run Enzyme tests on prerelease or Julia >= 1.12 (Enzyme
-            # compatibility issues). See:
+            # Don't run the AD group on prerelease Julia (some AD backends lag
+            # behind Julia prereleases). See:
             # https://github.com/SciML/LinearSolve.jl/issues/817
             "AD" => function ()
                 if isempty(VERSION.prerelease)
@@ -118,10 +118,7 @@ else
                     @time @safetestset "Mooncake Derivative Rules" include("AD/mooncake.jl")
                     @time @safetestset "Static Arrays" include("AD/static_arrays.jl")
                     @time @safetestset "Caching Allocation Tests" include("AD/caching_allocation_tests.jl")
-                    # Disable Enzyme tests on Julia >= 1.12 due to compatibility issues
-                    if VERSION < v"1.12.0-"
-                        @time @safetestset "Enzyme Derivative Rules" include("AD/enzyme.jl")
-                    end
+                    @time @safetestset "Enzyme Derivative Rules" include("AD/enzyme.jl")
                 end
                 return nothing
             end,


### PR DESCRIPTION
## Summary

Fixes #1087 (and closes #817). Enzyme.jl now supports Julia 1.12, so the version guard that skipped the Enzyme derivative-rule tests on Julia >= 1.12 is removed. The AD group still skips on prerelease Julia versions (some AD backends lag behind Julia prereleases).

## Change

`test/runtests.jl`: removed the `if VERSION < v"1.12.0-"` guard around `@safetestset "Enzyme Derivative Rules" include("AD/enzyme.jl")`, and updated the surrounding comment.

## Verification

Ran the full `test/AD/enzyme.jl` suite locally on **Julia 1.12.6** with **Enzyme 0.13**. All assertions pass:

```
Symmetric BunchKaufman reverse |    1      1
Hermitian reverse              |    2      2
UpperTriangular reverse        |    2      2
LowerTriangular reverse        |    2      2
UnitUpperTriangular reverse    |    2      2
UnitLowerTriangular reverse    |    2      2
Diagonal reverse               |    2      2
Bidiagonal reverse             |    2      2
Tridiagonal reverse            |    2      2
SymTridiagonal reverse         |    2      2
alg = LUFactorization  (fwd)   |    2      2
alg = RFLUFactorization (fwd)  |    2      2
```
plus the top-level bare `@test` reverse/batch/caching checks (script exits 0 with no failures).

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)