### PR TITLE
Import FunctionOperator from its owner in Core tests

### DIFF
--- a/test/Core/default_algs.jl
+++ b/test/Core/default_algs.jl
@@ -1,4 +1,5 @@
 using LinearSolve, RecursiveFactorization, LinearAlgebra, SparseArrays, Test
+using SciMLOperators: FunctionOperator
 
 @test LinearSolve.defaultalg(nothing, zeros(3)).alg === LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
 prob = LinearProblem(rand(3, 3), rand(3))


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Problem

`GROUP=Core` fails on `main` in the "Default Alg Tests" safetestset:

```
Default Alg Tests: Error During Test at .../SafeTestsets.jl:30
  Got exception outside of a @test
  LoadError: UndefVarError: `FunctionOperator` not defined in `Main.var"##Default Alg Tests#292"`
  Hint: a global variable of this name also exists in SciMLOperators.
  Stacktrace:
   [1] top-level scope
     @ .../LinearSolve.jl/test/Core/default_algs.jl:167
```

`test/Core/default_algs.jl` calls `FunctionOperator(...)` at lines 167, 179 and 191 but only does
`using LinearSolve, RecursiveFactorization, LinearAlgebra, SparseArrays, Test`.

## Root cause (not a LinearSolve commit)

`git bisect` over LinearSolve does not find a culprit — the name was never provided by LinearSolve itself.
`FunctionOperator` reached the test scope through `@reexport using SciMLBase` (src/LinearSolve.jl:94) because
SciMLBase in turn did `@reexport using SciMLOperators`. That re-export was removed by
SciML/SciMLBase.jl@b9c3507a2670fae804bf627ca32354efeee8dc15 ("Make strict QA owner-contract clean", SciML/SciMLBase.jl#1472),
which shipped in **SciMLBase v3.40.0**. LinearSolve's compat is `SciMLBase = "3.33"`, so the failure appeared
purely from a dependency upgrade.

Evidence (all run locally):

```
SciMLBase 3.33.1 exports FunctionOperator: true
SciMLBase 3.35.2 exports FunctionOperator: true
SciMLBase 3.37.0 exports FunctionOperator: true
SciMLBase 3.39.1 exports FunctionOperator: true
SciMLBase 3.40.0 exports FunctionOperator: false
SciMLBase 3.41.0 exports FunctionOperator: false
```

```
LinearSolve@9443cb2a (pre-#1130) with SciMLBase 3.41.0 -> FunctionOperator in Main: false
LinearSolve@main       with SciMLBase 3.39.1 -> FunctionOperator in Main: true
```

So neither #1129 nor #1130 introduced it; those PRs were fixing other names hit by the same upstream change.
`FunctionOperator` was simply the next one to be missed.

## Fix

```julia
using LinearSolve, RecursiveFactorization, LinearAlgebra, SparseArrays, Test
using SciMLOperators: FunctionOperator
```

I swept every name that SciMLBase v3.39.1 exported and v3.41.0 no longer does (36 names, essentially the
SciMLOperators surface: `MatrixOperator`, `IdentityOperator`, `WOperator`, `cache_operator`, `issquare`,
`update_coefficients!`, ...) against all of `test/`, `src/`, `ext/`. `FunctionOperator` in
`test/Core/default_algs.jl` was the only remaining unqualified use; every other occurrence in `test/` already
has an explicit `using SciMLOperators: ...` (`test/Core/basictests.jl:2-3`, `test/Core/traits.jl:4`,
`test/Core/default_algs.jl:360`), and `src/`/`ext/` import from SciMLOperators directly.

## Local verification

`julia --project=<env> test/Core/default_algs.jl` on this branch (env = LinearSolve dev'd + RecursiveFactorization,
SciMLOperators, StableRNGs, Test, LinearAlgebra, SparseArrays, Random; SciMLBase v3.41.0):

```
Test Summary:                     | Pass  Total   Time
Sparse Float32 with Int64 indices |    5      5  12.8s
Test Summary:                     | Pass  Total  Time
Sparse Float32 with Int32 indices |    5      5  8.5s
Test Summary:                        | Pass  Total   Time
Sparse ComplexF32 with Int64 indices |    5      5  13.9s
Test Summary:                        | Pass  Total  Time
Sparse ComplexF32 with Int32 indices |    5      5  8.8s
EXIT=0
```

Same command on unmodified `main` errors at `default_algs.jl:167` with the `UndefVarError` above.

A full `GROUP=Core julia --project=. -e 'using Pkg; Pkg.test()'` run is in progress; I will post the result as a
comment when it finishes.

Runic formatting checked on the touched file (`Runic.main(["--check", "test/Core/default_algs.jl"])` -> exit 0).
