### PR TITLE
Bump LinearSolve to v5.0.1 for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.0.0"
+version = "5.0.1"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Releases unreleased fixes on master: KLU JET inference paths (#1095) and cache-free static failure solutions (#1094).

Detected by comparing the `git-tree-sha1` of the latest live registered version in General against the `src` subtree on the default branch. Only the `version` field in `Project.toml` is changed. **No local test run** — CI on this PR is the check. Please ignore until reviewed by @ChrisRackauckas.