### PR TITLE
Approve intentional SciMLBase reexports in QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -29,6 +29,7 @@ scimlbase_reexports = Tuple(names(LinearSolve.SciMLBase; all = false, imported =
 run_qa(
     LinearSolve;
     explicit_imports = true,
+    reexports_allow = scimlbase_reexports,
     api_docs_kwargs = (; rendered = true, docs_src, rendered_ignore = scimlbase_reexports),
     # Recursive ambiguities are tracked separately; placeholder until resolved.
     aqua_broken = (:ambiguities,),


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- approve the public SciMLBase names that LinearSolve intentionally exposes through `@reexport using SciMLBase`
- reuse the tuple already maintained for rendered-documentation QA
- keep SciMLTesting rejecting every other unapproved public reexport

## Regression analysis

`GROUP=QA` passes at parent commit d4786f90 and starts failing at 6e50f19d (#1096), where the SciMLTesting 2.x upgrade enabled public-reexport QA. Current main reports all 185 intentional SciMLBase facade names because `scimlbase_reexports` was only supplied to `rendered_ignore`, not `reexports_allow`.

## Local verification

- `GROUP=QA julia +1.12 --startup-file=no --project=. -e "using Pkg; Pkg.test()"` — passed: Quality Assurance 20 passed / 2 broken; JET 28 passed / 7 broken
- Runic v1.7.0 `--check .` — passed
- `git diff --check` — passed

## Process

Reproduced on a clean main worktree, compared the introducing commit with its passing parent, inspected SciMLTesting 2.4.0 reexport-check semantics, and applied the smallest configuration-only correction.