### PR TITLE
Resolve the Aqua method ambiguities and drop the QA escape hatch

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -119,6 +119,54 @@ function LinearSolve.init_cacheval(
     return LinearSolve.do_factorization(alg, newA, b, u)
 end
 
+# The method above is specific on `A` (a sparse `Symmetric`/`Hermitian`) but generic
+# on the algorithm, while LinearSolve declares
+# `init_cacheval(::GenericFactorization{typeof(f)}, ::AbstractMatrix, ...)` for each
+# wrapped factorization function -- specific on the algorithm, generic on `A`. Neither
+# is more specific than the other, so every combination is ambiguous. Define the
+# intersections here; a sparse `Symmetric`/`Hermitian` operand takes the sparse path
+# above regardless of which factorization function is wrapped.
+for f in (
+        :(LinearAlgebra.lu), :(LinearAlgebra.lu!),
+        :(LinearAlgebra.qr), :(LinearAlgebra.qr!),
+        :(LinearAlgebra.svd), :(LinearAlgebra.svd!),
+        :(LinearAlgebra.cholesky), :(LinearAlgebra.cholesky!),
+    )
+    @eval function LinearSolve.init_cacheval(
+            alg::GenericFactorization{typeof($f)},
+            A::Union{
+                Hermitian{T, <:SparseMatrixCSC},
+                Symmetric{T, <:SparseMatrixCSC},
+            }, b, u, Pl, Pr,
+            maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
+            assumptions::OperatorAssumptions
+        ) where {T}
+        newA = copy(convert(AbstractMatrix, A))
+        return LinearSolve.do_factorization(alg, newA, b, u)
+    end
+end
+
+# The Bunch-Kaufman pair needs a single method rather than one per function: the
+# LinearSolve side declares both in one signature (`Union{GenericFactorization{
+# typeof(bunchkaufman)}, GenericFactorization{typeof(bunchkaufman!)}}`), and splitting
+# the intersection across two methods leaves the original pair ambiguous even though
+# the two together cover it.
+function LinearSolve.init_cacheval(
+        alg::Union{
+            GenericFactorization{typeof(LinearAlgebra.bunchkaufman)},
+            GenericFactorization{typeof(LinearAlgebra.bunchkaufman!)},
+        },
+        A::Union{
+            Hermitian{T, <:SparseMatrixCSC},
+            Symmetric{T, <:SparseMatrixCSC},
+        }, b, u, Pl, Pr,
+        maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
+        assumptions::OperatorAssumptions
+    ) where {T}
+    newA = copy(convert(AbstractMatrix, A))
+    return LinearSolve.do_factorization(alg, newA, b, u)
+end
+
 @static if Base.USE_GPL_LIBS
     const PREALLOCATED_UMFPACK = SparseArrays.UMFPACK.UmfpackLU(
         SparseMatrixCSC(
@@ -1063,6 +1111,26 @@ end
         function LinearSolve._ldiv!(
                 x::AbstractVector,
                 A::SparseArrays.SPQR.QRSparse, b::AbstractVector
+            )
+            x .= A \ b
+        end
+
+        # Disambiguate the method above against the `SVector` methods below and
+        # against LinearSolve's generic `_ldiv!(x, A, b::SVector)`: `SVector` is an
+        # `AbstractVector`, so those overlap without either being more specific.
+        # An `SVector` output cannot be written into, hence the `A \ b` returns.
+        function LinearSolve._ldiv!(
+                ::SVector, A::SparseArrays.SPQR.QRSparse, b::AbstractVector
+            )
+            (A \ b)
+        end
+        function LinearSolve._ldiv!(
+                ::SVector, A::SparseArrays.SPQR.QRSparse, b::SVector
+            )
+            (A \ b)
+        end
+        function LinearSolve._ldiv!(
+                x::AbstractVector, A::SparseArrays.SPQR.QRSparse, b::SVector
             )
             x .= A \ b
         end

--- a/src/default.jl
+++ b/src/default.jl
@@ -153,6 +153,18 @@ function defaultalg(
     return defaultalg(A.A, b, assump)
 end
 
+# Fix ambiguity with the `AbstractSciMLOperator`/`AnyGPUArray` method below: a
+# `MatrixOperator` with a GPU `b` matches both, and neither is more specific.
+# Unwrapping to `A.A` is what the `MatrixOperator` method above does, and it is the
+# better answer here too -- a concretized operator does not need the operator-only
+# Krylov fallback.
+function defaultalg(
+        A::MatrixOperator, b::GPUArraysCore.AnyGPUArray,
+        assump::OperatorAssumptions{Bool}
+    )
+    return defaultalg(A.A, b, assump)
+end
+
 function defaultalg(A, b, assump::OperatorAssumptions{Nothing})
     issq = issquare(A)
     return defaultalg(

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -124,10 +124,20 @@ run_qa(
     LinearSolve;
     explicit_imports = true,
     reexports_allow = scimlbase_reexports,
-    api_docs_kwargs = (; rendered = true, docs_src, rendered_ignore = scimlbase_reexports),
-    # Recursive ambiguities are tracked separately; placeholder until resolved.
-    aqua_broken = (:ambiguities,),
+    # `scimlbase_reexports` covers both checks: `names(SciMLBase)` includes the
+    # module's own name, so re-exporting it puts `:SciMLBase` in LinearSolve's public
+    # API, where the docstring check counts it as undocumented. It is SciMLBase's name
+    # to document, not LinearSolve's, hence the same ignore list as the rendered check.
+    api_docs_kwargs = (;
+        rendered = true, docs_src,
+        ignore = scimlbase_reexports, rendered_ignore = scimlbase_reexports,
+    ),
     aqua_kwargs = (;
+        # `MKL_jll` is not stale: `src/LinearSolve.jl` and `src/mkl.jl` load it
+        # (`using MKL_jll: MKL_jll` / `libmkl_rt`) behind a `@static if` gated on a
+        # `Preferences.@load_preference`, so MKL can be opted out of at build time.
+        # Aqua analyzes the source without resolving that branch and cannot see the
+        # use, so the dependency has to be ignored here rather than dropped.
         deps_compat = (; ignore = [:MKL_jll]),
         stale_deps = (; ignore = [:MKL_jll]),
         piracies = (; treat_as_own = [LinearProblem, EigenvalueProblem]),


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #1107.

- `run_qa` carried `aqua_broken = (:ambiguities,)` as a placeholder. Removing it surfaces 13 ambiguities (the issue reported 11), in three families, all fixed by defining the intersection methods. No test additions: the Aqua ambiguity check itself is the test, and it now runs unbroken.
- **`init_cacheval`, 9 of them.** The SparseArrays extension declares one method specific on `A` (a sparse `Symmetric`/`Hermitian`) but generic on the algorithm, while LinearSolve declares `GenericFactorization{typeof(f)}` methods specific on the algorithm but generic on `A`. Neither is more specific, so every combination is ambiguous. The intersections now live in the extension and take the sparse path, which is the correct operand handling whichever factorization function is wrapped.
- Bunch-Kaufman needed a single method rather than one per function: LinearSolve declares both in one signature (`Union{GenericFactorization{typeof(bunchkaufman)}, GenericFactorization{typeof(bunchkaufman!)}}`), and splitting the intersection across two methods leaves the original pair reported as ambiguous even though the two together cover it.
- **`_ldiv!` with SPQR, 3 of them.** `SVector` is an `AbstractVector`, so the extension's `(x::AbstractVector, ::QRSparse, b::AbstractVector)` overlaps both the `SVector` methods below it and LinearSolve's generic `_ldiv!(x, A, b::SVector)`. The disambiguators sit inside the existing `@static if VERSION < v"1.13"` block, where the conflicting method lives; on 1.13+ SparseArrays supplies `ldiv!` and none of them are compiled.
- **`defaultalg`, 1.** A `MatrixOperator` with a GPU `b` matches both the `MatrixOperator` method and the `AbstractSciMLOperator`/`AnyGPUArray` one. Unwrapping to `A.A` is what the `MatrixOperator` method already does, and a concretized operator does not need the operator-only Krylov fallback.
- **`MKL_jll`** stays ignored in `deps_compat`/`stale_deps`, now with the reason recorded. `src/LinearSolve.jl` and `src/mkl.jl` load it (`using MKL_jll: MKL_jll` / `libmkl_rt`) behind a `@static if` gated on a `Preferences.@load_preference`, so MKL can be opted out at build time and Aqua cannot see the use through the unresolved branch. It is a real runtime dependency, not a stale one, so the ignore is the correct resolution rather than dropping the dep.
- Removing the ambiguity hatch let the api-docs check run for the first time and exposed a latent gap: `names(SciMLBase)` includes the module's own name, so re-exporting it puts `:SciMLBase` in LinearSolve's public API, where the docstring check counts it as undocumented. `scimlbase_reexports` was already passed to `rendered_ignore`; it now covers `ignore` too. This has never been seen in CI because `jet.jl` runs first in the `qa` group and aborts it before `qa.jl` is reached.
- Verified locally on Julia 1.12.6: `Test.detect_ambiguities` over `LinearSolve` + `LinearSolveSparseArraysExt` with `recursive = true` goes 13 to 0, and the full `test/qa/qa.jl` (all 26 extensions loaded) reports **19 pass, 1 broken, 0 failures**, the broken one being the pre-existing `all_qualified_accesses_are_public` tracked in #1058. The `Core` group also passes, 29 testsets, 0 failures.
- Note this does not turn the QA job green on its own: `jet.jl:136` fails first for an unrelated reason, filed separately as #1148.
