### PR TITLE
Skip KrylovPreconditioners in downgrade promotion

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -17,4 +17,6 @@ jobs:
     with:
       julia-version: "lts"
       group: "Core"
+      # Resolver.jl cannot minimum-resolve KrylovPreconditioners' historical Arpack/LightGraphs graph.
+      no_promote: "Mooncake,KrylovPreconditioners"
     secrets: "inherit"


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Keep `KrylovPreconditioners` out of the joint minimum-version promotion in the downgrade workflow, alongside the existing fleet-wide `Mooncake` exception.

## Root cause and impact

Resolver.jl cannot minimum-resolve KrylovPreconditioners' historical Arpack/LightGraphs dependency graph. This is a resolver limitation in an old transitive graph, not a LinearSolve runtime incompatibility. The package remains installed at a compatible version for tests; all other promoted dependencies continue to be floor-tested.

## Local validation

- Ran the exact Julia 1.10 downgrade resolver with `no_promote=Mooncake,KrylovPreconditioners`.
- Ran the locked `LINEARSOLVE_TEST_GROUP=Core` suite and observed exit code 0 with `LinearSolve tests passed`.
- Ran `julia -m Runic --check --diff --verbose .`: all 142 Julia files passed.
- Ran `actionlint .github/workflows/Downgrade.yml` and `git diff --check`: both passed.

## Process

Reproduced the resolver failure at the current default-branch SHA, isolated it from the runtime tests, applied the narrow workflow input exception, and reran the full root Core downgrade suite.