### PR TITLE
Enforce downstream test failures

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -23,7 +23,4 @@ jobs:
       repo: "${{ matrix.package.repo }}"
       group: "${{ matrix.package.group }}"
       julia-version: "lts"
-      # Allow downstream failures that are not caused by LinearSolve.jl
-      # See: https://github.com/SciML/LinearSolve.jl/issues/880
-      continue-on-error: true
     secrets: "inherit"


### PR DESCRIPTION
## Summary

- remove job-level `continue-on-error` from the downstream integration matrix
- preserve every existing target and group while making their resolver/test outcomes visible

The previous setting made the entire downstream job non-blocking, including failures caused by LinearSolve changes, so a green workflow could not confirm integration coverage.

## Local verification

- workflow-shaped Julia 1.10 run for `NonlinearSolve/Core` with LinearSolve developed — the suite ran substantively (94 pass, 19 already-marked broken) and exited 1 on the two already-triaged failures covered by NonlinearSolve#1057 and NonlinearSolve#1056
- `actionlint` — passed
- `julia +1.12 -m Runic --check .` — passed
- `git diff --check` — passed

This PR intentionally exposes those legitimate downstream failures instead of suppressing them.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.