### PR TITLE
Import FunctionOperator from SciMLOperators in Core tests

### DIFF
--- a/test/Core/default_algs.jl
+++ b/test/Core/default_algs.jl
@@ -1,4 +1,5 @@
 using LinearSolve, RecursiveFactorization, LinearAlgebra, SparseArrays, Test
+using SciMLOperators: FunctionOperator, MatrixOperator, WOperator
 
 @test LinearSolve.defaultalg(nothing, zeros(3)).alg === LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
 prob = LinearProblem(rand(3, 3), rand(3))
@@ -357,7 +358,6 @@ sol_qr2 = solve(
 
 # Regression test for https://github.com/SciML/LinearSolve.jl/issues/890
 # WOperator with init_cacheval overload that unwraps A.J (as OrdinaryDiffEqDifferentiation does)
-using SciMLOperators: WOperator, MatrixOperator
 function LinearSolve.init_cacheval(
         alg::LinearSolve.DefaultLinearSolver, A::WOperator, b, u,
         Pl, Pr,


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- Import `FunctionOperator`, `MatrixOperator`, and `WOperator` directly from their owning package, SciMLOperators, at the start of `test/Core/default_algs.jl`.
- Remove the later duplicate owner import.
- Keep this change test-only; LinearSolve already has a direct SciMLOperators dependency.

## Why

SciMLBase's re-export cleanup removed the transitive `FunctionOperator` binding. The boundary is SciMLBase commit `b9c3507a2670fae804bf627ca32354efeee8dc15`: its parent still exposes the binding, while that commit does not. SciMLOperators v1.25.0 publicly exports and documents `FunctionOperator`, so the Core test should import it from SciMLOperators rather than rely on a transitive re-export.

## Verification

- Clean-current focused reproduction before the patch: including `test/Core/default_algs.jl` stops at line 167 with `UndefVarError: FunctionOperator not defined`.
- Rebased focused test against SciMLBase v3.40.1 in an isolated depot:
  `Default Alg Tests | 109 pass | 109 total`.
- Whole-repository Runic check exited 0.
- `git diff --check upstream/main...HEAD` exited 0.

I also ran the official `GROUP=Core` harness with the now-merged #1125 and #1126 fixes applied. It passed the default-algorithm tests (109/109) and continued through the ForwardDiff overload tests (128/128), then stopped at an independent clean-main regression in `test/Core/traits.jl`: `UndefVarError: IdentityOperator not defined in SciMLBase`. That owner-import regression needs a separate focused follow-up and is intentionally not included here.
