### PR TITLE
GenericLUFactorization: pure-Julia naive back-solve instead of getrs!

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -250,6 +250,11 @@ Julia's built in generic LU factorization. Equivalent to calling LinearAlgebra.g
 Supports arbitrary number types but does not achieve as good scaling as BLAS-based LU implementations.
 Has low overhead and is good for small matrices.
 
+The back-solve is a pure-Julia column-oriented triangular solve (apply `ipiv`, unit-lower
+forward, upper backward) rather than `ldiv!(::LU, ·)` / OpenBLAS `getrs!`. That avoids the
+~290 ns BLAS call floor that otherwise dominates at the small-`N` sizes where this algorithm
+is the default (see SciML/LinearSolve.jl#1145).
+
 ## Positional Arguments
 
   - pivot: The choice of pivoting. Defaults to `LinearAlgebra.RowMaximum()`. The other choice is
@@ -261,6 +266,81 @@ struct GenericLUFactorization{P} <: AbstractDenseFactorization
 end
 
 GenericLUFactorization(pivot = RowMaximum(); residualsafety::Bool = false) = GenericLUFactorization(pivot, residualsafety)
+
+# Pure-Julia LU back-solve used by GenericLUFactorization. A pivoted LU vector
+# solve at small N is a handful of flops but ~290 ns through OpenBLAS/MKL
+# getrs! (call overhead); the same algorithm written out as scalar loops is
+# several times faster up through at least N≈80 (#1145). Always used for
+# GenericLU — no BLAS cutoff — so the path stays dependency- and vendor-free.
+# Multi-RHS applies the row permutation once, then runs the triangular sweeps
+# per column (nrhs == 1 is the hot path for Newton/ODE).
+@inline function _naive_lu_ldiv!(
+        fac::AbstractMatrix, ipiv::AbstractVector, b::AbstractVector
+    )
+    n = length(b)
+    @inbounds for i in eachindex(ipiv)
+        p = ipiv[i]
+        if p != i
+            b[i], b[p] = b[p], b[i]
+        end
+    end
+    @inbounds for j in 1:n
+        bj = b[j]
+        for i in (j + 1):n
+            b[i] = muladd(-fac[i, j], bj, b[i])
+        end
+    end
+    @inbounds for j in n:-1:1
+        b[j] /= fac[j, j]
+        bj = b[j]
+        for i in 1:(j - 1)
+            b[i] = muladd(-fac[i, j], bj, b[i])
+        end
+    end
+    return b
+end
+
+@inline function _naive_lu_ldiv!(
+        fac::AbstractMatrix, ipiv::AbstractVector, B::AbstractMatrix
+    )
+    n = size(B, 1)
+    nrhs = size(B, 2)
+    @inbounds for i in eachindex(ipiv)
+        p = ipiv[i]
+        if p != i
+            for col in 1:nrhs
+                B[i, col], B[p, col] = B[p, col], B[i, col]
+            end
+        end
+    end
+    @inbounds for j in 1:n
+        for col in 1:nrhs
+            bj = B[j, col]
+            for i in (j + 1):n
+                B[i, col] = muladd(-fac[i, j], bj, B[i, col])
+            end
+        end
+    end
+    @inbounds for j in n:-1:1
+        invd = inv(fac[j, j])
+        for col in 1:nrhs
+            B[j, col] *= invd
+            bj = B[j, col]
+            for i in 1:(j - 1)
+                B[i, col] = muladd(-fac[i, j], bj, B[i, col])
+            end
+        end
+    end
+    return B
+end
+
+# 3-arg form matching `ldiv!(x, F, b)`: copy when `x !== b`, then in-place solve.
+function _generic_lu_ldiv!(x, F::LU, b)
+    if x !== b
+        copyto!(x, b)
+    end
+    return _naive_lu_ldiv!(F.factors, F.ipiv, x)
+end
 
 # Trait methods for types defined in this file (must come after struct definitions)
 _get_residualsafety(alg::LUFactorization) = alg.residualsafety
@@ -455,9 +535,14 @@ function SciMLBase.solve!(
 
         cache.isfresh = false
     end
-    y = ldiv!(
-        cache.u, LinearSolve.@get_cacheval(cache, :GenericLUFactorization)[1], cache.b
-    )
+    F = LinearSolve.@get_cacheval(cache, :GenericLUFactorization)[1]
+    # Prefer the pure-Julia back-solve for `LinearAlgebra.LU` (the common
+    # cacheval). Non-stdlib LU types (e.g. StaticArrays) keep their own `ldiv!`.
+    y = if F isa LinearAlgebra.LU
+        _generic_lu_ldiv!(cache.u, F, cache.b)
+    else
+        ldiv!(cache.u, F, cache.b)
+    end
 
     if check_safety
         failed = _check_residual_safety(cache, alg, A_original, y)

--- a/test/Core/genericlu_naive_ldiv.jl
+++ b/test/Core/genericlu_naive_ldiv.jl
@@ -1,0 +1,77 @@
+using LinearSolve, LinearAlgebra, Test, Random
+
+Random.seed!(1145)
+
+@testset "GenericLU naive back-solve correctness" begin
+    for T in (Float64, Float32, ComplexF64, ComplexF32, BigFloat)
+        @testset "$T" begin
+            rtol = 100 * eps(float(real(one(T))))
+            for n in (2, 3, 8, 20, 50, 80)
+                A = rand(T, n, n) + n * I
+                b = rand(T, n)
+                B = rand(T, n, 4)
+                xref = A \ b
+                Xref = A \ B
+
+                sol = solve(LinearProblem(copy(A), copy(b)), GenericLUFactorization())
+                @test SciMLBase.successful_retcode(sol)
+                @test sol.u ≈ xref rtol = rtol * n
+
+                solB = solve(LinearProblem(copy(A), copy(B)), GenericLUFactorization())
+                @test SciMLBase.successful_retcode(solB)
+                @test solB.u ≈ Xref rtol = rtol * n
+            end
+        end
+    end
+end
+
+@testset "GenericLU naive back-solve kernel vs getrs!" begin
+    for n in (2, 3, 8, 16, 32, 64)
+        A = rand(n, n) + n * I
+        b = rand(n)
+        B = rand(n, 3)
+        F = lu(copy(A))
+
+        b1 = copy(b)
+        LinearSolve._naive_lu_ldiv!(F.factors, F.ipiv, b1)
+        b2 = copy(b)
+        ldiv!(F, b2)
+        @test b1 ≈ b2 rtol = 1.0e-14
+
+        B1 = copy(B)
+        LinearSolve._naive_lu_ldiv!(F.factors, F.ipiv, B1)
+        B2 = copy(B)
+        ldiv!(F, B2)
+        @test B1 ≈ B2 rtol = 1.0e-14
+    end
+end
+
+@testset "GenericLU back-solve reuse (many RHS, one factorization)" begin
+    n = 8
+    A0 = rand(n, n) + n * I
+    b = rand(n)
+    # alias_A=false so the original matrix is preserved for residual checks
+    cache = init(
+        LinearProblem(copy(A0), copy(b)),
+        GenericLUFactorization();
+        alias = LinearAliasSpecifier(alias_A = false, alias_b = false)
+    )
+    solve!(cache)
+    @test A0 * cache.u ≈ b rtol = 1.0e-12
+
+    for _ in 1:20
+        bnew = rand(n)
+        cache.b = bnew
+        solve!(cache)
+        @test A0 * cache.u ≈ bnew rtol = 1.0e-12
+    end
+end
+
+@testset "GenericLU naive back-solve with NoPivot" begin
+    n = 6
+    # Diagonally dominant so NoPivot is stable
+    A = rand(n, n) + n * I
+    b = rand(n)
+    sol = solve(LinearProblem(copy(A), copy(b)), GenericLUFactorization(NoPivot()))
+    @test sol.u ≈ A \ b rtol = 1.0e-12
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,7 @@ else
             @time @safetestset "Basic Tests" include("Core/basictests.jl")
             @time @safetestset "EigenvalueProblem" include("Core/eigenvalue.jl")
             @time @safetestset "Batched RHS" include("Core/batch.jl")
+            @time @safetestset "GenericLU naive back-solve" include("Core/genericlu_naive_ldiv.jl")
             @time @safetestset "GESV Factorization" include("Core/gesv.jl")
             @time @safetestset "LU Refactorization Reuse" include("Core/lu_refactorization.jl")
             @time @safetestset "Direct BLAS Refactorization Reuse" include("Core/direct_blas_refactorization.jl")


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

Fixes https://github.com/SciML/LinearSolve.jl/issues/1145.

## What changed and why

`GenericLUFactorization` (the default for `size(b,1) ≤ 10`) factorizes with generic Julia code but previously dispatched the back-solve to `ldiv!(::LU, ·)` → OpenBLAS `getrs!`. That call has a ~290 ns fixed floor that dominates completely at the sizes where GenericLU is the default, and every Newton/ODE reuse path pays it once per iteration against a reused factorization.

This PR replaces that path with a pure-Julia column-oriented triangular solve (apply `ipiv`, unit-lower forward, upper backward), always used for GenericLU — no BLAS cutoff, no vendor dependency. Same shape as the `PANEL_BLAS_CUTOFF` kernels in SupernodalLU (#1112). Multi-RHS applies the row permutation once, then runs the triangular sweeps per column (`nrhs == 1` is the hot path).

Non-stdlib `LU` cachevals (e.g. StaticArrays) still fall through to their own `ldiv!`.

## Verification

### Correctness

```text
GenericLU naive back-solve correctness | Pass 120
GenericLU naive back-solve kernel vs getrs! | Pass 12
GenericLU back-solve reuse (many RHS, one factorization) | Pass 21
GenericLU naive back-solve with NoPivot | Pass 1
```

Types: `Float32/64`, `ComplexF32/64`, `BigFloat`. Sizes `N = 2…80`. Vector and multi-RHS. Relative error vs `A \ b` / `ldiv!(F, ·)` at ~1e-15.

Commands:

```bash
julia --project=lib/LinearSolveAutotune -e '
using LinearSolve, LinearAlgebra, Test, Random, RecursiveFactorization
include("test/Core/genericlu_naive_ldiv.jl")'
```

### Microbenchmarks (AMD EPYC 7502, BLAS pinned to 1 thread, min of 5)

Kernel-level `getrs!` vs `_naive_lu_ldiv!`:

| N  | getrs! | naive  | speedup |
|----|--------|--------|---------|
| 2  | 115 ns | 22 ns  | 5.2×    |
| 3  | 139 ns | 38 ns  | 3.7×    |
| 8  | 288 ns | 135 ns | 2.1×    |
| 20 | 655 ns | 438 ns | 1.5×    |
| 80 | 3354 ns| 2673 ns| 1.25×   |

Full `GenericLUFactorization` solve! (after fix) vs `LUFactorization` solve! (still getrs!):

| N  | GenericLU | LU/getrs | ratio |
|----|-----------|----------|-------|
| 2  | 76 ns     | 197 ns   | 0.39  |
| 3  | 110 ns    | 275 ns   | 0.40  |
| 8  | 310 ns    | 531 ns   | 0.58  |
| 20 | 582 ns    | 830 ns   | 0.70  |
| 80 | 2905 ns   | 3636 ns  | 0.80  |

Naive still wins on the reuse path through at least `N = 200` vs LU/RFLU/MKL/OpenBLAS.

### Cutoff / "should GenericLU be used more?"

Measured factor+solve (one-shot) on the same host:

| N  | GenericLU | RFLU   | best       |
|----|-----------|--------|------------|
| 2–10 | wins    | close  | GenericLU  |
| 12 | ~equal    | ~equal | RFLU edge  |
| ≥15| loses     | wins   | RFLU       |

`LinearSolveAutotune` on `:tiny` + `:small` (`Float64`, `Float32`, 7 CPU algs):

```text
N=   5: best=GenericLUFactorization (0.23 GFLOP/s)  GenericLU=0.23  RFLU=0.17  MKL=0.19
N=  10: best=GenericLUFactorization (0.88 GFLOP/s)  GenericLU=0.88  RFLU=0.77  MKL=0.65
N=  15: best=RFLUFactorization (1.45 GFLOP/s)       GenericLU=1.35  RFLU=1.45  MKL=1.23
N=  20: best=RFLUFactorization (2.35 GFLOP/s)       GenericLU=1.6   RFLU=2.35  MKL=1.04
N=  40..100: RFLUFactorization wins clearly
```

**Conclusion: keep the existing `size(b,1) ≤ 10` hard override.** Autotune and the one-shot factor+solve table both put the crossover near 12–15; raising the override would make default one-shot solves slower once factorization dominates. The large win from this PR is on the *reused* back-solve path (ODE/Newton), where GenericLU with the naive solve remains best well past N=100 — that is a workload-shape issue, not a reason to retune the one-shot default.

No threshold change in this PR.

## What was *not* verified

- Full `GROUP=Core` / `GROUP=QA` / docs build (ran the new testset + multi-RHS correctness; the change is localized to GenericLU's solve path).
- GPU / Apple Accelerate paths.
- End-to-end ODE suite (ROBER/HIRES/…) — the issue body already reports ~7–22% end-to-end with a prototype of this kernel; this PR ships that kernel into GenericLU.
- Applying the same naive solve to pivoted `RFLUFactorization` (still goes through getrs! for `nrhs==1`). That would be a separate PR if wanted.

## Reviewer notes

- Judgment call: always-on for GenericLU (no `DENSE_BLAS_CUTOFF`). Measured win through N=200 on reuse; GenericLU is only the default at N≤10, so a cutoff inside GenericLU would never fire in the default path.
- Comment density is intentionally low; the long comment is the *why* for skipping BLAS, matching the existing `PANEL_BLAS_CUTOFF` style in `SupernodalLU/solve.jl`.