### PR TITLE
Use SciMLOperators as the operator API owner

### DIFF
--- a/ext/LinearSolveCUDAExt.jl
+++ b/ext/LinearSolveCUDAExt.jl
@@ -11,7 +11,6 @@ using LinearSolve: LinearSolve, is_cusparse, defaultalg, cudss_loaded, DefaultLi
     CUDAOffload32MixedLUFactorization,
     SparspakFactorization, KLUFactorization, UMFPACKFactorization, LinearVerbosity
 using LinearSolve.LinearAlgebra, LinearSolve.SciMLBase, LinearSolve.ArrayInterface
-using SciMLBase: AbstractSciMLOperator
 
 LinearSolve.usecuda(x::Nothing) = CUDACore.functional()
 

--- a/ext/LinearSolveMetalExt.jl
+++ b/ext/LinearSolveMetalExt.jl
@@ -2,7 +2,6 @@ module LinearSolveMetalExt
 
 using Metal, LinearSolve
 using LinearAlgebra, SciMLBase
-using SciMLBase: AbstractSciMLOperator
 using LinearSolve: ArrayInterface, MKLLUFactorization, MetalOffload32MixedLUFactorization,
     @get_cacheval, LinearCache, SciMLBase, OperatorAssumptions, LinearVerbosity
 

--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -55,7 +55,7 @@ end
 
 function LinearSolve.init_cacheval(
         alg::RFLUFactorization,
-        A::Union{AbstractSparseArray, LinearSolve.SciMLOperators.AbstractSciMLOperator}, b, u, Pl, Pr,
+        A::Union{AbstractSparseArray, AbstractSciMLOperator}, b, u, Pl, Pr,
         maxiters::Int,
         abstol, reltol, verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
     )

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -15,11 +15,11 @@ using LinearAlgebra: LinearAlgebra, BlasInt, LU, Adjoint, BLAS, Bidiagonal, Bunc
     cholesky, cholesky!, diagind, dot, inv, ldiv!, ldlt!, lu, lu!, mul!,
     norm,
     qr, qr!, svd, svd!
-using SciMLBase: SciMLBase, LinearAliasSpecifier, AbstractSciMLOperator,
+using SciMLBase: SciMLBase, LinearAliasSpecifier,
     init, solve!, reinit!, solve, ReturnCode, LinearProblem
 using SciMLOperators: SciMLOperators, AbstractSciMLOperator, IdentityOperator,
     MatrixOperator,
-    has_ldiv!, issquare, has_concretization
+    has_ldiv!, issquare
 using SciMLLogging: SciMLLogging, @SciMLMessage, verbosity_to_int,
     AbstractVerbositySpecifier, AbstractVerbosityPreset,
     Silent, InfoLevel, WarnLevel, MessageLevel, None, Minimal, Standard, Detailed, All


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- remove the stale root `has_concretization` import
- import `AbstractSciMLOperator` only through its owner, SciMLOperators
- use the already imported owner type in `LinearSolveSparseArraysExt`
- remove unused non-owner `AbstractSciMLOperator` imports from the CUDA and Metal extensions

## Dependency boundary

SciMLBase commit `b9c3507a` (#1472) removed `@reexport using SciMLOperators`. A fresh current-main checkout with local SciMLBase 3.40.1 reproduced exactly two ExplicitImports errors: the stale `has_concretization` root import and `LinearSolve.SciMLOperators.AbstractSciMLOperator` accessed through a non-owner in the sparse extension.

SciMLOperators 1.25.1 is the declaring owner. Runtime checks confirm `AbstractSciMLOperator` is public and `has_concretization` is exported; both have docstrings and rendered `docs/src/interface.md` entries.

## Verification

- unchanged main, local SciMLBase 3.40.1: reproduced 18 passes, 2 ExplicitImports errors, and 2 existing broken cases
- fixed `GROUP=QA`, local SciMLBase 3.40.1: passed (110 passes, 10 existing broken cases across QA/JET; allocation sets 48/48 and 8/8)
- fixed `GROUP=QA`, registered-current SciMLBase 3.39.1: passed with the same counts
- owner-clean `GROUP=Core`: 1,580 top-level assertions passed before the independent current-main `FunctionOperator` error owned by draft #1127; relevant sparse sets passed, including re-solve 133/133, SupernodalLU 72/72, sparse-vector RHS 12/12, and nonstructural zeros 141/141
- official GPU environment: `LinearSolveCUDAExt` compiled and loaded successfully; no GPU runtime test was claimed on this host
- Runic on all changed files and the full repository: passed
- `git diff --check`: passed

## Independent current-main prerequisites

- #1127 owns the `FunctionOperator` Core failure exposed by SciMLBase 3.40.1
- #1124 owns the two unchanged `thr` spell-check findings on current main

No MKL/JET changes or QA suppressions are included.