### PR TITLE
Release 5.4.0 so the ForwardDiff extension issquare fix ships

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.3.0"
+version = "5.4.0"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Problem

The newest registered LinearSolve, v5.3.0, is broken against SciMLBase >= 3.40.0. Any `solve` of a `LinearProblem` with `ForwardDiff.Dual` entries throws:

```
ERROR: UndefVarError: `issquare` not defined in `LinearSolveForwardDiffExt`
Hint: a global variable of this name also exists in SciMLOperators.
Stacktrace:
 [1] solve(::LinearProblem{Nothing, true, Matrix{ForwardDiff.Dual{...}}, ...}, ::Nothing)
   @ LinearSolveForwardDiffExt ~/.julia/packages/LinearSolve/Jvqzc/ext/LinearSolveForwardDiffExt.jl:335
```

Root cause: `LinearSolveForwardDiffExt` used `issquare` unqualified. It resolved only because `using SciMLBase` inside the extension pulled it in via SciMLBase's `@reexport using SciMLOperators`. SciMLBase v3.40.0 removed that re-export (it now goes through SciMLOperators as the owner of the operator API), so the name disappeared from the extension's scope.

This is already fixed on master by f1908b92 (#1125), which adds `using SciMLOperators: issquare` to the extension. The problem is that master still carries `version = "5.3.0"` — the same version already in the General registry — so the fix is not installable by anyone.

## What this PR does

Bumps the version to 5.4.0 so the fix can be registered. Minor rather than patch because master has also gained the TriangularSolve-backed `LinearSolveRecursiveFactorizationExt` (new weakdep + extension trigger) and the SupernodalLU work since v5.3.0.

## Verification

Minimal reproduction (Julia 1.12.4):

```julia
using LinearSolve, ForwardDiff
A = [ForwardDiff.Dual(2.0, 1.0) 1.0; 1.0 3.0]
b = [ForwardDiff.Dual(1.0, 0.0), 2.0]
solve(LinearProblem(A, b))
```

- LinearSolve v5.3.0 (registered) + SciMLBase v3.41.0 -> `UndefVarError: issquare not defined in LinearSolveForwardDiffExt`
- LinearSolve v5.3.0 (registered) + SciMLBase v3.39.1 pinned -> works (`Dual{Nothing}(0.2,-0.12), Dual{Nothing}(0.6,0.04)`), confirming SciMLBase 3.40.0 is the trigger
- LinearSolve master (this branch) + SciMLBase v3.41.0 -> works, same values

`test/Core/forwarddiff_overloads.jl` run against this branch with SciMLBase v3.41.0 passes (exit code 0), including `ForwardDiff square-system initialization`, `DualLinearCache` reuse/setu!/partials-validity, sparse, PureKLU and SupernodalLU dual cases.

Downstream impact: this is what makes `SciML/PreallocationTools.jl` `test/core_nesteddual.jl` error on unmodified master today (`DiffCache Nested Duals`), since it solves stiff ODEs under nested ForwardDiff.

## Follow-up worth considering

v5.3.0 is broken in place for every user who resolves SciMLBase >= 3.40. A retroactive `[SciMLBase]` compat cap of `3.39` on LinearSolve 5.3.0 in the General registry would stop new installs from landing on the broken combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yb5kCpT5SRzTrhppKSh1n7
