### PR TITLE
Enforce needs_square_A at init, and correct the algorithms it was wrong about

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -548,12 +548,44 @@ end
     needs_square_A(alg)
 
 Returns `true` if the algorithm requires a square matrix.
+
+`init` enforces this: an algorithm that returns `true` and is handed a
+non-square `A` throws an `ArgumentError` naming the algorithms that do solve
+least-squares/minimum-norm systems, rather than letting a `DimensionMismatch`
+(or worse) escape from inside the factorization. Anything not listed below falls
+back to the conservative `true`, so a new algorithm is rejected on non-square
+input until it is declared otherwise.
 """
 needs_square_A(::Nothing) = false  # Linear Solve automatically will use a correct alg!
 needs_square_A(alg::SciMLLinearSolveAlgorithm) = true
 for alg in (
+        # Same reason as the `Nothing` method above: by the time `init` runs, an
+        # unspecified algorithm has already been resolved to a
+        # `DefaultLinearSolver`, and the polyalgorithm picks a non-square-capable
+        # algorithm (pivoted QR, sparse column-pivoted QR, or a least-squares
+        # Krylov method) for a non-square `A` itself.
+        :DefaultLinearSolver,
         :QRFactorization, :FastQRFactorization, :NormalCholeskyFactorization,
         :NormalBunchKaufmanFactorization,
+        # Rank-revealing/least-squares capable: `svd` and the column-pivoted
+        # sparse QR both accept a non-square `A` and return the same answer as
+        # `A \ b`. `SparseColumnPivotedQRFactorization` is in fact the default
+        # for non-square sparse systems, so it must not be rejected here.
+        :SVDFactorization, :SparseColumnPivotedQRFactorization,
+        # Rank-revealing column-pivoted QR (`geqp3`): documented to return the
+        # least-squares solution for any shape, including rank-deficient.
+        :SpecializedQRFactorization,
+        # QR-based GPU offloads. These cannot be exercised on a machine without
+        # the corresponding GPU, and a QR is least-squares capable in principle,
+        # so they are declared permissive: enforcing `true` here would newly
+        # reject a shape that may work today.
+        :CudaOffloadQRFactorization, :AMDGPUOffloadQRFactorization,
+        :CudaOffloadFactorization,
+        # A wrapper around a user-supplied factorization: whether a non-square
+        # `A` is allowed depends on `fact_alg`, and the default (`factorize`) as
+        # well as the obvious choices (`qr`, `svd`) all handle it. Leave the
+        # rejection to the wrapped factorization.
+        :GenericFactorization,
     )
     @eval needs_square_A(::$(alg)) = false
 end
@@ -565,8 +597,8 @@ for kralg in (
     @eval needs_square_A(::KrylovJL{$(typeof(kralg))}) = false
 end
 for alg in (
-        :LUFactorization, :FastLUFactorization, :SVDFactorization,
-        :GenericFactorization, :GenericLUFactorization, :SimpleLUFactorization,
+        :LUFactorization, :FastLUFactorization,
+        :GenericLUFactorization, :SimpleLUFactorization,
         :RFLUFactorization, :ButterflyFactorization, :UMFPACKFactorization, :KLUFactorization, :SparspakFactorization,
         :DiagonalFactorization, :CholeskyFactorization, :BunchKaufmanFactorization,
         :CHOLMODFactorization, :LDLtFactorization, :AppleAccelerateLUFactorization,

--- a/src/common.jl
+++ b/src/common.jl
@@ -481,6 +481,35 @@ function _check_batched_rhs_support(alg::DefaultLinearSolver, b::AbstractMatrix)
     return nothing
 end
 
+"""
+    _check_square_A_support(alg, A)
+
+Throw an informative `ArgumentError` at `init` time when a non-square `A` is
+used with an algorithm that requires a square one (see [`needs_square_A`](@ref)).
+
+Without this, a non-square `A` reaches the factorization and fails there, in a
+different way for each algorithm and with no indication of what to use instead:
+`DimensionMismatch: matrix is not square` from LU and Cholesky, `ArgumentError:
+Bunch-Kaufman decomposition is only valid for...`, or `FieldError: type Array has
+no field diag` from `DiagonalFactorization`. Least-squares and minimum-norm
+systems are solved by the default algorithm and by the algorithms named in the
+message.
+"""
+_check_square_A_support(alg, A) = nothing
+function _check_square_A_support(alg::SciMLLinearSolveAlgorithm, A)
+    (needs_square_A(alg) && !issquare(A)) && throw(
+        ArgumentError(
+            "$(nameof(typeof(alg))) requires a square `A`, got $(size(A, 1))x$(size(A, 2)). " *
+                "A non-square system is solved in the least-squares (tall `A`) or " *
+                "minimum-norm (wide `A`) sense by the default algorithm, i.e. " *
+                "`solve(prob)`, or by `QRFactorization(ColumnNorm())`, " *
+                "`SVDFactorization()`, and the least-squares Krylov methods " *
+                "`KrylovJL_LSMR()` (tall) / `KrylovJL_CRAIGMR()` (wide)."
+        )
+    )
+    return nothing
+end
+
 function SciMLBase.init(prob::LinearProblem, alg::SciMLLinearSolveAlgorithm, args...; kwargs...)
     return __init(prob, alg, args...; kwargs...)
 end
@@ -571,6 +600,7 @@ function __init(
     end
 
     _check_batched_rhs_support(alg, b)
+    _check_square_A_support(alg, A)
 
     u0_ = u0 !== nothing ? u0 : __init_u0_from_Ab(A, b)
 

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -1095,10 +1095,13 @@ end
         sol_amg = solve(prob_amg, AlgebraicMultigridJL(), reltol = 1.0e-8)
         @test norm(A_amg * sol_amg.u - b_amg) < 1.0e-8
 
-        # Non-square matrix should throw
+        # Non-square matrix should throw. `needs_square_A(::AlgebraicMultigridJL)`
+        # is true, so this is now rejected at `init` with an `ArgumentError`
+        # naming the least-squares alternatives, rather than reaching the
+        # solver and tripping its `AssertionError`.
         A_rect = sparse([1.0 1.0 0.0; 0.0 1.0 1.0])
         b_rect = [1.0, 1.0]
-        @test_throws AssertionError solve(LinearProblem(A_rect, b_rect), AlgebraicMultigridJL())
+        @test_throws ArgumentError solve(LinearProblem(A_rect, b_rect), AlgebraicMultigridJL())
     end
 end
 

--- a/test/Core/nonsquare.jl
+++ b/test/Core/nonsquare.jl
@@ -95,6 +95,97 @@ prob = LinearProblem(A, b)
 res = A \ b
 @test solve(prob).u ≈ res
 
+# `needs_square_A` is enforced at `init`: an algorithm that requires a square `A`
+# and is handed a non-square one now throws an `ArgumentError` naming the
+# least-squares alternatives, instead of leaking a `DimensionMismatch` (LU,
+# Cholesky), an `ArgumentError` about Bunch-Kaufman validity, or a `FieldError`
+# about `Array` having no `diag` field from deep inside the factorization.
+# Regression test for https://github.com/SciML/LinearSolve.jl/issues/546
+@testset "needs_square_A enforcement" begin
+    A_tall = rand(12, 4)
+    b_tall = rand(12)
+    A_wide = rand(4, 12)
+    b_wide = rand(4)
+    res_tall = A_tall \ b_tall
+
+    @testset "square-only algorithms are rejected" begin
+        for alg in (
+                LUFactorization(), GenericLUFactorization(), SimpleLUFactorization(),
+                CholeskyFactorization(), BunchKaufmanFactorization(),
+                DiagonalFactorization(), LDLtFactorization(),
+            )
+            @test LinearSolve.needs_square_A(alg)
+            # Rejected for both orientations, and at `init` rather than `solve`.
+            @test_throws ArgumentError init(
+                LinearProblem(copy(A_tall), copy(b_tall)), alg
+            )
+            @test_throws ArgumentError solve(
+                LinearProblem(copy(A_tall), copy(b_tall)), alg
+            )
+            @test_throws ArgumentError solve(
+                LinearProblem(copy(A_wide), copy(b_wide)), alg
+            )
+        end
+        # The message names what to use instead.
+        err = try
+            solve(LinearProblem(copy(A_tall), copy(b_tall)), LUFactorization())
+        catch e
+            sprint(showerror, e)
+        end
+        @test occursin("requires a square `A`", err)
+        @test occursin("12x4", err)
+        @test occursin("QRFactorization(ColumnNorm())", err)
+        @test occursin("SVDFactorization()", err)
+    end
+
+    @testset "non-square-capable algorithms are unaffected" begin
+        # These were all marked as needing a square `A` while solving non-square
+        # systems correctly, so the trait had to be corrected before it could be
+        # enforced.
+        for alg in (
+                SVDFactorization(), GenericFactorization(),
+                GenericFactorization(fact_alg = qr), QRFactorization(),
+                QRFactorization(ColumnNorm()), NormalCholeskyFactorization(),
+                KrylovJL_LSMR(),
+            )
+            @test !LinearSolve.needs_square_A(alg)
+            @test solve(LinearProblem(copy(A_tall), copy(b_tall)), alg).u ≈ res_tall
+        end
+    end
+
+    @testset "the default algorithm is never rejected" begin
+        # `solve(prob)` resolves to a `DefaultLinearSolver` before `init` runs, so
+        # the trait must be false for it too or every non-square default solve
+        # would throw.
+        @test !LinearSolve.needs_square_A(
+            LinearSolve.defaultalg(A_tall, b_tall, OperatorAssumptions(false))
+        )
+        @test solve(LinearProblem(copy(A_tall), copy(b_tall))).u ≈ res_tall
+        @test solve(LinearProblem(copy(A_wide), copy(b_wide))).u ≈ A_wide \ b_wide
+
+        A_sparse = sprand(12, 4, 0.7)
+        while rank(Matrix(A_sparse)) < 4
+            A_sparse = sprand(12, 4, 0.7)
+        end
+        b_sparse = rand(12)
+        @test solve(LinearProblem(copy(A_sparse), copy(b_sparse))).u ≈
+            Matrix(A_sparse) \ b_sparse
+        # The sparse non-square default itself must not be rejected either.
+        @test !LinearSolve.needs_square_A(SparseColumnPivotedQRFactorization())
+    end
+
+    @testset "square problems are unaffected" begin
+        A_sq = rand(6, 6)
+        b_sq = rand(6)
+        for alg in (LUFactorization(), CholeskyFactorization(), nothing)
+            A_use = alg isa CholeskyFactorization ? A_sq'A_sq + 6I : A_sq
+            sol = alg === nothing ? solve(LinearProblem(copy(A_use), copy(b_sq))) :
+                solve(LinearProblem(copy(A_use), copy(b_sq)), alg)
+            @test sol.u ≈ A_use \ b_sq
+        end
+    end
+end
+
 # Rank-deficient least squares: the default is unpivoted QR, which cannot solve a
 # rank-deficient system — it used to return all-zeros with `ReturnCode.Failure`
 # (exactly-singular) or an overflowing solution with `ReturnCode.Success`


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #546. Companion to #1139, which fixed the silent-wrong-answer half of the same gap.

- `needs_square_A` is declared and unit-tested but **never consulted anywhere in `src/`**. A non-square `A` therefore reaches the factorization and fails there, differently per algorithm and with no hint of what to use instead: `DimensionMismatch: matrix is not square` (LU, Cholesky), `ArgumentError: Bunch-Kaufman decomposition is only valid for...`, and `FieldError: type Array has no field diag` (`DiagonalFactorization`).
- Adds `_check_square_A_support(alg, A)`, called from `__init` next to the existing `_check_batched_rhs_support`, throwing an `ArgumentError` naming the algorithms that do solve least-squares/minimum-norm systems:
  ```
  ArgumentError: LUFactorization requires a square `A`, got 12x4. A non-square system is
  solved in the least-squares (tall `A`) or minimum-norm (wide `A`) sense by the default
  algorithm, i.e. `solve(prob)`, or by `QRFactorization(ColumnNorm())`, `SVDFactorization()`,
  and the least-squares Krylov methods `KrylovJL_LSMR()` (tall) / `KrylovJL_CRAIGMR()` (wide).
  ```
- Enforcing the trait makes every `true` load-bearing for the first time, so I audited it against a 12x4 dense and a 12x4 sparse system with every loadable extension present. It was wrong in five places, all corrected to `false`:
  - `DefaultLinearSolver`, which an unspecified algorithm is resolved to before `init` runs. A `true` here rejects every non-square default solve; `needs_square_A(::Nothing) = false` only covers the pre-resolution case.
  - `SVDFactorization` and `SparseColumnPivotedQRFactorization`, both of which solve non-square systems and match `A \ b`. The latter is the default for non-square sparse problems, so the trait claimed the default algorithm needed a square `A`.
  - `SpecializedQRFactorization`, a rank-revealing `geqp3` QR documented to return the least-squares solution for any shape including rank-deficient.
  - `GenericFactorization`, a wrapper whose default `fact_alg` and the obvious choices (`qr`, `svd`) all handle non-square input.
- The QR-based GPU offloads (`CudaOffloadQRFactorization`, `AMDGPUOffloadQRFactorization`, `CudaOffloadFactorization`) only inherited `true` from the catch-all and cannot be exercised without the corresponding GPU. A QR is least-squares capable in principle, so they are declared permissive rather than newly rejecting a shape that may work today.
- After these corrections the audit reports no algorithm that claims to be square-only while solving a non-square system, and all nine declared non-square capable algorithms are verified working: `FastQRFactorization`, `GenericFactorization`, `NormalBunchKaufmanFactorization`, `NormalCholeskyFactorization`, `QRFactorization`, `SVDFactorization`, `SparseColumnPivotedQRFactorization`, `SpecializedQRFactorization`, `DefaultLinearSolver`. 33 algorithms genuinely fail on non-square input and correctly keep `true`.
- One existing assertion changes: the rectangular `AlgebraicMultigridJL` test expected the `AssertionError` that escaped from the solver, and now expects the `ArgumentError` from this check.
- New coverage in `test/Core/nonsquare.jl`: square-only algorithms rejected for both tall and wide `A` and at `init` as well as `solve`, the message naming the alternatives, the non-square-capable algorithms still matching `A \ b`, the dense and sparse defaults never being rejected, and square problems unaffected.
- Full `Core` group passes locally on Julia 1.12.6 (29 testsets, 0 failures).

AI Disclosure: Used Opus 5
