### PR TITLE
Route RFLU multi-RHS U-leg through TriangularSolve (#1146)

### DIFF
--- a/ext/LinearSolveRecursiveFactorizationExt.jl
+++ b/ext/LinearSolveRecursiveFactorizationExt.jl
@@ -3,7 +3,8 @@ module LinearSolveRecursiveFactorizationExt
 using LinearSolve: LinearSolve, RFLUFactorization, ButterflyFactorization,
     RF32MixedLUFactorization, LinearVerbosity
 using ArrayInterface: ArrayInterface
-using LinearAlgebra: LinearAlgebra, UnitLowerTriangular, UpperTriangular, ldiv!, mul!
+using LinearAlgebra: LinearAlgebra, UnitLowerTriangular, UpperTriangular,
+    LowerTriangular, ldiv!, mul!
 using RecursiveFactorization: RecursiveFactorization
 using TriangularSolve: TriangularSolve
 using SciMLBase: SciMLBase, ReturnCode
@@ -44,20 +45,35 @@ end
 # `RecursiveFactorization` already routes its own `lu!` through TriangularSolve,
 # but the `ldiv!` that consumes the factorization only does so for the pivotless
 # `NotIPIV` case (RecursiveFactorization/src/lu.jl); a pivoted `LU` falls back to
-# LinearAlgebra, i.e. BLAS `trsv`/`trsm`.  For a matrix right-hand side that
-# leaves a consistent ~1.6x on the table at every size we measured, because
-# TriangularSolve's blocked kernels beat `trsm` here:
+# LinearAlgebra, i.e. BLAS `trsv`/`trsm`.
 #
-#   n     BLAS trsm   TriangularSolve
-#   32     2.19 us      1.37 us  (1.60x)
-#   64     6.27 us      3.76 us  (1.67x)
-#   128   21.02 us     12.72 us  (1.65x)
-#   256   86.08 us     54.07 us  (1.59x)
-#   500  276.20 us    175.81 us  (1.58x)
+# TriangularSolve exposes blocked kernels for
+#   ldiv!(::LowerTriangular/UnitLowerTriangular, ::AbstractMatrix)
+#   rdiv!(::AbstractMatrix, ::UpperTriangular/UnitUpperTriangular)
+# but has no `ldiv!(::UpperTriangular, ...)` — that call hits the catch-all and
+# silently becomes `LinearAlgebra.ldiv!` (BLAS trsm).  The L leg therefore goes
+# through TS directly; the U leg is rewritten via the exchange-matrix identity
+#   U X = B  ⇔  (J U J) (J X) = J B
+# with L = J U J lower-triangular, so both legs hit TS kernels.  L = J U J is
+# materialized contiguously: a reverse-view of the packed factors has negative
+# strides that TriangularSolve mishandles at larger n (silent wrong answers).
+# A native upper-triangular `ldiv!` in TriangularSolve would remove that copy
+# (see SciML/LinearSolve.jl#1146).
+#
+# Full multi-RHS solve vs stdlib `ldiv!(::LU, ·)`, 1 BLAS thread, with the
+# per-solve J*U*J materialization included:
+#
+#   n    nrhs   stdlib     both-TS
+#   64     4    8.2 us      3.7 us  (2.2x)
+#  128     8   25.7 us     16.0 us  (1.6x)
+#  256     8   84.0 us     61.9 us  (1.4x)
+#  500     4  232 us      161 us    (1.4x)
 #
 # For a single vector right-hand side TriangularSolve has no advantage (it has
 # no vector kernel, and reshaping to n x 1 measured 1.09x at n=128 but 0.88x by
-# n=256), so vectors keep the stdlib path.
+# n=256), so vectors keep the stdlib path.  Complex BlasFloat also keeps the
+# stdlib U leg: TS only specialises Float32/Float64, so the reverse rewrite
+# would only add a useless copy before falling through to LinearAlgebra.
 @inline function _rf_ldiv!(
         u::AbstractVector, fact::LinearAlgebra.LU, b::AbstractVector, ::Val
     )
@@ -75,7 +91,30 @@ function _rf_ldiv!(
     LinearAlgebra._ipiv_rows!(fact, 1:length(fact.ipiv), U)
     F = fact.factors
     TriangularSolve.ldiv!(UnitLowerTriangular(F), U, Val(Thread))
-    TriangularSolve.ldiv!(UpperTriangular(F), U, Val(Thread))
+    _rf_upper_ldiv!(F, U, Val(Thread))
+    return U
+end
+
+# U X = B via L (J X) = J B with L = J U J lower-triangular (TS has lower ldiv!).
+function _rf_upper_ldiv!(
+        F::AbstractMatrix{T}, U::AbstractMatrix{T}, thread::Val
+    ) where {T <: Union{Float32, Float64}}
+    n = size(F, 1)
+    L = Matrix{T}(undef, n, n)
+    @inbounds for j in 1:n, i in j:n
+        L[i, j] = F[n + 1 - i, n + 1 - j]
+    end
+    reverse!(U, dims = 1)
+    TriangularSolve.ldiv!(LowerTriangular(L), U, thread)
+    reverse!(U, dims = 1)
+    return U
+end
+
+# Complex / other BlasFloat: no TS upper kernel either way; avoid the O(n²) copy.
+@inline function _rf_upper_ldiv!(
+        F::AbstractMatrix, U::AbstractMatrix, thread::Val
+    )
+    TriangularSolve.ldiv!(UpperTriangular(F), U, thread)
     return U
 end
 

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -246,10 +246,12 @@ end
     end
 
     @testset "RFLUFactorization multi-RHS" begin
-        # The extension routes matrix right-hand sides through TriangularSolve;
-        # results must match the stdlib path exactly in behaviour.
+        # Matrix RHS: L leg via TS UnitLower; U leg via exchange-matrix rewrite
+        # into TS Lower (TriangularSolve has no UpperTriangular ldiv! — #1146).
+        # nrhs == 1 stays on the stdlib path.  Include n large enough that a
+        # negative-stride reverse-view of the factors would miscompute.
         Random.seed!(7)
-        for n in (8, 40), nrhs in (1, 3)
+        for n in (8, 40, 128), nrhs in (1, 3, 8)
             Ar = rand(n, n) + n * I
             Br = rand(n, nrhs)
             sol = solve(LinearProblem(copy(Ar), copy(Br)), RFLUFactorization())
@@ -261,6 +263,10 @@ end
             cache.A = copy(A2)
             @test solve!(cache).u ≈ A2 \ Br
         end
+        # Float32 multi-RHS (same reverse-U path as Float64)
+        A32 = Float32.(rand(64, 64) + 64 * I)
+        B32 = Float32.(rand(64, 4))
+        @test solve(LinearProblem(copy(A32), copy(B32)), RFLUFactorization()).u ≈ A32 \ B32
     end
 
     @testset "SupernodalLU Factorization" begin


### PR DESCRIPTION
⚠️ **Draft — please ignore until reviewed by @ChrisRackauckas.**

Fixes https://github.com/SciML/LinearSolve.jl/issues/1146.

## What changed and why

`#1117` routed RFLU multi-RHS backsolves through TriangularSolve, but TS has no `ldiv!(::UpperTriangular, ·)`. That call hit the catch-all at `TriangularSolve.jl:750` and silently became BLAS `trsm`, so only the L leg was accelerated.

This rewrites the U leg via the exchange-matrix identity

```
U X = B  ⇔  (J U J) (J X) = J B
```

with `L = J U J` lower-triangular, so both legs use TS kernels for `Float32`/`Float64`. `L` is materialized contiguously (a reverse-view of the packed factors has negative strides that TS mishandles at larger `n` — silent wrong answers). Complex BlasFloat still uses the BLAS U-leg path: TS has no complex kernels either way, so the materialize would only add cost.

A native `ldiv!(::UpperTriangular, ·)` in TriangularSolve would remove the O(n²) materialization (option 3 in #1146); this PR is option 2 + the comment fix from option 1.

## Verification

Correctness (all relative errors O(ε) or better):

```
n ∈ {8,32,64,128,256}, nrhs ∈ {1,2,4,8}, T ∈ {Float32,Float64}: pass
ComplexF64 n=32 nrhs=4: pass
```

`GROUP=Core` local test run: **passed** (Basic Tests 670, multi-RHS expansion with n=128 / Float32, Adjoint, ForwardDiff Overloads, etc.).

Timing vs stdlib `ldiv!(::LU, ·)`, 1 BLAS thread, materialization included:

| n | nrhs | stdlib | both-TS (this PR) |
|---|------|--------|-------------------|
| 64 | 4 | 8.2 µs | 3.7 µs (2.2×) |
| 128 | 8 | 25.7 µs | 16.0 µs (1.6×) |
| 256 | 8 | 84.0 µs | 61.9 µs (1.4×) |
| 500 | 4 | 232 µs | 161 µs (1.4×) |

Vs the previous L-only-TS / U-BLAS path, the U-leg rewrite is also a win at these sizes (e.g. n=128: 16 µs vs 19–22 µs).

## What was not verified

- GPU paths / allowed-to-fail jobs
- Full `GROUP=Everything` / QA (JET Aqua ExplicitImports)
- Docs build (no docstring / public API change)
- Upstream TriangularSolve `UpperTriangular ldiv!` (JuliaSIMD; not opened here)

## Reviewer notes

- Per-solve allocates an `n×n` workspace for `J*U*J`. Pre-allocating it in the RFLU cacheval would remove that allocation; left out to keep this PR small. Upstream upper-`ldiv!` is the cleaner long-term fix.
- Negative-stride reverse-views were tried and **rejected**: correct at small n, wrong at n≥256.