### PR TITLE
Import IdentityOperator from SciMLOperators in Core tests

### DIFF
--- a/test/Core/traits.jl
+++ b/test/Core/traits.jl
@@ -1,13 +1,14 @@
 #
 using LinearSolve, LinearAlgebra, Test
 using LinearSolve: _isidentity_struct
+using SciMLOperators: IdentityOperator
 
 N = 4
 
 @testset "Traits" begin
     @test _isidentity_struct(I)
     @test _isidentity_struct(1.0 * I)
-    @test _isidentity_struct(SciMLBase.IdentityOperator(N))
+    @test _isidentity_struct(IdentityOperator(N))
     @test !_isidentity_struct(2.0 * I)
     @test !_isidentity_struct(rand(N, N))
     @test !_isidentity_struct(Matrix(I, N, N))


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- Import `IdentityOperator` directly from its owning package, SciMLOperators, in `test/Core/traits.jl`.
- Exercise the existing `_isidentity_struct` regression assertion with that owner import instead of reaching through `SciMLBase.IdentityOperator`.
- Keep the change test-only; LinearSolve already directly depends on SciMLOperators.

## Root cause

SciMLBase commit `b9c3507a2670fae804bf627ca32354efeee8dc15` (#1472) removed the blanket SciMLOperators re-export. Its parent, `7b806c50a9e0419d525374d8b716aa51918876b8`, still exposes `SciMLBase.IdentityOperator`; the first-bad commit does not. SciMLBase #1476 explicitly keeps the SciMLOperators names dropped because SciMLOperators owns and documents them.

SciMLOperators v1.25.1 publicly exports `IdentityOperator`, provides its docstring, and renders it in `docs/src/premade_operators.md`, so the test can use the owner API directly.

## Verification

- The unchanged current-main `GROUP=Core` harness is currently masked earlier by the open #1127 `FunctionOperator` regression.
- On a detached current-main + #1127 validation stack with SciMLBase v3.40.1, the official Core harness passed `Default Alg Tests` 109/109 and `ForwardDiff Overloads` 128/128, then reproduced `Traits` as 5 passes and one `UndefVarError` at `SciMLBase.IdentityOperator`.
- Focused fixed test: `Traits` 6/6.
- On the same validation-only stack with this patch, the complete official `GROUP=Core` harness passed through `SpecializingFactorizations`.
- Whole-repository Runic check exited 0.
- `git diff --check` exited 0.

#1127 is present only in the detached validation stack so the harness can reach Traits; this PR contains only the `IdentityOperator` owner-import correction.
