### PR TITLE
Fuse the Dual rhs construction instead of materialising p matrices (draft: breaks one existing testset)

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -54,6 +54,10 @@ const DualAbstractLinearProblem = Union{
 
     # Cached intermediate values for calculations
     rhs_list
+    # p x m scratch with the partial index contiguous, used by the fused
+    # xp_linsolve_rhs!. Sized from ∂A's rows, which differ from length(b) for a
+    # non-square system. `nothing` when there is no dense Dual matrix to sweep.
+    partials_scratch
     dual_u0_cache
     primal_u_cache
     primal_b_cache
@@ -174,6 +178,59 @@ function linearsolve_forwarddiff_solve!(cache::DualLinearCache, alg, args...; kw
     cache.linear_cache.u .= cache.primal_u_cache
 
     return sol
+end
+
+# Fused rhs construction for a dense Dual matrix.
+#
+# The generic method below materialises `p` separate derivative matrices via
+# update_partials_list! and then issues `p` mul! calls, i.e. p+1 passes over ∂A.
+# That materialisation exists only so each matvec can reach BLAS gemv, but gemv
+# is BLAS-2, where a plain loop is competitive, so the extra matrices and passes
+# buy nothing.
+#
+# Here rhs_k = ∂b_k - (∂A_k) * u is accumulated for all k in a single sweep of
+# ∂A, reading each element exactly once. The accumulator is a p x m scratch so
+# the innermost loop over the partial index is stride-1; accumulating straight
+# into rhs_list would instead be a strided write across p separate vectors,
+# which measures markedly slower than this.
+function xp_linsolve_rhs!(
+        uu, ∂_A::AbstractMatrix{<:Partials},
+        ∂_b::AbstractVector{<:Partials}, cache::DualLinearCache
+    )
+    rhs_list = cache.rhs_list
+    m, n = size(∂_A)
+    p = length(first(∂_A))
+
+    # Use the cached scratch when it matches, otherwise fall back to a local one.
+    # Never assign to the field: DualLinearCache is @concrete, so its declared
+    # type is fixed at construction.
+    cached = cache.partials_scratch
+    scratch = (cached isa Matrix && size(cached) == (p, m)) ? cached :
+        Matrix{eltype(first(rhs_list))}(undef, p, m)
+
+    @inbounds for i in 1:m
+        bi = ∂_b[i]
+        for k in 1:p
+            scratch[k, i] = bi[k]
+        end
+    end
+    @inbounds for j in 1:n
+        uj = uu[j]
+        for i in 1:m
+            aij = ∂_A[i, j]
+            for k in 1:p
+                scratch[k, i] -= aij[k] * uj
+            end
+        end
+    end
+    @inbounds for k in 1:p
+        rk = rhs_list[k]
+        for i in 1:m
+            rk[i] = scratch[k, i]
+        end
+    end
+
+    return rhs_list
 end
 
 function xp_linsolve_rhs!(
@@ -399,6 +456,18 @@ function __dual_init(
     else
         rhs_list = nothing
     end
+    # Scratch for the fused rhs construction: p rows (partial index) x m columns,
+    # so accumulating all p partials for one row of ∂A is contiguous. Allocated
+    # here rather than on first use because DualLinearCache is @concrete: a field
+    # initialised to `nothing` is typed Nothing and cannot later hold a Matrix.
+    partials_scratch = if isnothing(rhs_list) || !(∂_A isa AbstractMatrix{<:Partials}) ||
+                          _use_direct_dual_solve(alg)
+        # direct-Dual algorithms never build partial right-hand sides
+        nothing
+    else
+        Matrix{eltype(first(rhs_list))}(undef, length(rhs_list), size(∂_A, 1))
+    end
+
     # Use b for restructuring if sizes match (square system), otherwise use u (non-square)
     # This preserves ComponentArray structure from b when possible
     dual_u_init = if length(non_partial_cache.u) == length(b)
@@ -429,6 +498,7 @@ function __dual_init(
         partials_A_list,
         partials_b_list,
         rhs_list,
+        partials_scratch,
         similar(non_partial_cache.u),  # Use u's size, not b's size
         similar(non_partial_cache.u),  # primal_u_cache
         similar(new_b),                # primal_b_cache


### PR DESCRIPTION
Draft. **This branch knowingly fails one existing testset**; the failure is a design question rather than an oversight, and is described below. Filed as a draft so the measurement is available while that gets decided. Follows up #1135.

## What this does

For a dense `Matrix{<:Partials}`, `xp_linsolve_rhs!` transposes the derivative array into `p` separate matrices via `update_partials_list!`, then issues `p` `mul!` calls — `p+1` passes over `∂A`. The materialisation exists only so each matvec can reach BLAS `gemv`. `gemv` is BLAS-2, where a plain loop is competitive, so the `p` matrices and the extra passes buy nothing.

This adds a method for `(::AbstractMatrix{<:Partials}, ::AbstractVector{<:Partials})` that accumulates `rhs_k = ∂b_k - (∂A_k) * u` for all `k` in one sweep of `∂A`, reading each element exactly once.

The accumulator is a `p × m` scratch, partial index first, so the innermost loop is stride-1. Accumulating directly into `rhs_list` instead — a strided write across `p` separate vectors — measures **3.4-6.2× slower** than this on the kernel alone, so the scratch is doing real work rather than just avoiding an allocation.

## Numbers

Whole `solve!`, `Dual{Float64,p}`, min of 400 reps, this branch vs `main` (`339ca246`):

| n | p | main | this branch | speedup |
|---:|---:|---:|---:|---:|
| 29 | 6 | 16.5 µs | 7.5 µs | **2.20×** |
| 29 | 12 | 36.4 µs | 13.6 µs | **2.68×** |
| 50 | 6 | 42.8 µs | 15.2 µs | **2.82×** |
| 50 | 12 | 94.3 µs | 26.9 µs | **3.51×** |

Downstream, on a nested-Dual workload driving this path through a 29-state stiff ODE solve (`Dual{Dual{Float64,6},6}`), one gradient evaluation went 32.9 s → 25.4 s across the two changes in #1135 and this refinement.

## The failing test, and why I have not "fixed" it

`test/Core/forwarddiff_overloads.jl:627` — *"DualLinearCache separate A/b partials validity"* — fails 4 of 12 assertions. It requires `A_partials_valid` and `b_partials_valid` to be `true` after every `solve!`:

```julia
x_p = solve!(cache)
@test getfield(cache, :A_partials_valid)
@test getfield(cache, :b_partials_valid)
```

The fused path never populates `partials_A_list` / `partials_b_list`, so both flags stay `false`.

Setting them `true` anyway would make the suite green while leaving those lists **stale but marked current**, so any other path that later reads them — the `∂_b::Nothing` method, the `SparseMatrixCSC` method, `linearsolve_dual_solution` — would silently consume wrong derivative data. That seemed clearly worse than a visible test failure, so I left it failing.

**The underlying question:** for a dense Dual matrix, the fused kernel makes `partials_A_list`, `partials_b_list` and both validity flags dead state. Retiring them for that path (and rewriting this testset around the new invariant) is the coherent resolution, but it is your call whether that machinery should go, be kept for the other shapes only, or whether you would rather have the fused kernel maintain the lists as a side effect and forgo part of the gain. Happy to implement whichever you prefer.

## Verified

Alongside `main`'s suite, I ran a separate 43-assertion set covering:

* values matching `A \ b` (generic Dual LU) at n = 5, 12, 29, 50 and p = 2, 4, 6, 12
* repeated `solve!` with `A` reassigned between calls
* `b`-only-Dual and `A`-only-Dual problems
* nested Duals (`Dual{outer,p}` over `Dual{inner,p}`)
* `GenericLUFactorization` still taking the direct-Dual path, with no scratch allocated

All pass. The rest of `forwarddiff_overloads.jl` passes; only the validity testset fails.

## Implementation notes

* The scratch is allocated in `__dual_init`, not on first use: `DualLinearCache` is `@concrete`, so a field initialised to `nothing` is typed `Nothing` and cannot later hold a `Matrix`.
* It is sized from `size(∂_A, 1)`, not `length(b)` — those differ for a non-square system, and the sweep is over `∂A`'s rows. The method also falls back to a local scratch if the cached one does not match, so a shape change cannot corrupt anything.
* Skipped entirely when `_use_direct_dual_solve(alg)`, since those algorithms never build partial right-hand sides.
* Sparse and vector/scalar `∂A` shapes are untouched and still route to the existing methods.

## Not covered

Only the dense `(AbstractMatrix, AbstractVector)` shape is fused. The `∂_b::Nothing` and `∂_A::Nothing` methods have the same `p+1`-pass structure and would presumably benefit similarly; I have not measured them. `partials_to_list` and `linearsolve_dual_solution!` have the same array-of-structs to struct-of-arrays pattern and are also untouched.

Environment for all numbers: Julia 1.11.8, `x86_64-linux-gnu`, LinearSolve at `339ca246`, ForwardDiff 1.3.2.
