### PR TITLE
Drop KrylovPreconditioners from Core tests

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -17,6 +17,4 @@ jobs:
     with:
       julia-version: "lts"
       group: "Core"
-      # Resolver.jl cannot minimum-resolve KrylovPreconditioners' historical Arpack/LightGraphs graph.
-      no_promote: "Mooncake,KrylovPreconditioners"
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -151,7 +151,6 @@ JacobiDavidson = "0.1"
 KernelAbstractions = "0.9.30"
 Krylov = "0.10"
 KrylovKit = "0.10"
-KrylovPreconditioners = "0.3"
 LAPACK_jll = "3"
 Libdl = "1.10"
 LinearAlgebra = "1.10"
@@ -214,7 +213,6 @@ InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 JacobiDavidson = "11c68b98-9c9b-11e8-267b-bbb95576cead"
 KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
-KrylovPreconditioners = "45d422c2-293f-44ce-8315-2cb988662dec"
 MultiFloats = "bdf0d083-296b-4888-a5b6-7498122e68a5"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PureUMFPACK = "b7e1f0a2-3c4d-4e5f-9a0b-1c2d3e4f5a6b"
@@ -232,4 +230,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["AlgebraicMultigrid", "Arpack", "ArnoldiMethod", "BandedMatrices", "BlockDiagonals", "CliqueTrees", "ComponentArrays", "FastAlmostBandedMatrices", "FastLapackInterface", "FiniteDiff", "FixedSizeArrays", "ForwardDiff", "InteractiveUtils", "IterativeSolvers", "JacobiDavidson", "KrylovKit", "KrylovPreconditioners", "MultiFloats", "Pkg", "PureUMFPACK", "Random", "RecursiveFactorization", "STRUMPACK_jll", "SafeTestsets", "SciMLTesting", "SparseArrays", "Sparspak", "SpecializingFactorizations", "StableRNGs", "StaticArrays", "Test", "Zygote"]
+test = ["AlgebraicMultigrid", "Arpack", "ArnoldiMethod", "BandedMatrices", "BlockDiagonals", "CliqueTrees", "ComponentArrays", "FastAlmostBandedMatrices", "FastLapackInterface", "FiniteDiff", "FixedSizeArrays", "ForwardDiff", "InteractiveUtils", "IterativeSolvers", "JacobiDavidson", "KrylovKit", "MultiFloats", "Pkg", "PureUMFPACK", "Random", "RecursiveFactorization", "STRUMPACK_jll", "SafeTestsets", "SciMLTesting", "SparseArrays", "Sparspak", "SpecializingFactorizations", "StableRNGs", "StaticArrays", "Test", "Zygote"]

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -1,7 +1,7 @@
 using LinearSolve, LinearAlgebra, SparseArrays, MultiFloats, ForwardDiff
 using SciMLOperators: SciMLOperators, MatrixOperator, FunctionOperator, WOperator
 using RecursiveFactorization, Sparspak, FastLapackInterface
-using IterativeSolvers, KrylovKit, MKL_jll, KrylovPreconditioners
+using IterativeSolvers, KrylovKit, MKL_jll
 using Test
 import CliqueTrees, Random
 
@@ -481,7 +481,7 @@ end
 
     @testset "KrylovJL" begin
         kwargs = (; gmres_restart = 5)
-        precs = (A, p = nothing) -> (BlockJacobiPreconditioner(A, 2), I)
+        precs = (A, p = nothing) -> (Diagonal(inv.(diag(A))), I)
         algorithms = (
             ("Default", KrylovJL(; kwargs...)),
             ("CG", KrylovJL_CG(; kwargs...)),
@@ -507,7 +507,7 @@ end
 
         function countingprecs(A, p = nothing)
             num_precs_calls += 1
-            (BlockJacobiPreconditioner(A, 2), I)
+            (Diagonal(inv.(diag(A))), I)
         end
 
         n = 10


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Replace the external `BlockJacobiPreconditioner` used by the Core tests with a public-API `LinearAlgebra` inverse diagonal preconditioner.
- Remove the test-only `KrylovPreconditioners` compat, extra, target, and import entries.
- Remove LinearSolve's package-specific `no_promote` override from the downgrade workflow.

## Root cause and impact

`KrylovPreconditioners` was used indirectly through its exported `BlockJacobiPreconditioner` name, but its historical Arpack/LightGraphs dependency graph cannot be minimum-resolved with the rest of LinearSolve's test environment. PR #1091 worked around that resolver conflict by excluding the package from minimum promotion.

The existing tests only require an inverse-like preconditioner to exercise the Krylov wrapper. `Diagonal(inv.(diag(A)))` provides that behavior using public `LinearAlgebra` APIs. The GMRES and FGMRES preconditioned cases retain `ldiv = false`, so the inverse-preconditioner multiplication path remains covered. The `(M, I)` tuple continues to cover a nontrivial left preconditioner and identity right preconditioner, and the existing counting factory still verifies `reuse_precs = true` without rebuilding the preconditioner.

This changes only test infrastructure and downgrade coverage; it does not change LinearSolve's runtime dependencies or public API.

## Process

The requested task was to replace the downgrade promotion exception with a focused dependency fix without skipping or weakening tests. I reviewed current `main`, #1091, and the history that introduced the preconditioner tests. That review showed the dependency was used indirectly through an exported symbol, so I preserved the solver and reuse coverage with the documented stdlib preconditioner interface instead of deleting those cases. I then ran the exact downgrade resolver, locked downgrade and current Core suites, formatting, workflow, TOML, and diff checks before committing.

## Local validation

- Ran the Julia 1.10 `julia-actions/julia-downgrade-compat` v2.6.1 resolver in `deps` mode with the reusable workflow's default Mooncake exclusion. Resolution completed successfully, and the resulting manifest did not contain `KrylovPreconditioners`.
- Ran `Pkg.build()` against the downgraded manifest successfully.
- Ran `GROUP=Core` on Julia 1.10 with `force_latest_compatible_version = false` and `allow_reresolve = false`: the full Core suite passed; Basic Tests passed 590/590.
- Built the current Julia 1.12 environment and ran the same strict `GROUP=Core` command: the full Core suite passed; Basic Tests passed 590/590.
- Ran Runic over the full repository: 142/142 Julia files passed.
- Ran `actionlint .github/workflows/Downgrade.yml`, parsed and checked the `Project.toml` test target declarations, and ran `git diff --check`; all passed.

## Prior art

This replaces the package-specific workaround merged in #1091 with a dependency-level fix while preserving the affected preconditioner behavior tests.
