### PR TITLE
Import cache_operator from SciMLOperators in Core tests

### DIFF
--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -1,5 +1,6 @@
 using LinearSolve, LinearAlgebra, SparseArrays, MultiFloats, ForwardDiff
-using SciMLOperators: SciMLOperators, MatrixOperator, FunctionOperator, WOperator
+using SciMLOperators: SciMLOperators, MatrixOperator, FunctionOperator, WOperator,
+    cache_operator
 using RecursiveFactorization, Sparspak, FastLapackInterface
 using IterativeSolvers, KrylovKit, MKL_jll
 using Test


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- import `cache_operator` directly from its public owner, `SciMLOperators`, in the Core test that exercises cached inverse preconditioners
- keep this compatibility fix test-only; there are no production-code changes

## Root cause

`test/Core/basictests.jl` called bare `cache_operator` while relying on the transitive chain `using LinearSolve` → reexported SciMLBase names → SciMLOperators.

SciMLBase commit `b9c3507a` (`Make strict QA owner-contract clean (#1472)`) removed the blanket SciMLOperators reexport. The dependency boundary was checked directly:

- parent `7b806c50` (SciMLBase 3.40.0): `cache_operator` is defined after `using SciMLBase`
- child `b9c3507a`: it is not
- registered SciMLBase 3.39.1: the full LinearSolve `GROUP=Core` control passes

`SciMLOperators.cache_operator` is exported/public, has a docstring, and is included in SciMLOperators' rendered interface documentation.

## Verification

- focused cached diagonal-preconditioner regression on SciMLBase 3.40.1: 6/6
- exact `Basic Tests` on SciMLBase 3.40.1, stacked only for validation with the independent `issquare` fix in #1125: 635/635
- full registered SciMLBase 3.39.1 `GROUP=Core`: passed
- whole-repository Runic 1.7.0 check: passed
- `git diff --check`: passed

The full SciMLBase 3.40.1 Core stack continues past this fixed suite and then stops at a separate bare `FunctionOperator` use in `test/Core/default_algs.jl:167`. QA on that dependency likewise exposes separate existing owner-contract failures: stale `has_concretization` in `src/LinearSolve.jl:20` and non-owner `LinearSolve.SciMLOperators.AbstractSciMLOperator` access in `ext/LinearSolveSparseArraysExt.jl:58`. Those are intentionally outside this focused PR.
