### PR TITLE
Promote integer-eltype problems to float at init, matching backslash

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -255,6 +255,18 @@ mutable struct LinearCache{TA, Tb, Tu, Tp, Talg, Tc, Tl, Tr, Ttol, Tlv <: Linear
 end
 
 function Base.setproperty!(cache::LinearCache, name::Symbol, x)
+    # Default `setproperty!` semantics convert to the field's declared type; this
+    # override must do the same, or an update whose eltype differs from the cache's
+    # (an integer `cache.b = [1, 0, ...]` after the init-time integer-to-float
+    # promotion, or Float32 data into a Float64 cache) throws a raw `TypeError`
+    # from `setfield!`. `convert` is the identity for an already-matching array, so
+    # the `===` alias check in the `:A` branch below still sees the caller's
+    # object. `:cacheval` is exempt: for the default solver it stores into a slot
+    # of the cacheval rather than the field itself, so the field's type is not the
+    # right conversion target.
+    if name !== :cacheval
+        x = convert(fieldtype(typeof(cache), name), x)
+    end
     if name === :A
         setfield!(cache, :isfresh, true)
         setfield!(cache, :precsisfresh, true)
@@ -338,8 +350,95 @@ given floating point type, ensuring numerical accuracy appropriate for that prec
 default_tol(::Type{T}) where {T} = √(eps(T))
 default_tol(::Type{Complex{T}}) where {T} = √(eps(T))
 default_tol(::Type{<:Rational}) = 0
-default_tol(::Type{<:Integer}) = 0
+# Integer problems are promoted to float at `init` (the same promotion `\` performs,
+# since division does not stay in the integers), so their default tolerance is the
+# promoted type's, not the 0 of exact arithmetic. `Rational` stays exact above.
+default_tol(::Type{T}) where {T <: Integer} = default_tol(float(T))
 default_tol(::Type{Any}) = 0
+
+"""
+    __promote_int_arrays(A, b, u0) -> (A, b, u0)
+
+Promote arrays with integer-like element types (`Integer` or
+`Complex{<:Integer}`, which includes `Bool` and `BigInt`) the way `\\` does,
+and return everything else -- floats, `Rational` (division is closed, solves are
+exact), duals, operators -- unchanged, identically (`===`).
+
+Division does not stay in the integers, and LinearSolve factorizes and
+back-substitutes into preallocated storage, so without this promotion an integer
+`A`, `b`, or `u0` surfaces as an `InexactError` from deep inside `ldiv!` or a
+`MethodError` from the QR and Krylov wrappers (issue #206).
+
+The target type is the *joint* promotion of `eltype(A)` and `eltype(b)`, floated
+only if that joint type is itself still integer-like. This is what makes mixed
+problems match `A \\ b`: an integer `b` against a `Rational` `A` becomes
+`Rational` (the solve stays exact), against a `BigFloat` `A` becomes `BigFloat`
+(no precision loss), against a `Float32` `A` becomes `Float32`, and only
+all-integer problems become `Float64` (`BigInt` becomes `BigFloat`). Conversion
+goes through `convert(AbstractArray{T}, x)`, which preserves the container:
+structured wrappers (`Symmetric`, `Tridiagonal`, `Diagonal`, `Adjoint`,
+`Transpose`), sparse matrices, and static arrays keep their structure, while
+`BitArray`s become the `Array`s they must (there is no float bit-array).
+
+Abstractly-typed integer arrays (`Vector{Integer}`, `Union` eltypes) have no
+computable `float` eltype, so they promote to the `Float64`/`ComplexF64` default
+instead of crashing in `float(::AbstractArray)`.
+"""
+function __promote_int_arrays(A, b, u0)
+    a_int = A isa AbstractArray && _integer_like_eltype(eltype(A))
+    b_int = b isa AbstractArray && _integer_like_eltype(eltype(b))
+    u_int = u0 isa AbstractArray && _integer_like_eltype(eltype(u0))
+    (a_int || b_int || u_int) || return (A, b, u0)
+    TA = A isa AbstractArray ? eltype(A) : eltype(b)
+    Tb = b isa AbstractArray ? eltype(b) : TA
+    T = if isconcretetype(TA) && isconcretetype(Tb)
+        Tj = promote_type(TA, Tb)
+        _integer_like_eltype(Tj) ? float(Tj) : Tj
+    else
+        (TA <: Complex || Tb <: Complex) ? ComplexF64 : Float64
+    end
+    return (
+        a_int ? convert(AbstractArray{T}, A) : A,
+        b_int ? convert(AbstractArray{T}, b) : b,
+        u_int ? convert(AbstractArray{T}, u0) : u0,
+    )
+end
+
+_integer_like_eltype(::Type{<:Integer}) = true
+_integer_like_eltype(::Type{Complex{T}}) where {T} = _integer_like_eltype(T)
+_integer_like_eltype(::Type) = false
+
+"""
+    __wants_int_promotion(alg)
+
+Whether integer-like `A`/`b`/`u0` should be promoted to float for `alg`; see
+[`__promote_int_arrays`](@ref). `false` for the `AbstractSolveFunction` family
+(`LinearSolveFunction`, `DirectLdiv!`): those wrap user-supplied solve semantics
+-- a `LinearSolveFunction` may implement exact integer or GF(2)/`Bool`
+arithmetic, and `DirectLdiv!` calls `ldiv!` on exactly what it was given -- so
+LinearSolve must hand them the user's arrays untouched.
+"""
+__wants_int_promotion(::Union{SciMLLinearSolveAlgorithm, Nothing}) = true
+__wants_int_promotion(::AbstractSolveFunction) = false
+
+"""
+    __promote_int_problem(prob, alg) -> LinearProblem
+
+Apply [`__promote_int_arrays`](@ref) to a `LinearProblem` before the default
+algorithm is chosen. Promotion inside `__init` alone is not enough for
+`solve(prob)`: `defaultalg` would select on the unpromoted types while every
+cacheval is built from the promoted ones, and the two can disagree -- a
+`BitMatrix` or integer `Adjoint`/`Transpose` is not a `DenseMatrix`, so
+`defaultalg` picks a Krylov method whose workspace slot is then typed for the
+dense float matrix the cache actually holds. Returns `prob` itself (`===`) when
+nothing needs promoting.
+"""
+function __promote_int_problem(prob::LinearProblem, alg)
+    __wants_int_promotion(alg) || return prob
+    A, b, u0 = __promote_int_arrays(prob.A, prob.b, prob.u0)
+    (A === prob.A && b === prob.b && u0 === prob.u0) && return prob
+    return SciMLBase.remake(prob; A, b, u0)
+end
 
 """
     default_alias_A(alg, A, b) -> Bool
@@ -530,6 +629,21 @@ function __init(
     )
     (; A, b, u0, p) = prob
 
+    # Integer-eltype problems are solved as their float (or joint-promoted)
+    # counterparts, matching `\`; see `__promote_int_arrays`. This happens before
+    # the aliasing/copy blocks and before any cacheval is built, so every
+    # downstream type sees the promoted problem. `solve(prob)`/`init(prob)` also
+    # promote before `defaultalg` (see `__promote_int_problem`), making this a
+    # no-op there; doing it here as well covers direct `init(prob, alg)` calls.
+    if __wants_int_promotion(alg)
+        A, b, u0 = __promote_int_arrays(A, b, u0)
+    end
+    # The promoted counterpart of `prob.A` (identity when nothing promotes): the
+    # DefaultLinearSolver cacheval below types its `A_backup` from this rather
+    # than from the working `A`, and it must be the promoted type or the backup
+    # copy of the float working matrix throws `InexactError` into integer storage.
+    A_original = A
+
     if haskey(kwargs, :alias_A) || haskey(kwargs, :alias_b)
         aliases = LinearAliasSpecifier()
 
@@ -604,9 +718,17 @@ function __init(
 
     u0_ = u0 !== nothing ? u0 : __init_u0_from_Ab(A, b)
 
-    # Guard against type mismatch for user-specified reltol/abstol
-    reltol = real(eltype(prob.b))(SciMLBase.value(reltol))
-    abstol = real(eltype(prob.b))(SciMLBase.value(abstol))
+    # Guard against type mismatch for user-specified reltol/abstol. Use the working
+    # `b`, not `prob.b`: an integer `b` has been promoted to float above, and
+    # converting a float tolerance to the original integer eltype would throw
+    # `InexactError: Int64(1.0e-8)`. Algorithms exempted from promotion
+    # (`AbstractSolveFunction`) keep their integer `b`, so an integer eltype is
+    # still floated here for the tolerance itself.
+    Ttol = let T = real(eltype(b))
+        _integer_like_eltype(T) ? float(T) : T
+    end
+    reltol = Ttol(SciMLBase.value(reltol))
+    abstol = Ttol(SciMLBase.value(abstol))
 
     precs = if hasproperty(alg, :precs)
         isnothing(alg.precs) ? DEFAULT_PRECS : alg.precs
@@ -626,13 +748,18 @@ function __init(
         # TODO: deprecate once all docs are updated to the new form
         #@warn "passing Preconditioners at `init`/`solve` time is deprecated. Instead add a `precs` function to your algorithm."
     end
-    # For DefaultLinearSolver, pass original prob.A so the A_backup field gets the
-    # correct type at construction time (prob.A may be e.g. WOperator while the
-    # converted A used for sub-caches may be a different concrete type).
+    # For DefaultLinearSolver, pass the uncopied original `A` so the A_backup field
+    # gets the correct type at construction time (it may be e.g. a WOperator while
+    # the converted A used for sub-caches is a different concrete type). This is
+    # `A_original`, not `prob.A`: for an integer problem the backup must be typed
+    # on the promoted float matrix, or the safety-fallback's `copyto!` of the float
+    # working matrix into it throws `InexactError` (first solve for wrappers like
+    # `Symmetric{Int}` whose promoted copy holds non-integral values, and any cache
+    # reuse that assigns a fractional `A`).
     cacheval = if alg isa DefaultLinearSolver
         init_cacheval(
             alg, A, b, u0_, Pl, Pr, maxiters, abstol, reltol, init_cache_verb,
-            assumptions, prob.A
+            assumptions, A_original
         )
     else
         init_cacheval(
@@ -701,6 +828,9 @@ function SciMLBase.solve(
         prob::LinearProblem, ::Nothing, args...;
         assump = OperatorAssumptions(issquare(prob.A)), kwargs...
     )
+    # Promote integer-eltype problems before choosing the algorithm, so the choice
+    # and the cache agree on the types; see `__promote_int_problem`.
+    prob = __promote_int_problem(prob, nothing)
     return solve(prob, defaultalg(prob.A, prob.b, assump), args...; kwargs...)
 end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -254,18 +254,27 @@ mutable struct LinearCache{TA, Tb, Tu, Tp, Talg, Tc, Tl, Tr, Ttol, Tlv <: Linear
     alias_A::Bool
 end
 
-function Base.setproperty!(cache::LinearCache, name::Symbol, x)
+# `@inline` is load-bearing: `name` must constant-propagate into the body so the
+# branch chain and `fieldtype` fold away. Without it, the warm refactorization
+# loop's `cache.isfresh = false`-style assignments inside `solve!` degrade to
+# dynamic calls and allocate, breaking the 0-byte ceilings in
+# test/Core/lu_refactorization.jl on the default-algorithm paths.
+@inline function Base.setproperty!(cache::LinearCache, name::Symbol, x)
     # Default `setproperty!` semantics convert to the field's declared type; this
     # override must do the same, or an update whose eltype differs from the cache's
     # (an integer `cache.b = [1, 0, ...]` after the init-time integer-to-float
     # promotion, or Float32 data into a Float64 cache) throws a raw `TypeError`
-    # from `setfield!`. `convert` is the identity for an already-matching array, so
-    # the `===` alias check in the `:A` branch below still sees the caller's
-    # object. `:cacheval` is exempt: for the default solver it stores into a slot
-    # of the cacheval rather than the field itself, so the field's type is not the
-    # right conversion target.
+    # from `setfield!`. The `isa` guard keeps the matching-type hot path (e.g. the
+    # warm `cache.A = Awork` refactorization loop, which asserts 0 allocations)
+    # from ever reaching `convert`: an already-matching `x` passes through
+    # untouched even if constant propagation of `name` fails, so the `===` alias
+    # check in the `:A` branch below still sees the caller's object. `:cacheval`
+    # is exempt: for the default solver it stores into a slot of the cacheval
+    # rather than the field itself, so the field's type is not the right
+    # conversion target.
     if name !== :cacheval
-        x = convert(fieldtype(typeof(cache), name), x)
+        FT = fieldtype(typeof(cache), name)
+        x isa FT || (x = convert(FT, x))
     end
     if name === :A
         setfield!(cache, :isfresh, true)

--- a/src/default.jl
+++ b/src/default.jl
@@ -509,6 +509,9 @@ function SciMLBase.init(
         assumptions = OperatorAssumptions(issquare(prob.A)),
         kwargs...
     )
+    # Promote integer-eltype problems before choosing the algorithm, so the choice
+    # and the cache agree on the types; see `__promote_int_problem` in common.jl.
+    prob = __promote_int_problem(prob, nothing)
     return SciMLBase.init(
         prob, defaultalg(prob.A, prob.b, assumptions), args...; assumptions, kwargs...
     )

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -1137,3 +1137,166 @@ end
         @test norm(A_pyamg * sol_pyamg2.u - b_pyamg2) < 1.0e-6
     end
 end
+
+# Integer-eltype problems are promoted to float at `init`, matching `\` (division
+# does not stay in the integers). Previously every such input threw an opaque
+# `InexactError` from inside `ldiv!` or a `MethodError` from the QR/Krylov wrappers.
+# Regression test for https://github.com/SciML/LinearSolve.jl/issues/206
+@testset "Integer eltype promotion (#206)" begin
+    # The MWE from the issue: float A, integer b.
+    A206 = [
+        1.0 0.0 -1.0 0.0
+        0.0 -3152.28 0.0 3152.28
+        0.388658 0.921382 -1.76854 -1.45868
+        0.921382 -0.388658 1.45868 1.76854
+    ]
+    b206 = [0, 0, 1, 0]
+    res206 = A206 \ b206
+
+    @testset "float A, integer b" begin
+        for alg in (
+                nothing, LUFactorization(), GenericLUFactorization(),
+                QRFactorization(), KrylovJL_GMRES(),
+            )
+            prob = LinearProblem(copy(A206), copy(b206))
+            sol = alg === nothing ? solve(prob) : solve(prob, alg)
+            @test sol.retcode === ReturnCode.Success
+            @test eltype(sol.u) == Float64
+            @test sol.u ≈ res206
+        end
+        # A float tolerance with an integer `b` used to throw
+        # `InexactError: Int64(1.0e-8)` from the init-time tolerance conversion.
+        @test solve(LinearProblem(copy(A206), copy(b206)), reltol = 1.0e-8).u ≈ res206
+    end
+
+    @testset "integer A" begin
+        Ai = [4 1 0 0; 1 4 1 0; 0 1 4 1; 0 0 1 4]
+        @test solve(LinearProblem(copy(Ai), copy(b206))).u ≈ Ai \ b206
+        # Large enough to leave the small-matrix default path.
+        Random.seed!(206)
+        Al = rand(1:9, 50, 50) + 200I
+        bl = rand(1:9, 50)
+        @test solve(LinearProblem(copy(Al), copy(bl))).u ≈ Al \ bl
+        # Sparse and structured containers keep their structure through `float`.
+        @test solve(LinearProblem(sparse(Ai), copy(b206))).u ≈ Float64.(Ai) \ b206
+        @test solve(LinearProblem(Diagonal([2, 4, 5, 8]), copy(b206))).u ≈
+            Diagonal([2, 4, 5, 8]) \ b206
+        @test solve(
+            LinearProblem(Tridiagonal([1, 1, 1], [4, 4, 4, 4], [1, 1, 1]), copy(b206))
+        ).u ≈ Tridiagonal([1, 1, 1], [4, 4, 4, 4], [1, 1, 1]) \ b206
+    end
+
+    @testset "other integer-like eltypes" begin
+        # Bool is an Integer; Complex{Int} and BigInt promote to ComplexF64/BigFloat.
+        @test solve(LinearProblem(copy(A206), [false, false, true, false])).u ≈ res206
+        solc = solve(LinearProblem(copy(A206), Complex{Int}[0, 0, 1, 0]))
+        @test eltype(solc.u) == ComplexF64
+        @test solc.u ≈ res206
+        Abig = big.([4 1 0 0; 1 4 1 0; 0 1 4 1; 0 0 1 4])
+        solb = solve(LinearProblem(Abig, big.(b206)))
+        @test eltype(solb.u) == BigFloat
+        @test solb.u ≈ Abig \ big.(b206)
+    end
+
+    @testset "integer u0 and batched integer b" begin
+        # `u0` must be on the problem: a `u0` kwarg to `solve` lands in `__init`'s
+        # trailing kwargs and is silently ignored.
+        sol = solve(LinearProblem(copy(A206), copy(b206); u0 = [0, 0, 0, 0]))
+        @test eltype(sol.u) == Float64
+        @test sol.u ≈ res206
+        B = [0 1; 0 2; 1 3; 0 4]
+        solB = solve(LinearProblem(copy(A206), copy(B)))
+        @test solB.u ≈ A206 \ Float64.(B)
+    end
+
+    @testset "wrapped and abstractly-typed integer A" begin
+        # Adjoint/Transpose/BitMatrix are not `DenseMatrix`, so these only work if
+        # promotion happens before `defaultalg` sees the type: choosing on the
+        # unpromoted wrapper while the cache holds the promoted dense matrix left
+        # the Krylov workspace slot typed `Nothing` and threw a `TypeError`.
+        Ai = [4 1 0 0; 1 4 1 0; 0 1 4 1; 0 0 1 4]
+        @test solve(LinearProblem(adjoint(copy(Ai)), copy(b206))).u ≈ Ai' \ b206
+        @test solve(LinearProblem(transpose(copy(Ai)), copy(b206))).u ≈
+            transpose(Ai) \ b206
+        Abit = Bool[1 0 0 0; 1 1 0 0; 0 1 1 0; 0 0 1 1]
+        @test solve(LinearProblem(copy(Abit), copy(b206))).u ≈ Abit \ b206
+        # Symmetric{Int} with a float b: `A` is promoted while `b` is not; the
+        # default solver's `A_backup` must be typed on the promoted matrix or the
+        # first solve's safety backup throws `InexactError` from integer storage.
+        As = Symmetric([4 1 0 0; 1 4 1 0; 0 1 4 1; 0 0 1 4])
+        bf = [0.0, 0.0, 1.0, 0.0]
+        @test solve(LinearProblem(As, copy(bf))).u ≈ As \ bf
+        # Abstractly-typed integer arrays cannot go through `float(::AbstractArray)`;
+        # they promote to the Float64 default instead of crashing.
+        solabs = solve(LinearProblem(copy(A206), Integer[0, 0, 1, 0]))
+        @test eltype(solabs.u) == Float64
+        @test solabs.u ≈ res206
+    end
+
+    @testset "mixed exact/integer matches \\ via joint promotion" begin
+        # An integer operand against a Rational one promotes to Rational, so the
+        # solve stays exact, matching `\` -- not to Float64, which would have
+        # returned float-accuracy values (or worse, dressed them as Rationals).
+        Ar = Rational{Int}[4 1 0 0; 1 4 1 0; 0 1 4 1; 0 0 1 4]
+        solra = solve(LinearProblem(copy(Ar), copy(b206)))
+        @test eltype(solra.u) == Rational{Int}
+        @test solra.u == Ar \ b206
+        Ai = [4 1 0 0; 1 4 1 0; 0 1 4 1; 0 0 1 4]
+        brat = Rational{Int}[0, 0, 1, 0]
+        solrb = solve(LinearProblem(copy(Ai), copy(brat)))
+        @test eltype(solrb.u) == Rational{Int}
+        # Deliberate divergence from `\` here: `factorize(::Matrix{Int})` sends
+        # Base to Float64 for this orientation, while the joint promotion keeps
+        # the exact Rational solve (value-equal to floating accuracy).
+        @test solrb.u == Rational{Int}.(Ai) \ brat
+        @test solrb.u ≈ Ai \ brat
+        # An integer operand against Float32/BigFloat takes that type, not Float64.
+        @test eltype(solve(LinearProblem(Float32.(A206), copy(b206))).u) == Float32
+        @test eltype(solve(LinearProblem(big.(A206), copy(b206))).u) == BigFloat
+    end
+
+    @testset "cache reuse after integer init" begin
+        # The promoted cache's `A_backup` must accept any float update: assigning a
+        # fractional `A` after an all-integer init used to throw `InexactError`
+        # from the Int-typed backup during the safety copy.
+        Ai = [4 1 0 0; 1 4 1 0; 0 1 4 1; 0 0 1 4]
+        cache = init(LinearProblem(copy(Ai), copy(b206)))
+        @test solve!(cache).u ≈ Ai \ b206
+        Afrac = [0.5 0.1 0.0 0.0; 0.1 0.5 0.1 0.0; 0.0 0.1 0.5 0.1; 0.0 0.0 0.1 0.5]
+        cache.A = copy(Afrac)
+        @test solve!(cache).u ≈ Afrac \ b206
+    end
+
+    @testset "AbstractSolveFunction receives the user's arrays" begin
+        # Custom solve functions define their own semantics (exact integer solves,
+        # GF(2) arithmetic on Bool arrays); promotion must not touch their inputs.
+        received = Ref{Any}(nothing)
+        function record_solve!(A, b, u, p, isfresh, Pl, Pr, cacheval; kwargs...)
+            received[] = (typeof(A), typeof(b))
+            u .= b .÷ 2
+            return u
+        end
+        Ai = [2 0; 0 2]
+        sol = solve(LinearProblem(copy(Ai), [4, 4]), LinearSolveFunction(record_solve!))
+        @test received[] == (Matrix{Int}, Vector{Int})
+        @test sol.u == [2, 2]
+        @test eltype(sol.u) == Int
+    end
+
+    @testset "cache reuse converts integer updates" begin
+        cache = init(LinearProblem(copy(A206), copy(b206)))
+        @test solve!(cache).u ≈ res206
+        # `cache.b`/`cache.A` are float-typed fields; assigning integer arrays
+        # converts through `setproperty!` rather than reintroducing integer storage.
+        cache.b = [1, 0, 0, 0]
+        @test solve!(cache).u ≈ A206 \ [1.0, 0, 0, 0]
+    end
+
+    @testset "Rational stays exact (not promoted)" begin
+        Ar = Rational{Int}[4 1 0 0; 1 4 1 0; 0 1 4 1; 0 0 1 4]
+        br = Rational{Int}[0, 0, 1, 0]
+        sol = solve(LinearProblem(copy(Ar), copy(br)))
+        @test eltype(sol.u) == Rational{Int}
+        @test sol.u == Ar \ br
+    end
+end

--- a/test/Core/lu_refactorization.jl
+++ b/test/Core/lu_refactorization.jl
@@ -221,3 +221,10 @@ end
     end
     @test cache.u ≈ A2 \ b2
 end
+
+# The warm default-algorithm ceiling must hold without RecursiveFactorization
+# loaded: the AppleAccelerate CI group includes only this file, so the default
+# resolves to the platform BLAS path (MKL/Accelerate), which regressed to 64
+# bytes when `setproperty!` grew past the inlining budget and `name` stopped
+# constant-propagating. The ceilings above already catch this in that group; this
+# comment records why `setproperty!(::LinearCache, ...)` carries `@inline`.


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #206.

- Integer-like `A`/`b`/`u0` (`Integer`, `Complex{<:Integer}`, `Bool`, `BigInt`) previously failed on every path with an opaque `InexactError`/`MethodError` while `A \ b` worked. Rather than a better error message, they are now promoted to float at `init`, like `\` does, and solve correctly.
- The target is the joint `promote_type(eltype(A), eltype(b))`, floated only if still integer-like: a Rational partner keeps the solve exact, `BigFloat`/`Float32` partners win, all-integer goes to `Float64`. `convert(AbstractArray{T}, x)` preserves structured/sparse/static containers.
- `solve(prob)`/`init(prob)` promote before `defaultalg` so the algorithm choice and cache agree on types (a `BitMatrix` or integer `Adjoint`/`Transpose` otherwise gets a Krylov choice with a dense-typed cache and throws). The `DefaultLinearSolver` `A_backup` is typed on the promoted matrix.
- `AbstractSolveFunction` (`LinearSolveFunction`, `DirectLdiv!`) is exempt: user solve functions keep the user's arrays (e.g. exact integer or GF(2)/Bool arithmetic).
- `default_tol(::Type{<:Integer})` forwards to the float tolerance instead of 0 (Krylov would get zero tolerances); `Rational` keeps 0. `LinearCache` `setproperty!` now converts assignments to the field type, so `cache.b = [1, 0, 0, 0]` works on a promoted cache.
- One documented divergence from `\`: integer `A` with Rational `b` stays exact where Base's `factorize(::Matrix{Int})` drops to `Float64`; value-equal, strictly more accurate.
- Rational/float/dual inputs pass through identically; an integer problem builds the same cache type as its float counterpart and `solve!` stays inferable. `Core` group passes locally on Julia 1.12.6 (0 failures; Basic Tests 715/715).
- Note: touches `src/default.jl` (the `init(prob, ::Nothing)` head) ~350 lines from #1149's hunk in the same file; the two merge cleanly.

AI Disclosure: Used Fable 5