### PR TITLE
Move the SupernodalLU sweep proof to a QA-only file

### DIFF
--- a/test/qa/allocations.jl
+++ b/test/qa/allocations.jl
@@ -63,69 +63,7 @@ if LinearSolve.appleaccelerate_isavailable()
     end
 end
 
-# SupernodalLU: the triangular sweeps run entirely off buffers owned by the
-# factorization, whose sizes are known from the symbolic analysis, so they
-# carry no growth branch and AllocCheck can prove them allocation-free
-# statically (rather than sampling `@allocated`).  The user-facing `solve!`
-# keeps a one-time scratch sizing, so it is asserted at runtime instead.
-@check_allocs allocation_checked_supernodal_sweeps!(y, F) =
-    LinearSolve.SupernodalLU._solve_panels!(y, F)
-
-# What the sweeps can be *proved* about depends on the Julia version, because
-# above `PANEL_BLAS_CUTOFF` they hand off to LinearAlgebra's `ldiv!`/`mul!`,
-# whose wrappers are not statically clean on every release: 1.10 and 1.13 leave
-# a `generic_trimatdiv!` dynamic dispatch plus boxed `MulAddMul`/`SubArray`
-# values that AllocCheck reports (`triangular.jl`, `matmul.jl` — stdlib frames,
-# no SupernodalLU code involved), and 1.11 allocates them for real on the
-# `SubArray`-matrix path the multi-RHS sweep takes.  1.12 folds all of it away.
-# So pin each assertion to the versions that can carry it rather than weakening
-# it everywhere; the sweeps carry no growth branch on any version, which is what
-# these are here to protect.
-const STATIC_SWEEP_PROOF = v"1.12" <= VERSION < v"1.13"
-const RUNTIME_MULTIRHS_ZERO = VERSION < v"1.11" || VERSION >= v"1.12"
-
-function poisson2d_qa(k)
-    n = k * k
-    Is = Int[]; Js = Int[]; V = Float64[]
-    idx(i, j) = (j - 1) * k + i
-    for j in 1:k, i in 1:k
-        c = idx(i, j)
-        push!(Is, c); push!(Js, c); push!(V, 4.0)
-        i > 1 && (push!(Is, c); push!(Js, idx(i - 1, j)); push!(V, -1.0))
-        i < k && (push!(Is, c); push!(Js, idx(i + 1, j)); push!(V, -1.0))
-        j > 1 && (push!(Is, c); push!(Js, idx(i, j - 1)); push!(V, -1.0))
-        j < k && (push!(Is, c); push!(Js, idx(i, j + 1)); push!(V, -1.0))
-    end
-    return sparse(Is, Js, V, n, n)
-end
-
-@testset "SupernodalLU solve sweeps are provably allocation-free" begin
-    for A in (
-            SparseArrays.spdiagm(
-                0 => fill(4.0, 200), 1 => fill(-1.0, 199), -1 => fill(-1.0, 199)
-            ),
-            poisson2d_qa(30),                 # real panels: maxnu > 1
-        )
-        n = size(A, 1)
-        F = LinearSolve.SupernodalLU.snlu(A)
-        LinearSolve.SupernodalLU._ensure_panel_scratch!(F, 1)
-        y = ones(n)
-        if STATIC_SWEEP_PROOF
-            allocation_checked_supernodal_sweeps!(y, F)   # throws if it can allocate
-            @test true
-        end
-        # the full solve!, which owns the one-time sizing, is zero at runtime
-        b = ones(n)
-        x = similar(b)
-        LinearSolve.SupernodalLU.solve!(x, F, b; refine = 0)
-        @test @allocated(LinearSolve.SupernodalLU.solve!(x, F, b; refine = 0)) == 0
-        @test norm(A * x - b) <= 1.0e-8 * norm(b)
-        # multi-RHS reuses the factor-owned scratch once sized
-        B = ones(n, 3)
-        X = similar(B)
-        LinearSolve.SupernodalLU.solve!(X, F, B; refine = 0)
-        if RUNTIME_MULTIRHS_ZERO
-            @test @allocated(LinearSolve.SupernodalLU.solve!(X, F, B; refine = 0)) == 0
-        end
-    end
-end
+# SupernodalLU's sweep proof lives in `qa/supernodal_allocations.jl`, which only
+# the QA group includes: this file also runs under `[AppleAccelerate]`, which
+# covers `pre`, and that proof only holds on 1.12 (it bottoms out in stdlib
+# `ldiv!`/`mul!` wrappers).  The direct-BLAS proofs above hold on every release.

--- a/test/qa/supernodal_allocations.jl
+++ b/test/qa/supernodal_allocations.jl
@@ -1,0 +1,75 @@
+# SupernodalLU allocation coverage.
+#
+# Separate from `qa/allocations.jl` because the two are included by different
+# groups: `allocations.jl` also runs under `[AppleAccelerate]`, which covers
+# `pre`, while this file is QA-only.  The direct-BLAS refactorization proofs
+# over there hold on every release; the sweep proof here does not, because
+# above `PANEL_BLAS_CUTOFF` the sweeps hand off to LinearAlgebra's
+# `ldiv!`/`mul!`, whose wrappers are not statically clean on every version.
+# Keeping them in one file put a 1.12-only proof inside a file that `pre` runs.
+
+using AllocCheck, LinearAlgebra, LinearSolve, SparseArrays, Test
+
+# The triangular sweeps run entirely off buffers owned by the factorization,
+# whose sizes are known from the symbolic analysis, so they carry no growth
+# branch and AllocCheck can prove them allocation-free statically (rather than
+# sampling `@allocated`).  The user-facing `solve!` keeps a one-time scratch
+# sizing, so it is asserted at runtime instead.
+@check_allocs allocation_checked_supernodal_sweeps!(y, F) =
+    LinearSolve.SupernodalLU._solve_panels!(y, F)
+
+# The *static proof* is version-dependent: 1.10 and 1.13 leave a
+# `generic_trimatdiv!` dynamic dispatch plus boxed `MulAddMul`/`SubArray` values
+# that AllocCheck reports (`triangular.jl`, `matmul.jl` — stdlib frames, no
+# SupernodalLU code involved); 1.12 folds all of it away.  Measured identically
+# on x86_64-Linux and aarch64-Darwin (18 findings on 1.10 on both, 0 on 1.12),
+# so this is the stdlib, not the platform, and not this package's code.
+#
+# The *runtime* assertions below are deliberately NOT gated: those measure real
+# allocations, and skipping one would hide a genuine regression rather than a
+# limitation of the prover.
+const STATIC_SWEEP_PROOF = v"1.12" <= VERSION < v"1.13"
+
+function poisson2d_qa(k)
+    n = k * k
+    Is = Int[]; Js = Int[]; V = Float64[]
+    idx(i, j) = (j - 1) * k + i
+    for j in 1:k, i in 1:k
+        c = idx(i, j)
+        push!(Is, c); push!(Js, c); push!(V, 4.0)
+        i > 1 && (push!(Is, c); push!(Js, idx(i - 1, j)); push!(V, -1.0))
+        i < k && (push!(Is, c); push!(Js, idx(i + 1, j)); push!(V, -1.0))
+        j > 1 && (push!(Is, c); push!(Js, idx(i, j - 1)); push!(V, -1.0))
+        j < k && (push!(Is, c); push!(Js, idx(i, j + 1)); push!(V, -1.0))
+    end
+    return sparse(Is, Js, V, n, n)
+end
+
+@testset "SupernodalLU solve sweeps are provably allocation-free" begin
+    for A in (
+            SparseArrays.spdiagm(
+                0 => fill(4.0, 200), 1 => fill(-1.0, 199), -1 => fill(-1.0, 199)
+            ),
+            poisson2d_qa(30),                 # real panels: maxnu > 1
+        )
+        n = size(A, 1)
+        F = LinearSolve.SupernodalLU.snlu(A)
+        LinearSolve.SupernodalLU._ensure_panel_scratch!(F, 1)
+        y = ones(n)
+        if STATIC_SWEEP_PROOF
+            allocation_checked_supernodal_sweeps!(y, F)   # throws if it can allocate
+            @test true
+        end
+        # the full solve!, which owns the one-time sizing, is zero at runtime
+        b = ones(n)
+        x = similar(b)
+        LinearSolve.SupernodalLU.solve!(x, F, b; refine = 0)
+        @test @allocated(LinearSolve.SupernodalLU.solve!(x, F, b; refine = 0)) == 0
+        @test norm(A * x - b) <= 1.0e-8 * norm(b)
+        # multi-RHS reuses the factor-owned scratch once sized
+        B = ones(n, 3)
+        X = similar(B)
+        LinearSolve.SupernodalLU.solve!(X, F, B; refine = 0)
+        @test @allocated(LinearSolve.SupernodalLU.solve!(X, F, B; refine = 0)) == 0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,6 +230,9 @@ else
                 @time @safetestset "Quality Assurance" include("qa/qa.jl")
                 @time @safetestset "JET Tests" include("qa/jet.jl")
                 @time @safetestset "Allocation QA" include("qa/allocations.jl")
+                @time @safetestset "SupernodalLU Allocation QA" include(
+                    "qa/supernodal_allocations.jl"
+                )
             end
             return nothing
         end,


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Follow-up to #1119, which merged while this was in progress — rebased onto main. Addresses the structural half of the macOS failure: the `pre` job specifically.

### The problem

`test/runtests.jl` includes `qa/allocations.jl` from two groups that do not cover the same Julia versions:

```toml
[QA]              versions = ["lts", "1"]
[AppleAccelerate] versions = ["lts", "1", "pre"]
```

So AllocCheck ran on `pre` through a group that was never meant to carry it.

### The split

The file mixes two things with different portability:

- **Direct-BLAS refactorization proofs** — hold on every release. That contract is the reason the AppleAccelerate group exists. **Stay put**, still run under both groups on all versions.
- **The SupernodalLU sweep proof** — above `PANEL_BLAS_CUTOFF` the sweeps hand off to LinearAlgebra's `ldiv!`/`mul!`, whose wrappers leave a `generic_trimatdiv!` dynamic dispatch plus boxed `MulAddMul`/`SubArray` values that AllocCheck reports on 1.10 and 1.13. **Moves** to `test/qa/supernodal_allocations.jl`, included only by QA.

Measured on the same two matrices the testset uses:

| Julia | arch | static findings | runtime 1-RHS | 3-RHS |
|---|---|---|---|---|
| 1.10.11 | x86_64-Linux | 18 | 0 B | 0 B |
| 1.12.6 | x86_64-Linux | 0 | 0 B | 0 B |

18 findings on 1.10 x86_64-Linux is the same count #1119 measured on 1.10 aarch64-Darwin, and 1.12 is clean on both — so this is the stdlib and the Julia version, not the platform and not this package's code. (That also closes the "I have no Linux box here" caveat in #1119.)

Worth flagging: the coverage is narrower than the toml suggests — only one QA job actually materialises (`QA (julia 1)`), so the static proof is exercised on 1.12 alone, and it was green on Linux only because QA/lts never runs.

### One deliberate difference from #1119

The static proof keeps a version guard — that is a genuine limit of the prover, and the runtime numbers above show the sweeps are allocation-free anyway.

**`RUNTIME_MULTIRHS_ZERO` is dropped.** It gated a *runtime* allocation assertion, and per #1119's own table the 1.11 multi-RHS path allocates 6144 B for real — that is a regression, not a prover limitation, and skipping the assertion hides it. With the gate gone the test fails on 1.11 until the allocation is fixed, which I think is the correct behavior. 1.11 is not in the CI matrix (`lts`/`1`/`pre` = 1.10/1.12/1.13), so this costs nothing today. I could not reproduce the 6144 B myself — my 1.11 QA env failed to precompile AllocCheck — so I have not verified that number independently.

### Testing

- `qa/allocations.jl` completes on Julia **1.10**, the version that was failing.
- `GROUP=QA` on Julia **1.12** (what CI runs): `rc=0`.
- `GROUP=Core` on Julia **1.12**: `rc=0`.
- Runic reports no formatting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rr42T1vFRRT8D7DMAmJzf
