### PR TITLE
Spell out the SupernodalLU threshold test variable

### DIFF
--- a/test/Core/supernodal_lu.jl
+++ b/test/Core/supernodal_lu.jl
@@ -173,8 +173,8 @@ end
     Base.get_extension(LinearSolve, :LinearSolveBLISExt) !== nothing &&
         push!(algs, LinearSolve.BLISLUFactorization())
     @test !isempty(algs)        # every platform has at least one of these
-    for alg in algs, thr in (4, 64)
-        F = SNLU.snlu(A; dense_alg = alg, dense_threshold = thr)
+    for alg in algs, threshold in (4, 64)
+        F = SNLU.snlu(A; dense_alg = alg, dense_threshold = threshold)
         @test length(F.bcaches) > 0
         x = similar(b)
         SNLU.solve!(x, F, b)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- rename the local `thr` loop variable in the SupernodalLU Core test to `threshold`
- clear the two Typos findings introduced by #1119 without changing solver behavior or reverting #1125/#1126

## Root cause

A clean `upstream/main` checkout reproduced exactly two Typos 1.48.0 findings at `test/Core/supernodal_lu.jl:176-177`. An automated bisect identified `4c58ce272a79969d45eaa640bdf74c2a437263bf` (#1119) as the first bad commit.

## Verification

- `GROUP=Core JULIA_NUM_THREADS=2 julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` — passed (2,299 passes; three pre-existing broken cases; `SupernodalLU internals` 72/72)
- `typos-cli 1.48.0 .` — passed with zero findings
- `julia +1.12 --project=<Runic env> -m Runic --check --diff test/Core/supernodal_lu.jl` — passed
- `julia +1.12 --project=<Runic env> -m Runic --check --diff .` — passed
- `git diff --check` — passed