### PR TITLE
Use a scalar back-solve for small dense LU systems

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -152,6 +152,54 @@ _ldiv!(x, A, b::SVector) = (x .= A \ b)
 _ldiv!(::SVector, A, b::SVector) = (A \ b)
 _ldiv!(::SVector, A, b) = (A \ b)
 
+# Below this size a single-vector LU back-solve is dominated by the cost of
+# entering BLAS rather than by its arithmetic: `getrs!` measures ~290 ns
+# independent of `n`. The measured crossover is `n ~ 192` against multithreaded
+# BLAS and `n ~ 300` pinned to one thread; 64 stays well under both, and matches
+# the `PANEL_BLAS_CUTOFF` SupernodalLU picked for the same reason.
+const DENSE_BLAS_CUTOFF = 64
+
+@inline function _scalar_lu_ldiv!(
+        x::AbstractVector, factors::AbstractMatrix, ipiv::AbstractVector
+    )
+    n = length(x)
+    @inbounds for i in eachindex(ipiv)
+        p = ipiv[i]
+        if p != i
+            x[i], x[p] = x[p], x[i]
+        end
+    end
+    @inbounds for j in 1:n
+        xj = x[j]
+        @simd for i in (j + 1):n
+            x[i] -= factors[i, j] * xj
+        end
+    end
+    @inbounds for j in n:-1:1
+        x[j] /= factors[j, j]
+        xj = x[j]
+        @simd for i in 1:(j - 1)
+            x[i] -= factors[i, j] * xj
+        end
+    end
+    return x
+end
+
+# Restricting the pivot to `Vector` keeps RecursiveFactorization's pivotless
+# `NotIPIV` factorizations on their own `ldiv!`, which is already BLAS-free.
+function _ldiv!(
+        x::StridedVector{T}, A::LinearAlgebra.LU{T, <:StridedMatrix{T}, <:Vector{<:Integer}},
+        b::StridedVector{T}
+    ) where {T <: LinearAlgebra.BlasFloat}
+    factors = A.factors
+    n = size(factors, 1)
+    if n > DENSE_BLAS_CUTOFF || n != size(factors, 2) || length(x) != n || length(b) != n
+        return ldiv!(x, A, b)
+    end
+    x === b || copyto!(x, b)
+    return _scalar_lu_ldiv!(x, factors, A.ipiv)
+end
+
 function _direct_lu_factorize! end
 function _direct_lu_solve! end
 
@@ -455,7 +503,7 @@ function SciMLBase.solve!(
 
         cache.isfresh = false
     end
-    y = ldiv!(
+    y = _ldiv!(
         cache.u, LinearSolve.@get_cacheval(cache, :GenericLUFactorization)[1], cache.b
     )
 

--- a/test/Core/scalar_backsolve.jl
+++ b/test/Core/scalar_backsolve.jl
@@ -1,0 +1,93 @@
+using LinearSolve, LinearAlgebra, Random, SciMLBase, Test
+
+# Sizes deliberately straddle the cutoff so both the scalar kernel and the BLAS
+# fallback stay exercised rather than one silently rotting.
+const SIZES = [1, 2, 3, 8, 63, 64, 65, 96]
+
+# Unstructured Gaussian matrices, so partial pivoting actually permutes rows. A
+# diagonally dominant test matrix would leave `ipiv == 1:n` and silently accept a
+# back-solve that skipped the interchanges entirely.
+testmat(rng, T, n) = randn(rng, T, n, n)
+
+backward_error(A, x, b) = norm(A * x - b) / (opnorm(A, 1) * norm(x) + norm(b))
+
+@testset "sizes straddle DENSE_BLAS_CUTOFF" begin
+    @test any(<=(LinearSolve.DENSE_BLAS_CUTOFF), SIZES)
+    @test any(>(LinearSolve.DENSE_BLAS_CUTOFF), SIZES)
+end
+
+# At n >= 8 an unstructured Gaussian matrix leaving every pivot on the diagonal
+# is vanishingly unlikely, so this pins the property without being flaky the way
+# n = 2 would be.
+@testset "test matrices exercise the row interchanges" begin
+    rng = MersenneTwister(0x5ca1ab1e)
+    big = filter(>=(8), SIZES)
+    pivoted = count(big) do n
+        F = lu!(testmat(rng, Float64, n), check = false)
+        any(i -> F.ipiv[i] != i, eachindex(F.ipiv))
+    end
+    @test pivoted == length(big)
+end
+
+@testset "_ldiv! matches LinearAlgebra for $T" for T in (Float64, Float32, ComplexF64)
+    rng = MersenneTwister(0xf00d)
+    tol = real(T) === Float32 ? 1.0f-4 : 1.0e-12
+    for n in SIZES
+        A = testmat(rng, T, n)
+        b = randn(rng, T, n)
+        F = lu!(copy(A), check = false)
+        expected = ldiv!(similar(b), F, b)
+
+        got = similar(b)
+        LinearSolve._ldiv!(got, F, b)
+        @test backward_error(A, got, b) <= tol
+        @test norm(got - expected) <= tol * max(norm(expected), one(real(T)))
+
+        # in-place aliasing: x === b must still solve rather than corrupt
+        aliased = copy(b)
+        LinearSolve._ldiv!(aliased, F, aliased)
+        @test backward_error(A, aliased, b) <= tol
+    end
+end
+
+# A pivot-forcing matrix: without the row interchange the first elimination
+# divides by 1e-14 and the result is garbage.
+@testset "matrix requiring an interchange" begin
+    A = [1.0e-14 1.0; 1.0 1.0]
+    b = [1.0, 2.0]
+    F = lu!(copy(A), check = false)
+    @test F.ipiv != [1, 2]
+    got = similar(b)
+    LinearSolve._ldiv!(got, F, b)
+    @test backward_error(A, got, b) <= 1.0e-12
+end
+
+@testset "$(nameof(typeof(alg))) solves correctly across the cutoff" for alg in (
+        GenericLUFactorization(), LUFactorization(),
+    )
+    rng = MersenneTwister(0xbeef)
+    for n in SIZES
+        A = testmat(rng, Float64, n)
+        b = randn(rng, n)
+        sol = solve(LinearProblem(copy(A), copy(b)), alg)
+        @test SciMLBase.successful_retcode(sol)
+        @test backward_error(A, sol.u, b) <= 1.0e-12
+    end
+end
+
+@testset "default algorithm solves correctly across the cutoff" begin
+    rng = MersenneTwister(0xcafe)
+    for n in SIZES
+        A = testmat(rng, Float64, n)
+        b = randn(rng, n)
+        sol = solve(LinearProblem(copy(A), copy(b)))
+        @test backward_error(A, sol.u, b) <= 1.0e-12
+    end
+end
+
+# A singular matrix must still be reported through the factorization's own
+# success check, not silently divided by a zero pivot in the scalar kernel.
+@testset "singular input is reported" begin
+    sol = solve(LinearProblem(zeros(4, 4), randn(4)), GenericLUFactorization())
+    @test !SciMLBase.successful_retcode(sol)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ else
             @time @safetestset "Batched RHS" include("Core/batch.jl")
             @time @safetestset "GESV Factorization" include("Core/gesv.jl")
             @time @safetestset "LU Refactorization Reuse" include("Core/lu_refactorization.jl")
+            @time @safetestset "Scalar Back-Solve" include("Core/scalar_backsolve.jl")
             @time @safetestset "Direct BLAS Refactorization Reuse" include("Core/direct_blas_refactorization.jl")
             @time @safetestset "Lightweight Solution (no cache)" include("Core/lightweight_solution.jl")
             @time @safetestset "Return codes" include("Core/retcodes.jl")


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

Fixes #1145.

## What and why

A single-vector LU back-solve at small `n` is dominated by the cost of *entering* BLAS, not
by its arithmetic. `getrs!` measures ~290 ns essentially independent of `n`, so at `n = 4` a
handful of flops costs the same as several hundred. `GenericLUFactorization` — the default
for `n <= 10` — inherits this through `ldiv!(::LU, ::Vector)`.

This adds `_scalar_lu_ldiv!`, a column-oriented kernel doing exactly what `getrs!` does (row
interchanges, unit-lower forward sweep, upper backward sweep), and dispatches `_ldiv!` to it
below `DENSE_BLAS_CUTOFF = 64`. `GenericLUFactorization` is routed through `_ldiv!` so it
benefits alongside `LUFactorization` and the default algorithm.

Same tradeoff, and the same cutoff, that #1112 already established for SupernodalLU's panel
solves via `PANEL_BLAS_CUTOFF` — where a 12x12 `trsv` measured ~260 ns of almost pure call
overhead. This is the dense single-vector case of the same problem.

Restricting the pivot type to `Vector` leaves RecursiveFactorization's pivotless `NotIPIV`
factorizations on their own `ldiv!`, which is already BLAS-free.

## Why 64

Measured, not copied. The crossover where BLAS overtakes the scalar loop is **n ~ 192**
against multithreaded OpenBLAS and **n ~ 300** pinned to one thread. 64 keeps a wide margin
under both. (My first crossover run had BLAS pinned to one thread, which flatters the scalar
loop; I re-ran with the default 64 threads before choosing.)

## Verification

Per the method note in #1112 — that isolated microbenchmarks of these loops mislead — every
number below is an end-to-end A/B of the same binary with only `src/factorization.jl` swapped
between committed and `main`, run alternating AFTER/BEFORE/AFTER/BEFORE. Both values from
each arm are shown.

Back-solve only, cached factorization, single vector RHS (ns):

| n | BEFORE | AFTER | ratio |
|---|---|---|---|
| 4 | 429, 420 | **149, 150** | 0.35x |
| 8 | 540, 539 | **249, 230** | 0.44x |
| 16 | 810, 800 | **429, 430** | 0.53x |
| 32 | 1390, 1370 | **879, 919** | 0.65x |
| 64 | 2720, 2740 | **2000, 2000** | 0.73x |
| 96 | 4519, 4610 | 4510, 4540 | 1.00x |

`n = 96` is above the cutoff and is unchanged, confirming the fallback costs nothing measurable.

Stiff ODE solves through the default algorithm, `abstol = 1e-8`, `reltol = 1e-6` (µs):

| problem | n | FBDF before | FBDF after | | Rodas5P before | Rodas5P after | |
|---|---|---|---|---|---|---|---|
| VDPOL | 2 | 2751, 2515 | **1906, 1880** | 0.72x | 1639, 1639 | **777, 770** | 0.47x |
| ROBER | 3 | 940, 943 | **765, 754** | 0.81x | 535, 530 | **277, 277** | 0.52x |
| OREGO | 3 | 2697, 2668 | **1995, 1959** | 0.74x | 2232, 2221 | **1112, 1119** | 0.50x |
| HIRES | 8 | 1201, 1204 | **943, 942** | 0.78x | 982, 1004 | **613, 613** | 0.62x |
| POLLU | 20 | 845, 875 | 1412\*, 839 | ~1.00x | 763, 751 | 744, 777 | ~1.00x |

**POLLU is the built-in control.** At `n = 20` the default algorithm selects
`RFLUFactorization` (RecursiveFactorization is loaded), which this PR does not touch — and it
is unchanged, as predicted. \*The 1412 is an outlier from a run that started while the test
suite was still releasing the machine; the second AFTER run gives 839 against a BEFORE of
845/875.

Rosenbrock gains most because it issues several back-solves per step against one factorization.

## Tests

New `test/Core/scalar_backsolve.jl`, registered in `runtests.jl`. Sizes deliberately straddle
the cutoff and the testset asserts they do, so neither branch can silently rot.

**The first version of this test did not discriminate.** It used `I + 0.1*randn` matrices,
which are diagonally dominant, so partial pivoting leaves `ipiv == 1:n` and deleting the entire
row-interchange sweep still passed. It now uses unstructured Gaussian matrices, asserts that
pivoting actually occurs, and includes a matrix that forces an interchange. Re-verified by
mutation:

| kernel mutation | result |
|---|---|
| none (committed code) | passes, 0 failures |
| drop row interchanges | 15 failures |
| break upper-triangular division | 18 failures |
| drop lower forward sweep | 15 failures |

Full Core group, against this branch:

```
Scalar Back-Solve |  118    118  4.1s
     Testing LinearSolve tests passed
CORE_EXIT=0
```

Runic and `typos` clean on the diff.

## Not verified

- **QA group and docs build** — not run. No public API is added or changed (`DENSE_BLAS_CUTOFF`
  and `_scalar_lu_ldiv!` are internal), so I do not expect docs impact, but I have not confirmed it.
- **One host only** — AMD EPYC / OpenBLAS / Julia 1.11.9. Not tested against MKL, Apple
  Accelerate, or on Intel. The change is BLAS-vendor-independent by construction, which is the
  main reason to prefer it over retuning the MKL threshold, but the crossover value itself is
  hardware-specific.
- `Float16` and non-`BlasFloat` element types fall through unchanged (the method is restricted
  to `BlasFloat`); not separately benchmarked.
- The machine carries permanent unrelated load (several multi-day Julia jobs), which is why
  every number is min-of-N with alternating arms rather than a single pass.

## For a reviewer to push back on

`DENSE_BLAS_CUTOFF = 64` is a single global constant applied regardless of BLAS vendor or
thread count. The measured crossover is 3-5x higher than the chosen value on this host, so it
is conservative here, but a vendor whose `getrs` has much lower call overhead could in
principle make 64 too aggressive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bHrkkvJzfYPMMJMRJ5GqX
