### PR TITLE
Keep failed static linear solutions cache-free

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -775,7 +775,7 @@ function SciMLBase.solve(
             # with the (zero-)initialized `u` instead of throwing.
             u = prob.u0 !== nothing ? prob.u0 : __init_u0_from_Ab(prob.A, prob.b)
             return SciMLBase.build_linear_solution(
-                alg, u, nothing, prob; retcode = ReturnCode.Failure
+                alg, u, nothing, nothing; retcode = ReturnCode.Failure
             )
         end
         u = F \ prob.b
@@ -790,7 +790,7 @@ function SciMLBase.solve(
         if !gesv_ok
             u = prob.u0 !== nothing ? prob.u0 : __init_u0_from_Ab(prob.A, prob.b)
             return SciMLBase.build_linear_solution(
-                alg, u, nothing, prob; retcode = ReturnCode.Failure
+                alg, u, nothing, nothing; retcode = ReturnCode.Failure
             )
         end
     elseif alg isa QRFactorization

--- a/test/Core/lightweight_solution.jl
+++ b/test/Core/lightweight_solution.jl
@@ -1,4 +1,4 @@
-using LinearSolve, LinearAlgebra, SparseArrays, StableRNGs, Test
+using LinearSolve, LinearAlgebra, SparseArrays, StableRNGs, StaticArrays, Test
 
 # LinearSolve 5.0: `solve!`/`solve` return a lightweight `LinearSolution` that
 # no longer carries the `LinearCache` (`sol.cache === nothing`). Anyone who
@@ -49,6 +49,14 @@ rng = StableRNG(7)
     # also returns a cache-free solution
     sol = solve!(init(LinearProblem(copy(Asing), copy(b)), nothing; verbose = false))
     @test sol.cache === nothing
+
+    Astatic = @SMatrix [1.0 1.0; 1.0 1.0]
+    bstatic = @SVector [1.0, 1.0]
+    for alg in (LUFactorization(), GESVFactorization())
+        sol = solve(LinearProblem(Astatic, bstatic), alg)
+        @test sol.retcode == ReturnCode.Failure
+        @test sol.cache === nothing
+    end
 end
 
 @testset "warm aliased refactorize+solve loop is allocation-free" begin


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- pass `nothing` as the solution cache when static LU/GESV factorization reports failure
- cover singular `SMatrix` LU and GESV solves with a lightweight-solution regression

The successful static paths already return cache-free `LinearSolution` objects. The failure paths instead passed the problem as the cache, which violates the LinearSolve 5 lightweight-solution invariant and makes otherwise successful static solves infer a union of `cache::Nothing` and `cache::LinearProblem`.

## Root cause

An automated `git bisect` from `a9b13cfa` through clean main `0496f135` identified `459445950ef413fe96ed78d0b1507aca7abe591c` (LinearSolve 5.0 lightweight solutions) as the first bad commit.

Explicit adjacent validation on Julia 1.10.11 confirmed:

- parent `a9b13cfa`: the reduced static LU `@inferred solve(...)` passes and returns a successful solution with `cache::LinearProblem`
- child `45944595`: the same call fails inference because the successful return has `cache::Nothing` while the singular-failure branch still has `cache::LinearProblem`

Making both static LU and GESV failure returns cache-free restores one concrete return type and completes the intended LinearSolve 5 behavior.

## Local verification

On commit `a10fe1283009e27d7499ce4d3239bfcaf3046b33`:

- Julia 1.10.11, `GROUP=AD`: Mooncake 41/41; Static Arrays 23 pass + 1 pre-existing broken; Caching 49 pass + 23 pre-existing broken; Enzyme 47/47; `Pkg.test()` exited 0
- Julia 1.12.6, `GROUP=AD`: the same counts passed; `Pkg.test()` exited 0
- reduced static LU `@inferred` reproducer: passed on Julia 1.10.11 and 1.12.6 with `sol.cache === nothing`
- Julia 1.12, `GROUP=Core`: exited 0; the modified Lightweight Solution testset passed 43/43, and all remaining Core testsets passed with only their pre-existing broken tests
- Runic 1.7.0, repository-wide `--check .`: exited 0
- `git diff --check`: exited 0
- generated manifests and the test-environment source rewrite were removed; the worktree is clean

## CI

The PR's AD jobs pass on Julia LTS and current, and Core passes on Julia LTS, current, and pre-release. The remaining red checks are unrelated baseline/external failures (including the PyAMG documentation link returning HTTP 429, the clean-main KLU JET failure tracked in #1095, and the Trim environment compatibility failure tracked in #1093).