### PR TITLE
Fall back to pivoted QR when the default hits a rank-deficient least-squares problem

### DIFF
--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -34,6 +34,25 @@ this is only recommended for Float32 matrices. Choose `CudaOffloadLUFactorizatio
 performance on well-conditioned problems, or `CudaOffloadQRFactorization` for better numerical 
 stability on ill-conditioned problems.
 
+#### Non-Square and Least-Squares Systems
+
+A non-square `A` is solved in the least-squares (tall `A`) or minimum-norm
+(wide `A`) sense, matching `A \ b`. The default algorithm uses an unpivoted
+`QRFactorization()` for the overdetermined case because it is up to ~3x cheaper
+than a column-pivoted QR, and automatically re-solves with
+`QRFactorization(ColumnNorm())` when the factorization shows that `A` is
+rank-deficient — an unpivoted QR cannot solve a rank-deficient system, and would
+otherwise return either all zeros with `ReturnCode.Failure` or an overflowing
+solution. The wide case always uses the column-pivoted QR.
+
+If you select an algorithm explicitly, pick one that can handle a rank-deficient
+`A` when that is a possibility: `QRFactorization(ColumnNorm())` (rank-revealing,
+the same rank truncation LAPACK's `xGELSY` and hence `A \ b` uses),
+`SVDFactorization()` (slowest, most robust), or the least-squares Krylov methods
+`KrylovJL_LSMR()` (tall) and `KrylovJL_CRAIGMR()` (wide). An explicitly requested
+`QRFactorization()` reports `ReturnCode.Failure` on an exactly rank-deficient
+matrix rather than falling back.
+
 #### Mixed Precision Methods
 
 For large well-conditioned problems where memory bandwidth is the bottleneck, mixed precision 

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -494,36 +494,44 @@ using the same relative threshold LAPACK's `xGELSY` (and therefore `A \\ b`) use
 to truncate the rank: a factorization is called rank-deficient when the smallest
 `|R[i, i]|` falls at or below `min(m, n) * eps * max|R[i, i]|`.
 
+This scans the `R` diagonal rather than reading a LAPACK `info` because
+unpivoted QR has none to read: `geqrf`/`geqrt` only set `info < 0` for an
+illegal argument and return `info == 0` on an exactly rank-deficient matrix, and
+`QRCompactWY` correspondingly stores only `factors` and `T` with no `issuccess`
+method. That is the same reason `_notsuccessful(::QRCompactWY)` above hand-scans
+for an exact zero on the diagonal; this is that scan with a relative threshold,
+so it also catches a merely negligible entry.
+
 Unpivoted QR does not order the diagonal of `R` by magnitude, so this is a
-heuristic rather than a rank-revealing test — it can miss a deficiency that only
+heuristic rather than a rank-revealing test: it can miss a deficiency that only
 column pivoting would expose (Kahan-style matrices). It exists so the default
 algorithm can keep unpivoted QR on the fast path and only pay for a pivoted
 refactorization when the cheap check says the answer would otherwise be garbage;
-see `_default_qr_solve_with_fallback`. Returns `false` for factorization types
-where the test does not apply (SPQR, GPU factorizations without scalar indexing),
-which leaves the existing behavior untouched.
+see `_default_qr_solve_with_fallback`. Factorization types the test does not
+apply to (SPQR, GPU) return `false` and keep their existing behavior.
 """
 @inline _qr_rank_deficient(F) = false
 
+# GPU factorizations cannot be indexed elementwise. Mirrors the GPU method on
+# `_notsuccessful` above, and is constrained on the same `T` as the scanning
+# method below so that it is strictly more specific (no dispatch ambiguity).
 @inline function _qr_rank_deficient(
-        F::Union{LinearAlgebra.QRCompactWY, LinearAlgebra.QR}
-    )
-    # Dispatch on the storage so GPU factorizations (which cannot be indexed
-    # elementwise) and exotic element types fall through to the `false` method
-    # below without an ambiguity against the type-parameter-constrained methods.
-    return _qr_rank_deficient(F, F.factors)
+        ::LinearAlgebra.QRCompactWY{
+            T, A,
+        }
+    ) where {T <: BLASELTYPES, A <: GPUArraysCore.AnyGPUArray}
+    return false
 end
 
-@inline _qr_rank_deficient(F, factors) = false
-
 @inline function _qr_rank_deficient(
-        F, factors::AbstractMatrix{T}
-    ) where {T <: BLASELTYPES}
-    ArrayInterface.fast_scalar_indexing(factors) || return false
+        F::LinearAlgebra.QRCompactWY{
+            T, A,
+        }
+    ) where {T <: BLASELTYPES, A}
     (m, n) = size(F)
     mn = min(m, n)
     mn == 0 && return false
-    R = view(factors, 1:mn, 1:n)
+    R = view(F.factors, 1:mn, 1:n)
     dmin = typemax(real(T))
     dmax = zero(real(T))
     for x in @view R[diagind(R)]

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -486,6 +486,54 @@ end
 @inline _notsuccessful(F) = hasmethod(LinearAlgebra.issuccess, (typeof(F),)) ?
     !LinearAlgebra.issuccess(F) : false
 
+"""
+    _qr_rank_deficient(F)
+
+Cheap `O(min(m, n))` rank-deficiency test for an *unpivoted* QR factorization,
+using the same relative threshold LAPACK's `xGELSY` (and therefore `A \\ b`) uses
+to truncate the rank: a factorization is called rank-deficient when the smallest
+`|R[i, i]|` falls at or below `min(m, n) * eps * max|R[i, i]|`.
+
+Unpivoted QR does not order the diagonal of `R` by magnitude, so this is a
+heuristic rather than a rank-revealing test — it can miss a deficiency that only
+column pivoting would expose (Kahan-style matrices). It exists so the default
+algorithm can keep unpivoted QR on the fast path and only pay for a pivoted
+refactorization when the cheap check says the answer would otherwise be garbage;
+see `_default_qr_solve_with_fallback`. Returns `false` for factorization types
+where the test does not apply (SPQR, GPU factorizations without scalar indexing),
+which leaves the existing behavior untouched.
+"""
+@inline _qr_rank_deficient(F) = false
+
+@inline function _qr_rank_deficient(
+        F::Union{LinearAlgebra.QRCompactWY, LinearAlgebra.QR}
+    )
+    # Dispatch on the storage so GPU factorizations (which cannot be indexed
+    # elementwise) and exotic element types fall through to the `false` method
+    # below without an ambiguity against the type-parameter-constrained methods.
+    return _qr_rank_deficient(F, F.factors)
+end
+
+@inline _qr_rank_deficient(F, factors) = false
+
+@inline function _qr_rank_deficient(
+        F, factors::AbstractMatrix{T}
+    ) where {T <: BLASELTYPES}
+    ArrayInterface.fast_scalar_indexing(factors) || return false
+    (m, n) = size(F)
+    mn = min(m, n)
+    mn == 0 && return false
+    R = view(factors, 1:mn, 1:n)
+    dmin = typemax(real(T))
+    dmax = zero(real(T))
+    for x in @view R[diagind(R)]
+        a = abs(x)
+        a < dmin && (dmin = a)
+        a > dmax && (dmax = a)
+    end
+    return dmin <= mn * eps(real(T)) * dmax
+end
+
 # Solver Specific Traits
 ## Needs Square Matrix
 """

--- a/src/default.jl
+++ b/src/default.jl
@@ -684,6 +684,11 @@ function _do_qr_fallback(cache::LinearCache, alg, sol, reason::Symbol)
             "LU solve residual check failed, falling back to QR factorization. `A` is potentially ill-conditioned.",
             cache.verbose, :default_lu_fallback
         )
+    elseif reason === :qr_rank_deficient
+        @SciMLMessage(
+            "Unpivoted QR detected a rank-deficient `A`, falling back to column-pivoted QR so the least-squares solution matches `A \\ b`.",
+            cache.verbose, :default_lu_fallback
+        )
     else
         @SciMLMessage(
             "LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.",
@@ -869,6 +874,51 @@ function _default_lu_solve_with_fallback(
 end
 
 """
+    _default_qr_solve_with_fallback(cache::LinearCache, alg::DefaultLinearSolver, sol)
+
+Post-process an unpivoted-QR solve result: if the factorization failed, the
+solution contains NaN/Inf, or the `R` diagonal says `A` is rank-deficient, redo
+the solve with column-pivoted QR. Otherwise return the QR solution directly.
+
+Unpivoted QR is the default for non-square (and for ill-conditioned square)
+dense problems because it is up to ~3x cheaper than `geqp3`, but it cannot solve
+a rank-deficient least-squares problem: the triangular solve divides by a zero
+(or negligible) diagonal entry and returns garbage — all-zeros with
+`ReturnCode.Failure` for an exact zero, an overflowing solution with
+`ReturnCode.Success` for a nearly-zero one (issue #531). Column-pivoted QR
+truncates the rank the same way LAPACK's `xGELSY` does, so the fallback
+reproduces `A \\ b`.
+
+The fallback only triggers for factorizations the check applies to, so sparse
+(SPQR) and GPU defaults keep their current behavior.
+"""
+function _default_qr_solve_with_fallback(
+        cache::LinearCache, alg::DefaultLinearSolver, sol
+    )
+    # `DenseMatrix` (not just "not GPU") because `fell_back_to_qr` reuse on the
+    # next solve routes dense and sparse to different helpers. All of these are
+    # decided by the cache's type, so the branch folds away at compile time.
+    if alg.safetyfallback && cache.cacheval isa DefaultLinearSolverInit &&
+            cache.A isa DenseMatrix && _qr_fallback_pivot(cache.A) isa ColumnNorm
+        if sol.retcode === ReturnCode.Failure
+            return _do_qr_fallback(cache, alg, sol, :qr_rank_deficient)
+        end
+        if sol.retcode === ReturnCode.Success &&
+                (
+                any(!isfinite, sol.u) ||
+                    _qr_rank_deficient(getfield(cache.cacheval, :QRFactorization))
+            )
+            return _do_qr_fallback(cache, alg, sol, :qr_rank_deficient)
+        end
+    end
+    # Use cache directly for type-stable inference (see _do_qr_fallback).
+    return SciMLBase.build_linear_solution(
+        alg, cache.u, nothing, nothing;
+        retcode = sol.retcode, iters = sol.iters, stats = nothing
+    )
+end
+
+"""
     _algchoice_to_alg_with_safety(alg::Symbol)
 
 Like `algchoice_to_alg`, but generates an expression that passes
@@ -963,6 +1013,14 @@ end
                 end
                 sol = SciMLBase.solve!(cache, $inner_alg_expr)
                 _default_lu_solve_with_fallback(cache, alg, sol)
+            end
+        elseif alg == Symbol(DefaultAlgorithmChoice.QRFactorization)
+            # Unpivoted QR (dense non-square, or ill-conditioned square): on a
+            # rank-deficient `A` it cannot produce the least-squares solution, so
+            # redo the solve with column-pivoted QR.
+            newex = quote
+                sol = SciMLBase.solve!(cache, $(algchoice_to_alg(alg)))
+                _default_qr_solve_with_fallback(cache, alg, sol)
             end
         else
             if alg in LinearSolve._SPARSE_ONLY_ALGORITHMS

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -621,6 +621,15 @@ Julia's built in `qr`. Equivalent to calling `qr!(A)`.
   - On sparse matrices, this will use SPQR from SparseArrays
   - On CuMatrix, it will use a CUDA-accelerated QR from CuSolver.
   - On BandedMatrix and BlockBandedMatrix, it will use a banded QR.
+
+With the default `NoPivot()` this is not rank-revealing, so it cannot solve a
+rank-deficient (least-squares) system: it reports `ReturnCode.Failure` when a
+diagonal entry of `R` is exactly zero, and can return an overflowing solution
+when one is merely negligible. Pass `ColumnNorm()` for a rank-revealing
+factorization that truncates the rank the way `A \\ b` does. The default
+algorithm handles this automatically — it starts with the cheaper unpivoted QR
+and re-solves with `QRFactorization(ColumnNorm())` if `A` turns out to be
+rank-deficient.
 """
 struct QRFactorization{P} <: AbstractDenseFactorization
     pivot::P

--- a/test/Core/default_algs.jl
+++ b/test/Core/default_algs.jl
@@ -195,17 +195,23 @@ sol1 = solve(prob)
 sol2 = solve(prob, LinearSolve.KrylovJL_CRAIGMR())
 @test sol1.u == sol2.u
 
-# Default for Underdetermined problem but the size is a long rectangle
+# Default for Underdetermined problem but the size is a long rectangle.
+# `A` is rank-deficient, so the unpivoted-QR default falls back to column-pivoted
+# QR and returns the same least-squares solution as `A \ b` (it used to report
+# `ReturnCode.Failure` with an all-zero `u`).
+# https://github.com/SciML/LinearSolve.jl/issues/531
 A = [
     2.0 1.0
     0.0 0.0
     0.0 0.0
 ]
 b = [1.0, 0.0, 0.0]
-prob = LinearProblem(A, b)
+res = A \ b
+prob = LinearProblem(copy(A), copy(b))
 sol = solve(prob)
 
-@test !SciMLBase.successful_retcode(sol.retcode)
+@test SciMLBase.successful_retcode(sol.retcode)
+@test sol.u ≈ res
 
 ## Show that we cannot select a default alg once by checking the rank, since it might change
 ## later in the cache
@@ -223,15 +229,22 @@ sol = solve!(cache)
 
 @test sol.u ≈ [0.0, 1.0]
 
-cache.A = [
+A_deficient = [
     2.0 1.0
     0.0 0.0
     0.0 0.0
 ]
+# Reference computed up front: `cache.A = X` stores `X` itself and the in-place
+# QR overwrites it.
+res_deficient = A_deficient \ b
+cache.A = copy(A_deficient)
 
 sol = solve!(cache)
 
-@test !SciMLBase.successful_retcode(sol.retcode)
+# The rank dropped between solves; the pivoted-QR fallback handles it in the
+# cache just as it does on a fresh solve.
+@test SciMLBase.successful_retcode(sol.retcode)
+@test sol.u ≈ res_deficient
 
 ## Non-square Sparse Defaults
 # https://github.com/SciML/NonlinearSolve.jl/issues/599

--- a/test/Core/nonsquare.jl
+++ b/test/Core/nonsquare.jl
@@ -95,6 +95,101 @@ prob = LinearProblem(A, b)
 res = A \ b
 @test solve(prob).u ≈ res
 
+# Rank-deficient least squares: the default is unpivoted QR, which cannot solve a
+# rank-deficient system — it used to return all-zeros with `ReturnCode.Failure`
+# (exactly-singular) or an overflowing solution with `ReturnCode.Success`
+# (numerically singular). The default now falls back to column-pivoted QR, which
+# truncates the rank the same way `A \ b` does.
+# Regression test for https://github.com/SciML/LinearSolve.jl/issues/531
+@testset "Rank-deficient least squares" begin
+    @testset "tall, exactly rank-deficient" begin
+        A = rand(10, 4)
+        A[:, 1] .= 0    # a column of all zeros
+        b = rand(10)
+        res = A \ b
+        sol = solve(LinearProblem(copy(A), copy(b)))
+        @test sol.retcode === ReturnCode.Success
+        @test sol.u ≈ res
+        # Column-pivoted QR and SVD reach the same answer directly.
+        @test solve(LinearProblem(copy(A), copy(b)), QRFactorization(ColumnNorm())).u ≈ res
+        @test solve(LinearProblem(copy(A), copy(b)), SVDFactorization()).u ≈ res
+    end
+
+    @testset "tall, rank-deficient by duplicate column" begin
+        A = rand(10, 4)
+        A[:, 3] .= A[:, 2]
+        b = rand(10)
+        sol = solve(LinearProblem(copy(A), copy(b)))
+        @test sol.retcode === ReturnCode.Success
+        @test sol.u ≈ A \ b
+    end
+
+    @testset "tall, numerically rank-deficient" begin
+        # Not exactly singular, so the factorization "succeeds" and the failure is
+        # silent without the rank check.
+        A = rand(10, 4)
+        A[:, 1] .= 1.0e-14 .* A[:, 2]
+        b = rand(10)
+        sol = solve(LinearProblem(copy(A), copy(b)))
+        @test sol.retcode === ReturnCode.Success
+        @test sol.u ≈ A \ b
+        @test all(isfinite, sol.u)
+    end
+
+    @testset "wide, rank-deficient" begin
+        A = rand(3, 6)
+        A[:, 2] .= 0
+        b = rand(3)
+        sol = solve(LinearProblem(copy(A), copy(b)))
+        @test sol.retcode === ReturnCode.Success
+        @test sol.u ≈ A \ b
+    end
+
+    @testset "square but singular" begin
+        A = rand(5, 5)
+        A[:, 3] .= 0
+        b = rand(5)
+        sol = solve(
+            LinearProblem(copy(A), copy(b)),
+            assumptions = OperatorAssumptions(
+                true; condition = OperatorCondition.VeryIllConditioned
+            )
+        )
+        @test sol.retcode === ReturnCode.Success
+        @test sol.u ≈ qr(A, ColumnNorm()) \ b
+    end
+
+    @testset "cache reuse after the pivoted-QR fallback" begin
+        A = rand(10, 4)
+        A[:, 1] .= 0
+        b1 = rand(10)
+        b2 = rand(10)
+        cache = init(LinearProblem(copy(A), copy(b1)))
+        @test solve!(cache).u ≈ A \ b1
+        @test cache.cacheval.fell_back_to_qr
+        # Only `b` changes: the pivoted QR is reused, not the unpivoted one.
+        cache.b = b2
+        @test solve!(cache).u ≈ A \ b2
+        # A fresh full-rank `A` resets the fallback and stays on unpivoted QR.
+        # `cache.A = X` stores `X` itself and the in-place QR overwrites it, so
+        # compute the reference first and hand the cache a copy.
+        A_full = rand(10, 4)
+        res_full = A_full \ b2
+        cache.A = copy(A_full)
+        @test !cache.cacheval.fell_back_to_qr
+        @test solve!(cache).u ≈ res_full
+        @test !cache.cacheval.fell_back_to_qr
+    end
+
+    @testset "full rank does not trigger the fallback" begin
+        A = rand(10, 4)
+        b = rand(10)
+        cache = init(LinearProblem(copy(A), copy(b)))
+        @test solve!(cache).u ≈ A \ b
+        @test !cache.cacheval.fell_back_to_qr
+    end
+end
+
 # Least-squares Krylov solvers with preconditioning: identity-equivalent counting
 # preconditioner verifies Pl/Pr are actually forwarded to Krylov (not silently dropped).
 mutable struct CountingDiagPrec


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #531.

- `defaultalg` picks an unpivoted `QRFactorization` for overdetermined dense systems. It is not rank-revealing, so a rank-deficient `A` returns `cache.u` untouched (all zeros) with `ReturnCode.Failure`, while `A \ b` gives the correct least-squares solution.
- Worse variant not in the issue: with a nearly dependent column, no exact zero shows up on the `R` diagonal and the result is finite, so a wrong answer is returned with a success retcode. `A[:, 1] .= 1e-14 .* A[:, 2]` gives `[4.33e28, -4.33e14, 0.020, 0.305]` where `A \ b` gives `[0.0, 0.809, 0.100, 0.286]`.
- Pivoting unconditionally would fix both but taxes every full-rank solve: `qr!(A, ColumnNorm())` measured 1.5x to 2.8x `qr!(A, NoPivot())` on typical tall-skinny shapes here (1000x100: 2.80 ms vs 7.82 ms).
- Instead, unpivoted QR stays on the fast path and now hooks into the safety-fallback machinery that already exists for LU.
- `_qr_rank_deficient(F)` scans the `R` diagonal in `O(min(m, n))` against `min(m, n) * eps`, the threshold LAPACK's `xGELSY` (and so `A \ b`) uses to truncate the rank. It dispatches on the factorization's storage, so SPQR, GPU, and `Dual` factorizations keep their current behavior.
- The check is a heuristic, since unpivoted QR does not order `diag(R)` by magnitude, and can miss a Kahan-style deficiency. The docstring says so.
- `_default_qr_solve_with_fallback` re-solves with `QRFactorization(ColumnNorm())` on failure, non-finite output, or rank deficiency. It reuses `_do_qr_fallback`, so `A` restoration and `fell_back_to_qr` cache reuse work as they do for LU. Its guards are decided by the cache's type, so the branch folds away at compile time.
- Both the exactly-singular and numerically-singular cases now reproduce `A \ b`, `@inferred solve!` still returns a concrete `LinearSolution`, and full-rank problems never enter the fallback.
- An explicit `QRFactorization()` or `LUFactorization()` still reports `ReturnCode.Failure` on rank-deficient input, matching the conclusion in the issue thread. The `QRFactorization` docstring and `solvers.md` now say so and point at `ColumnNorm()`, `SVDFactorization`, and the least-squares Krylov methods.
- Two assertions in `test/Core/default_algs.jl` encoded the old failure behavior and now assert the corrected result. The second one's purpose (the default alg choice must not bake in a rank check, since rank can change across cache reuses) is unaffected, and it now also covers the fallback firing when rank drops mid-cache.
- New coverage in `test/Core/nonsquare.jl`: tall with a zero column, tall with a duplicated column, tall numerically rank-deficient, wide rank-deficient, square singular under `VeryIllConditioned`, cache reuse across the fallback, and a full-rank case leaving `fell_back_to_qr` unset.
- Full `Core` group passes locally on Julia 1.12.6 (25 testsets, 0 failures).

AI Disclosure: Used Opus 5