### PR TITLE
Use stable PyAMG project links

### DIFF
--- a/docs/src/basics/Preconditioners.md
+++ b/docs/src/basics/Preconditioners.md
@@ -136,7 +136,7 @@ The following preconditioners match the interface of LinearSolve.jl.
       + `AlgebraicMultigrid.smoothed_aggregation(A)`
   - [PyAMG via LinearSolvePyAMG.jl](https://github.com/SciML/LinearSolve.jl/tree/main/lib/LinearSolvePyAMG):
     Implementations of the algebraic multigrid method backed by the Python
-    [PyAMG](https://pyamg.readthedocs.io) library via PythonCall.jl.
+    [PyAMG](https://github.com/pyamg/pyamg) library via PythonCall.jl.
     The Python dependency is installed automatically via CondaPkg.jl.
     Provides the following solvers through the standard LinearSolve interface:
 

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -958,7 +958,7 @@ PETScAlgorithm
 
     `LinearSolvePyAMG` is a sub-library of LinearSolve.jl. Using these solvers
     requires adding it: `using LinearSolvePyAMG`. The Python
-    [PyAMG](https://pyamg.readthedocs.io) library is installed automatically via
+    [PyAMG](https://github.com/pyamg/pyamg) library is installed automatically via
     CondaPkg.jl; no manual Python setup is required.
 
 `PyAMG(; method = :RugeStuben, accel = nothing, kwargs...)` — Algebraic Multigrid

--- a/lib/LinearSolvePyAMG/README.md
+++ b/lib/LinearSolvePyAMG/README.md
@@ -7,7 +7,7 @@
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 
 LinearSolvePyAMG.jl is a component of the [LinearSolve.jl](https://github.com/SciML/LinearSolve.jl) monorepo. It
-wraps the Python [PyAMG](https://pyamg.readthedocs.io) Algebraic Multigrid (AMG)
+wraps the Python [PyAMG](https://github.com/pyamg/pyamg) Algebraic Multigrid (AMG)
 library via [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl).
 PyAMG is installed automatically into Julia's managed Python environment via
 [CondaPkg.jl](https://github.com/JuliaPy/CondaPkg.jl).

--- a/lib/LinearSolvePyAMG/src/LinearSolvePyAMG.jl
+++ b/lib/LinearSolvePyAMG/src/LinearSolvePyAMG.jl
@@ -1,7 +1,7 @@
 """
     LinearSolvePyAMG
 
-A wrapper around [PyAMG](https://pyamg.readthedocs.io) (Algebraic Multigrid Solvers in
+A wrapper around [PyAMG](https://github.com/pyamg/pyamg) (Algebraic Multigrid Solvers in
 Python) for use with [LinearSolve.jl](https://github.com/SciML/LinearSolve.jl).
 The Python library is accessed via [PythonCall.jl](https://github.com/JuliaPy/PythonCall.jl)
 and installed automatically via [CondaPkg.jl](https://github.com/JuliaPy/CondaPkg.jl).
@@ -43,7 +43,7 @@ import LinearSolve: LinearCache, LinearVerbosity, OperatorAssumptions
 """
     PyAMG(; method = :RugeStuben, accel = nothing, kwargs...)
 
-Algebraic Multigrid solver backed by [PyAMG](https://pyamg.readthedocs.io)
+Algebraic Multigrid solver backed by [PyAMG](https://github.com/pyamg/pyamg)
 (Python) via PythonCall.jl.
 
 PyAMG is automatically installed into the Julia-managed Python environment via


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Retarget all five PyAMG references from the intermittently rate-limited Read the Docs endpoint to the official PyAMG GitHub project.
- Keep Documenter strict link checking enabled. This does not add a linkcheck ignore, warn-only setting, retry suppression, or other failure bypass.
- Keep the source docstrings, rendered manual, and sublibrary README consistent.

## Baseline evidence

- Clean `main` commit `e80aaaee` failed documentation run 29722529521 with three HTTP 429 responses from `https://pyamg.readthedocs.io`, followed by a fatal `makedocs` linkcheck error: https://github.com/SciML/LinearSolve.jl/actions/runs/29722529521/job/88288359037
- PR #1099 independently failed in the same way at `27278b6e`: https://github.com/SciML/LinearSolve.jl/actions/runs/29747030285/job/88367481216
- The links were introduced with LinearSolvePyAMG in #900 (`4d8c7e3b`). No existing issue covers this failure.
- #1096 currently contains a branch-only `linkcheck_ignore` workaround; this focused change preserves strict checking instead.

## Validation

- Julia 1.12.4 full docs build: `julia --project=docs -e 'using Pkg; Pkg.instantiate(); include("docs/make.jl")'` completed with exit 0, including strict external link checking and HTML rendering.
- Runic 1.7.0 `--check .`: passed.
- `git diff --check`: passed.
- The replacement URL returned HTTP 200 for both GET and HEAD locally.
