### PR TITLE
Bound the UMFPACK-backed sparse cachevals to the eltypes UMFPACK has

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -128,6 +128,11 @@ end
     )
 end # @static if Base.USE_GPL_LIBS
 
+# UMFPACK's `UmfpackLU` only exists for `Float64`/`ComplexF64` (SuiteSparse's
+# `UMFVTypes`). The other BLAS eltypes are not a subset of it, so cachevals for
+# UMFPACK-backed algorithms must be bounded by this, not by `BLASELTYPES`.
+const UMFPACKELTYPES = Union{Float64, ComplexF64}
+
 function LinearSolve.init_cacheval(
         alg::LUFactorization, A::AbstractSparseArray{<:Number, <:Integer}, b, u,
         Pl, Pr,
@@ -169,7 +174,7 @@ end
             Pl, Pr,
             maxiters::Int, abstol, reltol,
             verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-        ) where {T <: BLASELTYPES}
+        ) where {T <: UMFPACKELTYPES}
         if LinearSolve.is_cusparse(A)
             LinearSolve.cudss_loaded(A) ? ArrayInterface.lu_instance(A) : nothing
         else
@@ -185,7 +190,7 @@ end
             Pl, Pr,
             maxiters::Int, abstol, reltol,
             verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-        ) where {T <: BLASELTYPES}
+        ) where {T <: UMFPACKELTYPES}
         if LinearSolve.is_cusparse(A)
             LinearSolve.cudss_loaded(A) ? ArrayInterface.lu_instance(A) : nothing
         else
@@ -197,6 +202,21 @@ end
         end
     end
 end # @static if Base.USE_GPL_LIBS
+
+# Single-precision sparse: no UMFPACK cacheval exists, but a cuDSS-backed
+# CuSparse matrix still needs its `lu_instance`.
+function LinearSolve.init_cacheval(
+        alg::LUFactorization, A::AbstractSparseArray{T, <:Union{Int32, Int64}}, b, u,
+        Pl, Pr,
+        maxiters::Int, abstol, reltol,
+        verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
+    ) where {T <: BLASELTYPES}
+    if LinearSolve.is_cusparse(A)
+        return LinearSolve.cudss_loaded(A) ? ArrayInterface.lu_instance(A) : nothing
+    else
+        return nothing
+    end
+end
 
 function LinearSolve.init_cacheval(
         alg::LUFactorization, A::LinearSolve.GPUArraysCore.AnyGPUArray, b, u,
@@ -231,7 +251,7 @@ end
             Pl, Pr,
             maxiters::Int, abstol, reltol,
             verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-        ) where {T <: BLASELTYPES}
+        ) where {T <: UMFPACKELTYPES}
         SparseArrays.UMFPACK.UmfpackLU(
             SparseMatrixCSC{T, Int64}(
                 zero(Int64), zero(Int64), [Int64(1)], Int64[], T[]
@@ -244,7 +264,7 @@ end
             Pl, Pr,
             maxiters::Int, abstol, reltol,
             verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
-        ) where {T <: BLASELTYPES}
+        ) where {T <: UMFPACKELTYPES}
         SparseArrays.UMFPACK.UmfpackLU(
             SparseMatrixCSC{T, Int32}(
                 zero(Int32), zero(Int32), [Int32(1)], Int32[], T[]

--- a/test/Core/default_algs.jl
+++ b/test/Core/default_algs.jl
@@ -115,6 +115,25 @@ let As_bf = sparse(BigFloat.([1 2 3; 2 4 6; 1 1 1])), bs_bf = BigFloat.([1, 2, 3
     @test all(isfinite, sol.u)
 end
 
+# Single-precision sparse has no UMFPACK/KLU (SuiteSparse) support, so the
+# default polyalgorithm — which eagerly builds a cacheval for *every* slot, not
+# just the selected one — must not try to allocate an UMFPACK cacheval for it.
+@testset "Sparse $T with $Ti indices" for T in (Float32, ComplexF32),
+        Ti in (Int64, Int32)
+
+    n = 20
+    A32 = sparse(Ti.(1:n), Ti.(1:n), fill(T(n), n), n, n) +
+        sparse(Ti.(1:(n - 1)), Ti.(2:n), fill(T(1), n - 1), n, n)
+    b32 = ones(T, n)
+    @test A32 isa SparseMatrixCSC{T, Ti}
+    @test LinearSolve.defaultalg(A32, b32, LinearSolve.OperatorAssumptions(true)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.KLUFactorization
+    sol32 = solve(LinearProblem(A32, b32))
+    @test SciMLBase.successful_retcode(sol32.retcode)
+    @test eltype(sol32.u) === T
+    @test norm(A32 * sol32.u - b32) / norm(b32) < 1.0f-5
+end
+
 @test LinearSolve.defaultalg(sprand(10^4, 10^4, 1.0e-5) + I, zeros(1000)).alg ===
     LinearSolve.DefaultAlgorithmChoice.KLUFactorization
 prob = LinearProblem(sprand(1000, 1000, 0.5), zeros(1000))


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Found while checking what the sparse default does per element type. Reproduces on a pristine checkout of `main`.

### The bug

```julia
A = sparse(Float32(1)I, 50, 50) + spdiagm(1=>fill(0.1f0,49)); b = ones(Float32, 50)
LinearSolve.defaultalg(A, b, OperatorAssumptions(true))
# => DefaultLinearSolver(DefaultAlgorithmChoice.KLUFactorization, true, false)
init(LinearProblem(A,b), nothing)
# => MethodError: no method matching SparseArrays.UMFPACK.UmfpackLU(::SparseMatrixCSC{Float32, Int64})
```

**The algorithm that throws is not the one selected.** `_init_default_cacheval` (`src/default.jl`, `@generated`) emits an unconditional `init_cacheval` for *every* slot — only the three Krylov slots are guarded — so a too-permissive `init_cacheval` on an unselected algorithm still breaks `init`. KLU is chosen; the `LUFactorization` slot is constructed first and throws.

`LUFactorization`'s and `UMFPACKFactorization`'s sparse cachevals are bounded by `BLASELTYPES = Union{Float32,Float64,ComplexF32,ComplexF64}`, but `UmfpackLU` exists only for `Float64`/`ComplexF64` (SuiteSparse's `UMFVTypes`) — too wide by exactly `Float32`/`ComplexF32`. KLU already gets this right with `T <: KLU.KLUTypes`.

4 of 10 eltype/index combinations fail on unmodified `main`:

```
Int64/Float32     INIT THREW    Int32/Float32     INIT THREW
Int64/ComplexF32  INIT THREW    Int32/ComplexF32  INIT THREW
```

### The fix

Bound them to a local `UMFPACKELTYPES = Union{Float64, ComplexF64}`.

Two notes on the shape of it:
- **The extra `BLASELTYPES` method is not redundant.** The old methods' `is_cusparse(A) → cudss_loaded(A) ? lu_instance(A) : nothing` branch is the only `LUFactorization`+CuSparse `init_cacheval` in the tree (`LinearSolveCUDAExt` defines none), so narrowing alone would have silently dropped Float32 cuDSS support.
- `UMFPACKELTYPES` is defined locally rather than reusing `SparseArrays.UMFPACK.UMFVTypes`, which is a non-public internal.

Float32/ComplexF32 sparse now resolve to the `KLUFactorization` slot, which `algchoice_to_alg` maps to `PureKLUFactorization()` — pure Julia, a hard dependency, and the only thing in the tree that actually supports these eltypes (SuiteSparse KLU, UMFPACK, and Sparspak all reject them).

### Bisect — two separate breakages

| commit | date | effect |
|---|---|---|
| [`0ce03c28`](https://github.com/SciML/LinearSolve.jl/commit/0ce03c284e5426757f9123bfc56a13f94c9fb8cf) | 2025-05-22 | widened the cachevals to `T <: BLASELTYPES` while adding ComplexF64. Broke Float32 sparse for Sparspak users; everyone else still hit the "`using Sparspak` required" error in `defaultalg` first, so it stayed hidden. |
| [`52ebf258`](https://github.com/SciML/LinearSolve.jl/commit/52ebf258046c1f22dd9af050841db39e05337478) (#1037) | 2026-06-13 | removed that early error, exposing the breakage to everyone. |

Measured at `0ce03c28^` with Sparspak loaded: `init` OK. So this path did work once.

### Testing

All 10 combinations after the fix — eltype preserved, no silent Float64 promotion:

```
Float32/Int64     OK resid=0.0  eltype=Float32
ComplexF32/Int32  OK resid=0.0  eltype=ComplexF32
BigFloat/Int64    OK resid=1.7e-77
```

- `test/Core/default_algs.jl` gains a 4-combination testset (`Float32`/`ComplexF32` × `Int64`/`Int32`). Confirmed it executes: `Default Alg Tests` goes 89 → 109 tests.
- `GROUP=Core` passes on the fixed tree **and** on unmodified `main` — main is not independently red.
- `Test.detect_ambiguities` on the extension: 12 before, 12 after.
- Runic reports no formatting changes.

### Out of scope

Explicitly-requested `LUFactorization`/`UMFPACKFactorization` on Float32 sparse remain unsupported, exactly as before this change — they now fail the way SuiteSparse KLU already does for an unsupported eltype instead of with a `MethodError`. Making them work would mean silent Float32→Float64 promotion (SparseArrays' `lu` does this), which is a behavior addition rather than a bug fix. Happy to do it separately if you want it.

Also cleared while looking: BigFloat sparse is **not** a second bug — the `KLUFactorization` enum slot maps to `PureKLUFactorization`, not SuiteSparse KLU, so it works today. And `Symmetric` Float32 sparse → CHOLMOD is fine, because CHOLMOD's `init_cacheval` returns `nothing` for the non-Float64 case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rr42T1vFRRT8D7DMAmJzf
