### PR TITLE
Use KrylovJL_GMRES in the ForwardDiff GPU test: JLArrays 0.3.2 rejects the LAPACK Ptr path LUFactorization fell through to

### DIFF
--- a/test/Core/forwarddiff_gpu.jl
+++ b/test/Core/forwarddiff_gpu.jl
@@ -10,6 +10,13 @@ using Test
 # rather than a smoke test -- the whole split-Dual path (partials extraction,
 # rhs construction, back-solves, dual reassembly) has to stay in broadcasts and
 # BLAS-level calls, or they error instead of merely running slowly.
+#
+# The device solves use KrylovJL_GMRES, not an LU factorization: JLArray ships
+# no native `lu` (real GPU backends get theirs from CUSOLVER etc.), and since
+# JLArrays 0.3.2 (JuliaGPU/GPUArrays.jl#549) `unsafe_convert(Ptr, ::JLArray)`
+# throws, so the stdlib LAPACK fallback that used to silently factorize the
+# underlying CPU buffer errors instead of running. A Krylov solve is the path
+# that genuinely honors the GPU contract here, which is what this file proves.
 
 const N_PARTIALS = 3
 
@@ -58,7 +65,10 @@ end
         # supported implementation rather than mere self-consistency.
         reference = solve(LinearProblem(A_case, b_case), LUFactorization()).u
 
-        cache = init(LinearProblem(JLArray(A_case), JLArray(b_case)), LUFactorization())
+        cache = init(
+            LinearProblem(JLArray(A_case), JLArray(b_case)), KrylovJL_GMRES();
+            abstol = 1.0e-14, reltol = 1.0e-14
+        )
         solution = Array(solve!(cache).u)
         @test value_error(solution, reference) < 1.0e-12
         @test partials_error(solution, reference) < 1.0e-12
@@ -72,7 +82,10 @@ end
     end
 
     @testset "A reassigned between solves" begin
-        cache = init(LinearProblem(JLArray(A), JLArray(b)), LUFactorization())
+        cache = init(
+            LinearProblem(JLArray(A), JLArray(b)), KrylovJL_GMRES();
+            abstol = 1.0e-14, reltol = 1.0e-14
+        )
         solve!(cache)
 
         A2 = A .+ ForwardDiff.Dual{Nothing}(0.5, ntuple(k -> 0.02k, N_PARTIALS))


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

`test/Core/forwarddiff_gpu.jl` (all four device testsets) errors on current master with `Illegal conversion of a JLArray to a Ptr`. Root cause: JLArrays v0.3.2, registered 2026-08-07T16:34Z (https://github.com/JuliaRegistries/General/pull/163829), makes `Base.unsafe_convert(::Type{Ptr}, ::JLArray)` throw — an intentional GPU-contract hardening from https://github.com/JuliaGPU/GPUArrays.jl/pull/549 (commit `00f6243`, "JLArrays: Disallow conversions to CPU pointers."). Under JLArrays ≤ 0.3.1 that conversion silently handed the JLArray's CPU-backed buffer to LAPACK, so `LUFactorization()` on a `JLArray{Float64}` "worked" by factorizing on the CPU through `getrf!` — the exact loophole the upstream change closes. JLArray ships no native `lu` (real GPU backends get theirs from CUSOLVER/rocSOLVER), and GPUArrays has no generic one, so no LU-type algorithm can satisfy the GPU contract on JLArray anymore.

This PR keeps the file's stated purpose — proving the split-Dual path (partials extraction, rhs construction, back-solves, dual reassembly) never scalar-indexes a GPU array — by running the device solves with `KrylovJL_GMRES()` at `abstol = reltol = 1e-14`. The dual machinery in `LinearSolveForwardDiffExt` is algorithm-agnostic (all back-solves go through `solve!(cache.linear_cache, alg, ...)`), so the same `xp_linsolve_rhs!` methods and `update_partials_list!` re-solve flows are exercised, and the results still have to match the CPU `LUFactorization` reference to `1e-12` (observed agreement is ~`1e-16`/`1e-17`).

Not a package-code change; `[compat] JLArrays = "0.2, 0.3"` still admits both 0.3.1 and 0.3.2 and the test now passes under both.

## Diagnosis evidence

- Tests CI on `main` was green for the Core group at `0713478a` on 2026-08-06 (https://github.com/SciML/LinearSolve.jl/actions/runs/31101161789 — only QA failed), before JLArrays 0.3.2 existed.
- Same commit `0713478a` fails locally today with JLArrays 0.3.2 resolved, so no LinearSolve commit is at fault.
- Pinning JLArrays to 0.3.1 at master `3d9ae95` makes the unmodified test pass (15/15); upgrading to 0.3.2 makes it error (4 errored). The 0.3.1 → 0.3.2 diff contains the `unsafe_convert` rejection.

Standalone reproducer, no SciML packages (Julia 1.12.4, JLArrays v0.3.2, GPUArrays v11.5.9):

```julia
using JLArrays, LinearAlgebra
A = JLArray(rand(4, 4) + 4I)
lu(A, check = false)
# ERROR: Illegal conversion of a JLArray to a Ptr
#   getrf! → lu!(::JLArray, ::RowMaximum) at LinearAlgebra/src/lu.jl:91 → lu
```

(With `check = true`, `chkfinite` hits "Scalar indexing is disallowed" first; LinearSolve calls `lu(A; check = false)`, which reaches the `ccall` and the Ptr error.)

## Failing before (unmodified master `3d9ae95`, JLArrays 0.3.2)

```
Test Summary:                          | Pass  Error  Total   Time
fdgpu                                  |    1      4      5  19.9s
  Dual solve! on a GPU array (JLArray) |    1      4      5  15.7s
    Dual A and Dual b                  |           1      1  12.1s
    Dual b only                        |           1      1   1.0s
    Dual A only                        |           1      1   1.0s
    A reassigned between solves        |           1      1   0.1s
ERROR: Some tests did not pass: 1 passed, 0 failed, 4 errored, 0 broken.
```

## Passing after (this branch)

JLArrays 0.3.2:

```
Test Summary: | Pass  Total   Time
fdgpu         |   15     15  36.0s
```

JLArrays 0.3.1:

```
Test Summary: | Pass  Total   Time
fdgpu         |   15     15  44.8s
```

### GROUP=Core

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` on this branch first aborted in `Core/resolve.jl` — **before ever reaching `forwarddiff_gpu.jl`** — with a second, unrelated master breakage that also landed today: SparseBandedMatrices v1.3.4 (registered 2026-08-07T14:05Z, https://github.com/JuliaRegistries/General/pull/163804) dropped `mul!` from its exports, and RecursiveFactorization v0.2.26's `butterflylu.jl` only had a `mul!` binding via `using SparseBandedMatrices`, so `ButterflyFactorization` init now throws `UndefVarError: mul! not defined in RecursiveFactorization` (`butterflylu.jl:176`). That failure is identical on unmodified master (this branch changes only `test/Core/forwarddiff_gpu.jl`, and `resolve.jl` runs before it); the one-line fix belongs in RecursiveFactorization (`using LinearAlgebra: Diagonal, I, mul!` — SBM 1.3.4 still extends `LinearAlgebra.mul!`, it just no longer re-exports it).

With SparseBandedMatrices held to 1.3.3 via a local, uncommitted test-env pin so the group can run to completion, GROUP=Core passes end to end on this branch, JLArrays 0.3.2 resolved:

```
Re-solve               |  133           133  30.4s
ForwardDiff GPU Arrays |   15            15  38.8s
Mixed Precision        |   14       2    16   2.5s
Resize                 |   70            70   2.0s
SpecializingFactorizations |   18        18   3.2s
     Testing LinearSolve tests passed
```

Runic check on the changed file: clean. `typos`: clean.

## What I did not verify

- Real-GPU groups (CUDA/AMDGPU/Metal offload algorithms) — no GPU on this machine. They are unaffected by JLArrays but also uncovered here.
- Downstream/IntegrationTest jobs.

## Reviewer judgment calls

- This drops the `LUFactorization`-on-JLArray combination from the test matrix. That combination is now impossible by upstream design (no device `lu`, no Ptr escape hatch); the alternative would be a KernelAbstractions-based generic LU in LinearSolve, which is a feature, not a test fix. Dual + `LUFactorization` coverage remains on the CPU in `test/Core/forwarddiff_overloads.jl`.
- Side observation, not addressed here: `SimpleGMRES` produces wrong dual partials (~3e-2 error vs ~2e-17 for `KrylovJL_GMRES`) through the ForwardDiff ext, on plain CPU `Array`s as well as JLArrays, even at `abstol = reltol = 1e-14`. Plain re-solves with an updated `b` are fine, so it is specific to the dual ext + SimpleGMRES interaction. Filed as a separate issue: https://github.com/SciML/LinearSolve.jl/issues/1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGVN6qeNL2jGCtaYg1386X
