### PR TITLE
test: spell out SupernodalLU threshold variable

### DIFF
--- a/test/Core/supernodal_lu.jl
+++ b/test/Core/supernodal_lu.jl
@@ -173,8 +173,8 @@ end
     Base.get_extension(LinearSolve, :LinearSolveBLISExt) !== nothing &&
         push!(algs, LinearSolve.BLISLUFactorization())
     @test !isempty(algs)        # every platform has at least one of these
-    for alg in algs, thr in (4, 64)
-        F = SNLU.snlu(A; dense_alg = alg, dense_threshold = thr)
+    for alg in algs, threshold in (4, 64)
+        F = SNLU.snlu(A; dense_alg = alg, dense_threshold = threshold)
         @test length(F.bcaches) > 0
         x = similar(b)
         SNLU.solve!(x, F, b)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Rename the local `thr` loop variable in the SupernodalLU dense-kernel tests to `threshold` so Typos does not interpret it as a misspelling.

## Regression evidence

- Clean current `main` (`ed7bcb014f03d15f50e9a5cf86f8a314ab2d248d`) reports exactly two Typos 1.48.0 findings at `test/Core/supernodal_lu.jl:176-177`.
- An automated bisect identified `4c58ce272a79969d45eaa640bdf74c2a437263bf` (#1119) as the first bad commit.

## Local verification

The rebased #1124 tree is byte-identical to the separately tested current-main validation tree (`a11cb43039569967e2bd97e862cf6b32a5b1ba5c`):

- `GROUP=Core JULIA_NUM_THREADS=2 julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` — passed: 2,299 assertions plus three pre-existing broken cases; `SupernodalLU internals` passed 72/72.
- Typos 1.48.0 over the whole repository — passed with zero findings.
- Runic over the changed file and whole repository — passed.
- `git diff --check` — passed.

The remote branch was audited before the lease-protected rebase push; it contained only the prior bot-authored version of this same commit.