### PR TITLE
Fix two JET runtime dispatches that only show up on Julia LTS

### DIFF
--- a/src/KLU/klu.jl
+++ b/src/KLU/klu.jl
@@ -270,70 +270,80 @@ function Base.propertynames(::AbstractKLUFactorization, private::Bool = false)
     end
 end
 
+function _symbolic_struct(klu::AbstractKLUFactorization{Tv, Ti}) where {Tv <: KLUTypes, Ti <: KLUITypes}
+    symptr = getfield(klu, :(_symbolic))
+    symptr == C_NULL &&
+        throw(ArgumentError("This KLUFactorization has not yet been analyzed. Try `klu_analyze!`."))
+    return if Ti == Int64
+        unsafe_load(Ptr{klu_l_symbolic}(symptr))
+    else
+        unsafe_load(Ptr{klu_symbolic}(symptr))
+    end
+end
+
+function _numeric_struct(klu::AbstractKLUFactorization{Tv, Ti}) where {Tv <: KLUTypes, Ti <: KLUITypes}
+    numptr = getfield(klu, :(_numeric))
+    numptr == C_NULL &&
+        throw(ArgumentError("This KLUFactorization has not yet been factored. Try `klu_factor!`."))
+    return if Ti == Int64
+        unsafe_load(Ptr{klu_l_numeric}(numptr))
+    else
+        unsafe_load(Ptr{klu_numeric}(numptr))
+    end
+end
+
 function getproperty(
         klu::AbstractKLUFactorization{Tv, Ti},
         s::Symbol
     ) where {Tv <: KLUTypes, Ti <: KLUITypes}
     # Forwards to the numeric struct:
     if s ∈ (:lnz, :unz, :nzoff)
-        klu._numeric == C_NULL &&
-            throw(ArgumentError("This KLUFactorization has not yet been factored. Try `klu_factor!`."))
-        return getproperty(klu.numeric, s)
+        return getproperty(_numeric_struct(klu), s)
     end
     if s ∈ (:nblocks, :maxblock)
-        klu._symbolic == C_NULL &&
-            throw(ArgumentError("This KLUFactorization has not yet been analyzed. Try `klu_analyze!`."))
-        return getproperty(klu.symbolic, s)
+        return getproperty(_symbolic_struct(klu), s)
     end
     if s === :symbolic
-        klu._symbolic == C_NULL &&
-            throw(ArgumentError("This KLUFactorization has not yet been analyzed. Try `klu_analyze!`."))
-        if Ti == Int64
-            return unsafe_load(Ptr{klu_l_symbolic}(klu._symbolic))
-        else
-            return unsafe_load(Ptr{klu_symbolic}(klu._symbolic))
-        end
+        return _symbolic_struct(klu)
     end
     if s === :numeric
-        klu._numeric == C_NULL &&
-            throw(ArgumentError("This KLUFactorization has not yet been factored. Try `klu_factor!`."))
-        if Ti == Int64
-            return unsafe_load(Ptr{klu_l_numeric}(klu._numeric))
-        else
-            return unsafe_load(Ptr{klu_numeric}(klu._numeric))
-        end
+        return _numeric_struct(klu)
     end
     # Non-overloaded parts:
     if s ∉ (:L, :U, :F, :p, :q, :R, :Rs, :(_L), :(_U), :(_F))
         return getfield(klu, s)
     end
-    # Factor parts:
+    # Factor parts: the sizes come from `_numeric_struct` rather than from
+    # `klu.lnz` etc., because reading them back through this same `getproperty`
+    # is a self-recursive call that inference abandons — the resulting `Any`
+    # sizes make the `_extract!` keyword calls below uninferable.
+    n = getfield(klu, :n)
     if s === :(_L)
-        lnz = Int(klu.lnz)
-        Lp = Vector{Ti}(undef, klu.n + 1)
+        lnz = Int(_numeric_struct(klu).lnz)
+        Lp = Vector{Ti}(undef, n + 1)
         Li = Vector{Ti}(undef, lnz)
         Lx = Vector{Float64}(undef, lnz)
         Lz = Tv == Float64 ? C_NULL : Vector{Float64}(undef, lnz)
         _extract!(klu; Lp, Li, Lx, Lz)
         return Lp, Li, Lx, Lz
     elseif s === :(_U)
-        unz = Int(klu.unz)
-        Up = Vector{Ti}(undef, klu.n + 1)
+        unz = Int(_numeric_struct(klu).unz)
+        Up = Vector{Ti}(undef, n + 1)
         Ui = Vector{Ti}(undef, unz)
         Ux = Vector{Float64}(undef, unz)
         Uz = Tv == Float64 ? C_NULL : Vector{Float64}(undef, unz)
         _extract!(klu; Up, Ui, Ux, Uz)
         return Up, Ui, Ux, Uz
     elseif s === :(_F)
-        fnz = Int(klu.nzoff)
+        fnz = Int(_numeric_struct(klu).nzoff)
         # We often don't have an F, so create the right vectors for an empty SparseMatrixCSC
         if fnz == 0
-            Fp = zeros(Ti, klu.n + 1)
+            Fp = zeros(Ti, n + 1)
             Fi = Vector{Ti}()
             Fx = Vector{Float64}()
             Fz = Tv == Float64 ? C_NULL : Vector{Float64}()
         else
-            Fp = Vector{Ti}(undef, klu.n + 1)
+            Fp = Vector{Ti}(undef, n + 1)
             Fi = Vector{Ti}(undef, fnz)
             Fx = Vector{Float64}(undef, fnz)
             Fz = Tv == Float64 ? C_NULL : Vector{Float64}(undef, fnz)
@@ -360,22 +370,25 @@ function getproperty(
         end
         return Fp, Fi, Fx, Fz
     end
-    if s ∈ (:q, :p, :R, :Rs)
-        if s === :Rs
-            out = Vector{Float64}(undef, klu.n)
-        elseif s === :R
-            out = Vector{Ti}(undef, klu.nblocks + 1)
-        else
-            out = Vector{Ti}(undef, klu.n)
-        end
-        # This tuple construction feels hacky, there's a better way I'm sure.
-        s === :q && (s = :Q)
-        s === :p && (s = :P)
-        _extract!(klu; NamedTuple{(s,)}((out,))...)
-        if s ∈ (:Q, :P, :R)
-            increment!(out)
-        end
-        return out
+    # Each branch names its keyword literally: splatting a `NamedTuple{(s,)}`
+    # built from a non-constant `s` makes the keyword call uninferable, and the
+    # `pairs(::NamedTuple)` eltype computation it lands in dispatches at runtime.
+    if s === :Rs
+        Rs = Vector{Float64}(undef, n)
+        _extract!(klu; Rs)
+        return Rs
+    elseif s === :R
+        R = Vector{Ti}(undef, Int(_symbolic_struct(klu).nblocks) + 1)
+        _extract!(klu; R)
+        return increment!(R)
+    elseif s === :q
+        Q = Vector{Ti}(undef, n)
+        _extract!(klu; Q)
+        return increment!(Q)
+    elseif s === :p
+        P = Vector{Ti}(undef, n)
+        _extract!(klu; P)
+        return increment!(P)
     end
     return if s ∈ (:L, :U, :F)
         if s === :L

--- a/src/SupernodalLU/solve.jl
+++ b/src/SupernodalLU/solve.jl
@@ -261,6 +261,16 @@ end
 # per solve for a residual change of ~1.5e-15 -> 7e-16.
 _auto_refine(F::SupernodalLUFactor) = F.nperturbed > 0 ? 3 : 0
 
+# Dispatch on the `refine` type rather than branching on its value: a value
+# branch leaves `Int(refine::Symbol)` reachable, which is both a runtime
+# dispatch and a MethodError instead of a usable message for a bad symbol.
+_refine_steps(::SupernodalLUFactor, refine::Integer) = Int(refine)
+function _refine_steps(F::SupernodalLUFactor, refine::Symbol)
+    refine === :auto ||
+        throw(ArgumentError("`refine` must be `:auto` or an integer number of steps"))
+    return _auto_refine(F)
+end
+
 """
     solve!(x, F::SupernodalLUFactor, b; refine=:auto) -> x
     solve(F::SupernodalLUFactor, b; refine=:auto) -> x
@@ -277,7 +287,7 @@ function solve!(
         x::AbstractVector{Tv}, F::SupernodalLUFactor{Tv}, b::AbstractVector;
         refine::Union{Symbol, Integer} = :auto
     ) where {Tv}
-    nref = refine === :auto ? _auto_refine(F) : Int(refine)
+    nref = _refine_steps(F, refine)
     _solve_once!(x, F, b)
     if nref > 0
         r = F.ir_r
@@ -301,7 +311,7 @@ function solve!(
         refine::Union{Symbol, Integer} = :auto
     ) where {Tv}
     size(X) == size(B) || throw(DimensionMismatch("X and B sizes differ"))
-    nref = refine === :auto ? _auto_refine(F) : Int(refine)
+    nref = _refine_steps(F, refine)
     if nref == 0
         return _solve_once!(X, F, B)
     end

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -187,6 +187,23 @@ end
         @test X * solve!(cache) ≈ b1
     end
 
+    @testset "KLU factor parts" begin
+        KLU = Base.get_extension(LinearSolve, :LinearSolveSparseArraysExt).KLU
+        # Block-triangular so the off-diagonal `F` part is non-empty
+        Abt = sparse([rand(3, 3) + 3I rand(3, 3); zeros(3, 3) rand(3, 3) + 3I])
+        for At in (sparse(A / 1), Abt)
+            K = KLU.klu(At)
+            @test (K.Rs .\ At)[K.p, K.q] ≈ K.L * K.U + K.F
+            @test sort(K.p) == 1:size(At, 1)
+            @test sort(K.q) == 1:size(At, 1)
+            @test length(K.R) == K.nblocks + 1
+            @test K.R[1] == 1
+            @test K.R[end] == size(At, 1) + 1
+        end
+        # unfactored handles still report what is missing
+        @test_throws ArgumentError KLU.KLUFactorization(sparse(A / 1)).lnz
+    end
+
     @testset "PureKLU Factorization" begin
         A1 = sparse(A / 1)
         b1 = rand(n)

--- a/test/Core/supernodal_lu.jl
+++ b/test/Core/supernodal_lu.jl
@@ -97,6 +97,12 @@ end
     Fp = SNLU.snlu(Ap; matching = false, check = false)
     @test SNLU.nperturbed(Fp) > 0
     @test SNLU._auto_refine(Fp) == 3
+    # `refine` resolves by dispatch, so an unknown symbol says what is accepted
+    # instead of reaching `Int(::Symbol)`
+    @test SNLU._refine_steps(Fp, 2) == 2
+    @test SNLU._refine_steps(Fp, :auto) == 3
+    bp = randn(size(Ap, 1))
+    @test_throws ArgumentError SNLU.solve!(similar(bp), Fp, bp; refine = :bogus)
 end
 
 @testset "residual check does not allocate a work vector" begin


### PR DESCRIPTION
**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

`GROUP=QA` fails on Julia LTS (1.10.11) while passing on 1.12.4. Two of the JET
assertions in `test/qa/jet.jl` report runtime dispatch on 1.10 only. Both are
real inference problems in main-package code that 1.12 optimizes away.

## Reproduction (pristine `main`, b6d3f824)

```
GROUP=QA ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
```

```
JET Tests for Sparse Factorizations: JET-test failed at test/qa/jet.jl:136
  Expression: JET.@test_opt solve(prob_sparse, KLUFactorization())
  ... kwcall(::NamedTuple{…}, ::typeof(KLU._extract!), klu::...) @ src/KLU/klu.jl:246
  ... pairs(nt::NamedTuple) -> eltype -> _compute_eltype -> promote_typejoin -> typejoin
      runtime dispatch detected: Base.UnionAll(%403::Any, %405::Any)::Any

JET Tests for SupernodalLU: JET-test failed at test/qa/jet.jl:277
  Expression: JET.@test_opt target_modules = (SNLU_MOD,) SNLU_MOD.solve!(x_snlu, F_snlu, b_snlu)
  ... solve!(...; refine::Symbol) @ src/SupernodalLU/solve.jl:280
      runtime dispatch detected: LinearSolve.SupernodalLU.Int(refine::Symbol)

Test Summary: | Pass  Fail  Broken  Total   Time
JET Tests     |   19     2      21     42  48.9s
```

## Bisect

* SupernodalLU: the `Int(refine::Symbol)` dispatch has been present since
  https://github.com/SciML/LinearSolve.jl/commit/6df384dc (#1102, the commit that
  added `src/SupernodalLU/`) — verified by running the current assertion against
  each of 6df384dc / 9e211947 / cbfd6b7c / ae3cf086 on 1.10, all report it. The
  *test* that exposes it was added by
  https://github.com/SciML/LinearSolve.jl/commit/ae3cf086 (#1114), which was
  verified on 1.12 only.
* KLU: `git bisect` over `36c29c1c..b6d3f824` on 1.10 (running each commit's own
  `test/qa/jet.jl`) → first bad commit
  https://github.com/SciML/LinearSolve.jl/commit/45944595 (#1083), which dropped
  the `broken = true` flag from `JET.@test_opt solve(prob_sparse, KLUFactorization())`
  ("The KLU JET optimization test now passes with the cache dropped from the
  solution, so its broken flag is removed") — true on 1.12, not on 1.10.

## Fixes

**`src/SupernodalLU/solve.jl`** — `solve!` resolved `refine` by value:

```julia
nref = refine === :auto ? _auto_refine(F) : Int(refine)
```

With `refine::Union{Symbol, Integer}` that leaves `Int(::Symbol)` reachable, which
is both a runtime dispatch and a `MethodError` (rather than a usable message) for
any symbol other than `:auto`. Replaced by `_refine_steps`, which dispatches on the
argument type and throws an `ArgumentError` naming what `refine` accepts.

**`src/KLU/klu.jl`** — two problems in `getproperty`, both feeding the same
uninferable keyword call into `_extract!`:

1. `_extract!(klu; NamedTuple{(s,)}((out,))...)` builds the keyword `NamedTuple`
   from a non-constant symbol. Each branch now names its keyword literally.
2. The extraction sizes were read back through the same `getproperty`
   (`klu.lnz`, `klu.n`, `klu.nblocks`), a self-recursive call inference abandons —
   the resulting `Any` sizes make the `NamedTuple` non-concrete even in the
   literal-keyword branches. New `_numeric_struct` / `_symbolic_struct` helpers
   load the underlying structs directly (and absorb the duplicated null checks);
   `n` is read with `getfield`.

A non-concrete keyword `NamedTuple` sends `pairs(::NamedTuple)` through
`typejoin` at runtime, which is what JET reported.

New tests: `test/Core/basictests.jl` gains a "KLU factor parts" testset checking
the reconstruction identity `(K.Rs .\ A)[K.p, K.q] == K.L * K.U + K.F` (with a
block-triangular matrix so `F` is non-empty), the `R` block pointers, and the
unfactored-handle `ArgumentError`; `test/Core/supernodal_lu.jl` covers
`_refine_steps` and the new `ArgumentError`. All the KLU factor-part outputs
(`p`, `q`, `R`, `Rs`, `L`, `U`, `F`, solves) are byte-identical before and after
this change on 1.10.

## Local verification

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'`, run on this branch:

**Julia 1.10.11** (`~/.juliaup/bin/julia +1.10`), before → after:

```
before: JET Tests | 19  2  21  42  48.9s      (Pass Fail Broken Total)
after:  JET Tests | 20  1  21  42  48.7s
```

```
Test Summary:                                                    | Pass  Fail  Broken  Total   Time
JET Tests                                                        |   20     1      21     42  48.7s
  JET Tests for Dense Factorizations                             |    3             6      9   2.3s
  JET Tests for Extension Factorizations                         |    1             2      3   0.1s
  JET Tests for Sparse Factorizations                            |          1       2      3   1.4s
  JET Tests for Krylov Methods                                   |                  3      3   1.5s
  JET Tests for Default Solver                                   |                  2      2  22.1s
  JET Tests for creating Dual solutions                          |    1                    1   0.4s
  JET Tests for default algs with DualLinear Problems            |                  2      2   0.3s
  solve!(cache) returns concrete LinearSolution — default solver |    2                    2   1.7s
  solve!(cache) is concrete for each algorithm                   |    8             2     10   0.1s
  JET Tests for SupernodalLU                                     |    5             2      7   0.2s
```

`JET Tests for SupernodalLU` goes 4 pass / 1 fail → 5 pass / 0 fail. The one
remaining failure is `JET Tests for Sparse Factorizations`, discussed below.

**Julia 1.12.4** (plain `julia`) — green:

```
Test Summary:     | Pass  Broken  Total     Time
Quality Assurance |   20       2     22  1m11.0s
Test Summary: | Pass  Broken  Total     Time
JET Tests     |   34       8     42  1m06.5s
Test Summary: | Pass  Total     Time
Allocation QA |   48     48  1m02.3s
Test Summary:              | Pass  Total   Time
SupernodalLU Allocation QA |    8      8  18.0s
     Testing LinearSolve tests passed
```

`GROUP=Core` on 1.10 is also green with the patch (no failures anywhere, and the
new KLU testset runs inside "Basic Tests"):

```
Test Summary: | Pass  Total     Time
Basic Tests   |  648    648  4m32.1s
...
     Testing LinearSolve tests passed
```

Also verified on 1.10: `test/Core/supernodal_lu.jl` passes in full, the new KLU
testset passes on both versions, and all KLU factor-part outputs are identical to
`main`.

## Remaining LTS failure — not fixed here, and not papered over

With the fix, `JET.@test_opt solve(prob_sparse, KLUFactorization())` still fails on
1.10, now for a reason that is entirely outside LinearSolve:

```
solve!(cache, alg::KLUFactorization) -> @SciMLMessage -> SciMLLogging.emit_message
  -> SciMLLogging._emit_log -> Base.CoreLogging.current_logger_for_env
  -> env_override_minlevel -> Base.moduleroot -> Base.is_root_module
  -> sprint(show, ::String; sizehint::Integer) -> IOBuffer kwcall
  -> pairs(::NamedTuple) -> typejoin
      runtime dispatch detected: Base.UnionAll(%403::Any, %405::Any)::Any
```

This is a Base 1.10 inference wart on *any* log emission, not something specific to
this solve path:

```
                          Julia 1.10.11   Julia 1.12.4
@warn                     2 report(s)     0 report(s)
current_logger_for_env    2 report(s)     0 report(s)
moduleroot                2 report(s)     0 report(s)
```

(`JET.report_opt` on `f(x) = (x > 0 && @warn("positive"); x)` etc.)

It was previously hidden behind the KLU `_extract!` report: JET deduplicates by the
innermost frame, and both routes end at the same `Base.typejoin` dispatch. Deleting
the two `@SciMLMessage` calls in the KLU `solve!` failure branches makes the
assertion pass on 1.10, which confirms nothing else remains on our side — but the
failure diagnostics obviously stay.

So the KLU assertion cannot pass on LTS without either dropping failure-path logging
or a change in `SciMLLogging`/Base. Per instruction, no `broken = true`, `@test_skip`,
`target_modules` narrowing or assertion removal was added to hide it; the SupernodalLU
assertion is genuinely fixed and the KLU inference bug is genuinely fixed, and the
residual is reported as-is. Say the word and I will open a follow-up on `SciMLLogging`
(e.g. routing `current_logger_for_env` through `invokelatest`, as `_emit_log` already
does for `shouldlog`/`handle_message`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yb5kCpT5SRzTrhppKSh1n7
