### PR TITLE
Bump LinearSolve subpackage versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.1.0"
+version = "5.1.1"
 authors = ["SciML"]
 
 [deps]

--- a/lib/LinearSolvePyAMG/Project.toml
+++ b/lib/LinearSolvePyAMG/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearSolvePyAMG"
 uuid = "7a56c47d-7ab1-4e99-b0e3-2952e463d64a"
 authors = ["SciML"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"


### PR DESCRIPTION
Bumps the following subpackages so their accumulated unreleased `src/` changes can be registered:

- `LinearSolve` v5.1.0 → **v5.1.1** (patch) — Reuse direct BLAS LU workspaces during refactorization (#1099) (docs/QA/compat/internal; no public API or behavior break)
- `LinearSolvePyAMG` v1.3.0 → **v1.3.1** (patch) — Add rendered public API docs QA (#1096) (docs/QA/compat/internal; no public API or behavior break)

Each bump reflects the semantic level of its diff (patch unless new public API was added). Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)