### PR TITLE
Fix missing needs_concrete_A dispatch for HYPREAlgorithm

### DIFF
--- a/ext/LinearSolveHYPREExt.jl
+++ b/ext/LinearSolveHYPREExt.jl
@@ -5,7 +5,7 @@ using HYPRE.LibHYPRE: HYPRE_Complex, HYPREError, HYPRE_ERROR_CONV
 using HYPRE: HYPRE, HYPREMatrix, HYPRESolver, HYPREVector
 using LinearSolve: HYPREAlgorithm, LinearCache, LinearProblem, LinearSolve,
     OperatorAssumptions, default_tol, init_cacheval, __issquare,
-    __conditioning, LinearSolveAdjoint, LinearVerbosity
+    __conditioning, LinearSolveAdjoint, LinearVerbosity, needs_concrete_A
 using SciMLLogging: SciMLLogging, verbosity_to_int, @SciMLMessage
 using SciMLBase: LinearProblem, LinearAliasSpecifier, SciMLBase
 using Setfield: @set!
@@ -20,6 +20,19 @@ mutable struct HYPRECache
     isfresh_A::Bool
     isfresh_b::Bool
     isfresh_u::Bool
+end
+
+LinearSolve.needs_concrete_A(::HYPREAlgorithm) = true
+
+function LinearSolve.update_tolerances_internal!(cache, alg::HYPREAlgorithm, abstol, reltol)
+    # The HYPRE solver is created lazily in solve!, so any tolerance change is
+    # naturally picked up from cache.abstol/cache.reltol the next time the
+    # solver is instantiated. Mark the cached solver as stale so it gets
+    # recreated with the updated tolerances.
+    if cache.cacheval isa HYPRECache && cache.cacheval.solver !== nothing
+        cache.cacheval.solver = nothing
+    end
+    return nothing
 end
 
 function LinearSolve.init_cacheval(

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -167,7 +167,7 @@ struct PETScAlgorithm <: SciMLLinearSolveAlgorithm
 end
 
 """
-`HYPREAlgorithm(solver; comm = nothing, Pl = nothing)`
+`HYPREAlgorithm(solver; comm = nothing)`
 
 [HYPRE.jl](https://github.com/fredrikekre/HYPRE.jl) is an interface to
 [`hypre`](https://computing.llnl.gov/projects/hypre-scalable-linear-solvers-multigrid-methods)
@@ -201,7 +201,8 @@ The single positional argument `solver` has the following choices:
 
   - `comm`: optional MPI communicator used to auto-construct distributed
     `HYPREMatrix` / `HYPREVector` inputs from plain Julia sparse matrices and vectors.
-  - `Pl`: A choice of left preconditioner.
+
+Preconditioners are passed to `solve`/`init` via the `Pl` keyword argument.
 
 ## Example
 

--- a/test/LinearSolveHYPRE/hypretests.jl
+++ b/test/LinearSolveHYPRE/hypretests.jl
@@ -174,6 +174,19 @@ function test_retcode_failure()
     return @test sol.resid > cache.reltol
 end
 
+function test_update_tolerances()
+    prob = failure_prob()
+    cache = SciMLBase.init(
+        prob, HYPREAlgorithm(HYPRE.PCG);
+        abstol = 1.0e-12, reltol = 1.0e-12, maxiters = 1
+    )
+    @test cache.cacheval.solver === nothing
+    LinearSolve.update_tolerances!(cache; abstol = 1.0e-6, reltol = 1.0e-6)
+    @test cache.abstol == 1.0e-6
+    @test cache.reltol == 1.0e-6
+    return @test cache.cacheval.solver === nothing
+end
+
 const comm = MPI.COMM_WORLD
 
 # HYPRE.BiCGSTAB
@@ -226,6 +239,11 @@ test_interface(HYPREAlgorithm(HYPRE.PCG), Pl = HYPRE.BoomerAMG)
 test_interface(HYPREAlgorithm(HYPRE.PCG(comm)))
 test_interface(HYPREAlgorithm(HYPRE.PCG(comm)), Pl = HYPRE.BoomerAMG())
 test_retcode_failure()
+test_update_tolerances()
+
+@test LinearSolve.needs_concrete_A(HYPREAlgorithm(HYPRE.GMRES))
+@test LinearSolve.needs_concrete_A(HYPREAlgorithm(HYPRE.PCG))
+@test LinearSolve.needs_concrete_A(HYPREAlgorithm(HYPRE.BoomerAMG))
 
 # Test MPI execution
 # Pass the active project explicitly: the group env (test/hypre) is activated


### PR DESCRIPTION
`HYPREAlgorithm` directly subtypes `SciMLLinearSolveAlgorithm`, so `needs_concrete_A(::HYPREAlgorithm)` was undefined. Downstream solvers (`NonlinearSolveBase`, `OrdinaryDiffEq`) call this trait for any `SciMLLinearSolveAlgorithm`, causing a `MethodError` and (with the old `solve(cache) ↔ solve(cache, cache.alg)` chain) a stack overflow when HYPRE is used as `linsolve` (#277).

- `ext/LinearSolveHYPREExt.jl`: add `needs_concrete_A(::HYPREAlgorithm) = true` and `update_tolerances_internal!`.
- `src/extension_algs.jl`: fix docstring — `Pl` is a `solve`/`init` keyword, not a constructor kwarg.
- `test/LinearSolveHYPRE/hypretests.jl`: tests for the trait and `update_tolerances!`.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #277. The downstream path (`needs_concrete_A` → concrete `W` → `LinearProblem` → `init` → `solve!` → update `A`/`b` → `solve!`) and the full `test/LinearSolveHYPRE/hypretests.jl` suite pass. 

AI Disclosure: Kimi K3