### PR TITLE
Import issquare from SciMLOperators in ForwardDiff extension

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -8,6 +8,7 @@ using SparseArrays
 using ForwardDiff
 using ForwardDiff: Dual, Partials
 using SciMLBase
+using SciMLOperators: issquare
 using RecursiveArrayTools
 using SciMLLogging
 using ArrayInterface

--- a/test/Core/forwarddiff_overloads.jl
+++ b/test/Core/forwarddiff_overloads.jl
@@ -32,6 +32,16 @@ function dual_isapprox(x, y; rtol)
     )
 end
 
+@testset "ForwardDiff square-system initialization" begin
+    A_dual = [
+        ForwardDiff.Dual(2.0, 1.0) ForwardDiff.Dual(1.0, 0.0)
+        ForwardDiff.Dual(1.0, 0.0) ForwardDiff.Dual(3.0, 1.0)
+    ]
+    b_dual = [ForwardDiff.Dual(1.0, 1.0), ForwardDiff.Dual(2.0, 0.0)]
+    sol = solve(LinearProblem(A_dual, b_dual), LUFactorization())
+    @test dual_isapprox(sol.u, A_dual \ b_dual; rtol = 1.0e-9)
+end
+
 A, b = h([ForwardDiff.Dual(5.0, 1.0, 0.0), ForwardDiff.Dual(5.0, 0.0, 1.0)])
 prob = LinearProblem(A, b)
 backslash_x_p = A \ b


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- import `issquare` directly from its public owner, `SciMLOperators`, in `LinearSolveForwardDiffExt`
- add a focused square split-dual initialization regression

## Root cause

`LinearSolveForwardDiffExt` called bare `issquare` while relying on `using SciMLBase` to make the name available indirectly. SciMLBase commit `b9c3507a` (`Make strict QA owner-contract clean (#1472)`) stopped reexporting SciMLOperators names. With SciMLBase 3.40.1, ForwardDiff initialization of a square linear problem therefore raised:

```text
UndefVarError: `issquare` not defined in `LinearSolveForwardDiffExt`
```

`SciMLOperators.issquare` is exported, has a docstring, and is included in SciMLOperators' rendered interface documentation. The ChainRules extension already uses the same owner import.

## Investigation

- searched open and recent merged LinearSolve PRs; no existing PR fixes this failure
- reproduced the failure on unmodified LinearSolve `fd8271c1` with SciMLBase 3.40.1
- ran the identical probe with registered SciMLBase 3.39.1; it passed with gradient `[0.16, 0.04]`
- applied only the owner import and confirmed the SciMLBase 3.40.1 probe passes with the same gradient

## Verification

- exact `test/Core/forwarddiff_overloads.jl` on SciMLBase 3.40.1: pass
  - new focused test: 1/1
  - all remaining testsets in the file completed successfully
- exact OrdinaryDiffEq nested-AD regression on SciMLBase 3.40.1:
  - nested ForwardDiff over implicit `NonlinearSolveAlg`: 4/4
  - DFBDF initialization with internal ForwardDiff Jacobian: 1/1
- registered SciMLBase 3.39.1 `GROUP=QA`:
  - QA: 20 pass, 2 pre-existing broken
  - JET: 34 pass, 8 pre-existing broken
  - Allocation QA: 48/48
  - SupernodalLU Allocation QA: 8/8
- whole-repository Runic check: pass
- `git diff --check`: pass

The official Core run against SciMLBase 3.40.1 reached 629 passes, then stopped at the independent existing test use of bare `cache_operator`. The same `cache_operator` error reproduces on unmodified LinearSolve `fd8271c1`; it is intentionally outside this focused PR and is being investigated separately. QA against SciMLBase 3.40.1 likewise reaches independent existing owner-contract failures for stale `has_concretization` and a qualified `LinearSolve.SciMLOperators` access. The registered 3.39.1 QA control is green as reported above.