### PR TITLE
Rebuild the SimpleGMRES cache state on every re-solve

### DIFF
--- a/src/simplegmres.jl
+++ b/src/simplegmres.jl
@@ -87,10 +87,37 @@ end
     warm_start::Bool
 end
 
-function update_cacheval!(cache::LinearCache, cacheval::SimpleGMRESCache, name::Symbol, x)
-    (name != :b || cache.isfresh) && return cacheval
-    vec(cacheval.w) .= vec(x)
-    fill!(cacheval.x, 0)
+"""
+    reinit_cacheval!(cacheval::SimpleGMRESCache, b)
+
+Re-establish the starting iterate and the initial residual `r₀` that
+`solve!(::SimpleGMRESCache, ::LinearCache)` consumes, so that the cache can be
+solved again against `b`.
+
+A `SimpleGMRESCache` is single-use as built: `w` doubles as the Arnoldi scratch
+vector `ANvₖ`, and the solution is accumulated into `x` in place. Re-entering
+`solve!` without this leaves `r₀` holding the last Krylov vector and `x` holding
+the previous solution, and leaves the tolerance `ε` scaled by the *first* right
+hand side's norm.
+"""
+function reinit_cacheval!(cacheval::SimpleGMRESCache, b)
+    (; A, Δx, q, x, w, Pl, PlisI, restart, warm_start) = cacheval
+    T = eltype(x)
+
+    cacheval.b = b
+    fill!(x, zero(T))
+    if warm_start
+        mul!(w, A, Δx)
+        axpby!(one(T), b, -one(T), w)
+        restart && axpy!(one(T), Δx, x)
+    else
+        vec(w) .= vec(b)
+    end
+
+    r₀ = PlisI ? w : q
+    PlisI || ldiv!(r₀, Pl, w)  # r₀ = Pl(b - Ax₀)
+    cacheval.β = _norm2(r₀)
+    cacheval.ε = cacheval.abstol + cacheval.reltol * cacheval.β
     return cacheval
 end
 
@@ -160,6 +187,10 @@ function SciMLBase.solve!(cache::LinearCache, alg::SimpleGMRES; kwargs...)
         )
         cache.cacheval = solver
         cache.isfresh = false
+    else
+        # Unconditional: an in-place `cache.b .= ...` reaches no hook, and a
+        # resolve against an unchanged `b` needs the reset just as much.
+        reinit_cacheval!(cache.cacheval, cache.b)
     end
     return SciMLBase.solve!(cache.cacheval, cache)
 end

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -562,6 +562,37 @@ end
         test_interface(SimpleGMRES(; restart), prob1, prob2)
     end
 
+    # Every way of re-entering `solve!` has to rebuild the cacheval's initial
+    # residual, not just the `cache.b = ...` setproperty hook.
+    @testset "Simple GMRES resolve: restart = $restart, blocksize = $blocksize" for
+        restart in (true, false), blocksize in (0, 2)
+
+        nr = 6
+        Ar = [
+            float(i == j ? 10 + i : 0.3 * (i + j)) *
+                (blocksize == 0 || (i - 1) ÷ blocksize == (j - 1) ÷ blocksize)
+                for i in 1:nr, j in 1:nr
+        ]
+        br = float.(1:nr)
+        br2 = [0.3i + 1 for i in 1:nr]
+        alg = SimpleGMRES(; restart, blocksize)
+
+        @testset "$desc" for (desc, update_b!, expected) in (
+                ("b mutated in place", (c, b) -> (c.b .= b), br2),
+                ("b replaced", (c, b) -> (c.b = copy(b)), br2),
+                ("b unchanged", (c, b) -> nothing, br),
+            )
+            cache = init(
+                LinearProblem(copy(Ar), copy(br)), alg; abstol = 1.0e-12, reltol = 1.0e-12
+            )
+            @test solve!(cache).u ≈ Ar \ br rtol = 1.0e-13
+            update_b!(cache, br2)
+            # Tighter than the requested tolerance on purpose: a resolve off
+            # stale state still lands near the answer, just orders short of it.
+            @test solve!(cache).u ≈ Ar \ expected rtol = 1.0e-13
+        end
+    end
+
     @testset "KrylovJL" begin
         kwargs = (; gmres_restart = 5)
         precs = (A, p = nothing) -> (Diagonal(inv.(diag(A))), I)

--- a/test/Core/forwarddiff_overloads.jl
+++ b/test/Core/forwarddiff_overloads.jl
@@ -855,3 +855,23 @@ end
     @test ForwardDiff.partials.(x, 1) ≈
         [-b[n + 1 - i] / (2.0 + i / n)^2 for i in 1:n] rtol = 1.0e-10
 end
+
+@testset "Iterative algorithms get the partials right through the split path" begin
+    # The split path re-solves the primal cache once per partial, updating `b`
+    # in place — which `SimpleGMRES` missed, giving partials off by ~3e-2.
+    n = 6
+    p = 3
+    A = [
+        ForwardDiff.Dual{Nothing}(
+                float(i == j ? 10 + i : 0.3 * (i + j)),
+                ntuple(k -> 0.1k + 0.01 * (i + j), p)
+            ) for i in 1:n, j in 1:n
+    ]
+    b = [ForwardDiff.Dual{Nothing}(float(i), ntuple(k -> 0.05k + 0.1i, p)) for i in 1:n]
+    reference = solve(LinearProblem(A, b), LUFactorization()).u
+
+    @testset "$(nameof(typeof(alg)))" for alg in (KrylovJL_GMRES(), SimpleGMRES())
+        u = solve(LinearProblem(A, b), alg; abstol = 1.0e-14, reltol = 1.0e-14).u
+        @test dual_isapprox(u, reference; rtol = 1.0e-10)
+    end
+end


### PR DESCRIPTION
**Draft — please ignore until reviewed by @ChrisRackauckas.**

Fixes https://github.com/SciML/LinearSolve.jl/issues/1154.

## What changed and why

`SimpleGMRESCache` is single-use as constructed: `w` doubles as the Arnoldi scratch vector `ANvₖ`, and the solution is accumulated into `x` in place. The state a second `solve!` needs — `x₀`, the initial residual `r₀`, and the stopping tolerance `ε` — was rebuilt only inside `update_cacheval!`, which fires from the `cache.b = ...` `setproperty!` hook. An in-place `cache.b .= ...` never reaches `setproperty!`, and a resolve against an unchanged `b` fires no hook at all. `ε` was never refreshed even on the hook path, so it stayed scaled by the *first* right hand side's norm.

The reported symptom is the ForwardDiff extension: its split path re-solves the primal cache once per partial and writes each right hand side in place (`cache.linear_cache.b .= rhs_list[i]`, `ext/LinearSolveForwardDiffExt.jl:175`), so every partials back-solve ran against a stale residual and a non-zeroed `x`. Values came out right, partials were off by ~3e-2.

This replaces the hook with `reinit_cacheval!`, called from `solve!(::LinearCache, ::SimpleGMRES)` on every non-fresh entry, which re-establishes `x₀`, `r₀`, `β` and `ε` from the cache's current `b`. It mirrors the residual setup in `_init_cacheval` exactly, so `warm_start` behaves as it did.

## Verification

### The issue's reproducer

Before (`a9bc83b7`):

```
KrylovJL:    value_err = 1.1102230246251565e-16  partials_err = 1.734723475976807e-17
SimpleGMRES: value_err = 1.1102230246251565e-16  partials_err = 0.031842606346975784
```

After:

```
KrylovJL:    value_err = 1.1102230246251565e-16  partials_err = 1.734723475976807e-17
SimpleGMRES: value_err = 1.1102230246251565e-16  partials_err = 2.42861286636753e-17
```

### It is not dual-specific — plain `Float64` resolves were wrong too

`norm(A*u - b)` after the second `solve!` on a 6×6 dense system at `abstol = reltol = 1e-14`:

| second solve | before | after |
| --- | --- | --- |
| `cache.b .= b2` (in place) | `4.603259716893725` | `2.560743305106871e-15` |
| `cache.b = b2` (setproperty) | `2.560743305106871e-15` | `2.560743305106871e-15` |
| `solve!` again, `b` untouched | `2.3014923323544392e-9` | `4.7207330545682824e-15` |

`KrylovJL_GMRES` is correct in all three cases before and after.

### The new tests fail without the fix

Both new testsets, run against unmodified `src/simplegmres.jl`:

```
Test Summary:                                                        | Pass  Fail  Total   Time
all                                                                  |   19     7     26  16.0s
  Simple GMRES resolve: restart = true, blocksize = 0                |    4     2      6   5.0s
    b mutated in place                                               |    1     1      2   4.7s
    b replaced                                                       |    2            2   0.1s
    b unchanged                                                      |    1     1      2   0.0s
  Simple GMRES resolve: restart = true, blocksize = 2                |    5     1      6   4.4s
  Simple GMRES resolve: restart = false, blocksize = 0               |    4     2      6   0.0s
  Simple GMRES resolve: restart = false, blocksize = 2               |    5     1      6   0.0s
  Iterative algorithms get the partials right through the split path |    1     1      2   6.5s
    KrylovJL                                                         |    1            1   1.8s
    SimpleGMRES                                                      |          1      1   1.9s
ERROR: LoadError: Some tests did not pass: 19 passed, 7 failed, 0 errored, 0 broken.
```

With the fix applied, the same file:

```
Test Summary: | Pass  Total   Time
all           |   26     26  13.7s
```

The `b unchanged` cell discriminates only at `blocksize = 0`; at `blocksize = 2` the stale-state resolve lands within `1e-13` anyway. The in-place cell discriminates in all four cells.

### Test groups, Julia 1.12.6 x86_64-linux

`GROUP=Core`:

```
Basic Tests                       |  678  678   6m41.6s
EigenvalueProblem                 |   27   27     53.5s
Batched RHS                       |   98   98   2m09.9s
GenericLU naive back-solve        |  154  154     17.4s
GESV Factorization                |   24   24      4.7s
LU Refactorization Reuse          |   56   56      2.7s
Direct BLAS Refactorization Reuse |  130  130     10.3s
Lightweight Solution (no cache)   |   43   43     12.4s
Return codes                      |   71   72     11.4s  (1 broken)
Re-solve                          |  133  133     31.8s
SupernodalLU internals            |   75   75     54.8s
Krylov warm start                 |   37   37     12.8s
Zero Initialization Tests         |    8    8      5.8s
Non-Square Tests                  |  121  121     23.8s
SparseVector b Tests              |   12   12      7.4s
Nonstructural Zeros               |  141  141      2.3s
Default Alg Tests                 |  111  111   6m27.9s
FixedSizeArrays                   |   47   47     36.6s
ComponentArrays                   |   10   10     12.8s
Adjoint Sensitivity               |  107  107   2m20.8s
ForwardDiff Overloads             |  147  147   5m26.7s
Traits                            |    6    6      1.2s
Algorithm Interface               |  135  135      7.4s
Verbosity                         |   66   66     12.0s
BandedMatrices                    |   11   11   1m07.6s
Butterfly Factorization           |   44   44     13.7s
Mixed Precision                   |   14   16     23.4s  (2 broken)
Resize                            |   70   70      9.3s
SpecializingFactorizations        |   18   18      6.0s
```

That full Core run predates #1156; the branch was rebased onto `128d73c8` afterwards and the two files this PR touches were re-run against the new base:

```
Basic Tests           |  729  729  8m10.2s
ForwardDiff Overloads |  147  147  5m40.2s
```

Aqua + ExplicitImports (`test/qa/qa.jl`, run directly):

```
Quality Assurance        | 19 pass  1 broken  20  1m24.6s
Public API documentation |  2 pass              2
EXIT=0
```

Runic and `typos` are clean on the three changed files.

## Two pre-existing failures I had to work around

Neither is caused by this PR, but both had to be routed around to get a full local run, and both are red on master today.

**1. `Re-solve` → `ButterflyFactorization` errors with RecursiveFactorization 0.2.26.**

```
Re-solve: Error During Test
  LoadError: UndefVarError: `mul!` not defined in `RecursiveFactorization`
      @ RecursiveFactorization .../RecursiveFactorization/src/butterflylu.jl:176
```

Standalone reproducer, no LinearSolve involved:

```julia
Pkg.add(name = "RecursiveFactorization", version = "0.2.26")
using RecursiveFactorization
RecursiveFactorization.🦋workspace([10.0 14.0; 14.0 20.0], [1.0, 2.0], Val(888))
# ERROR: UndefVarError: `mul!` not defined in `RecursiveFactorization`
```

0.2.26's `butterflylu.jl` opens with `using LinearAlgebra: Diagonal, I`; 0.2.27 changed it to `using LinearAlgebra: Diagonal, I, mul!`. `Project.toml` currently has `RecursiveFactorization = "0.2.26"` and the resolver picks exactly 0.2.26, so `ButterflyFactorization` is broken in `GROUP=Core`. Bumping the lower bound to `0.2.27` fixes it — `Re-solve` goes from `5 passed, 1 errored` to `133 passed`. That is a one-line compat change and belongs in its own PR, so it is **not** included here; the Core numbers above were produced with the bound bumped locally.

**2. `ForwardDiff GPU Arrays` errors with JLArrays 0.3.2** (`Illegal conversion of a JLArray to a Ptr`, from `lu(::JLArray)` falling through to the LAPACK `Ptr` path). This is the breakage https://github.com/SciML/LinearSolve.jl/pull/1155 is already fixing, and is what issue #1154 was split out of.

## What I did not verify

- **GPU paths.** No CUDA/Metal/AMDGPU hardware here; `GROUP=GPU` was not run. The fix uses only `fill!`, `vec .= vec`, `mul!`, `axpby!`, `axpy!`, `ldiv!` and `norm`, all of which the surrounding code already uses on GPU arrays, but the JLArray case reported in the issue is blocked behind #1155 and was not exercised.
- **`GROUP=QA` as a whole is red on master and stays red**, for a reason unrelated to this PR: `JET.@test_opt solve(prob_sparse, KLUFactorization())` at `test/qa/jet.jl:136` reports 37 possible errors. A clean `a9bc83b7` worktree produces the identical summary — `JET Tests | 33 pass 1 fail 8 broken 42` — so this is pre-existing. Because `qa/jet.jl` runs first and aborts the group, `qa/qa.jl` never executes in CI; I ran Aqua/ExplicitImports directly instead (result above).
- Downstream packages, and the allowed-to-fail `julia pre` job.

## Worth pushing back on

- `reinit_cacheval!` runs on every non-fresh `solve!`, costing one copy of `b` and one norm per solve. That is negligible against a GMRES solve, but it is unconditional rather than dirty-tracked.
- The re-solve assertions use `rtol = 1.0e-13` while the solves request `1.0e-12`. That is deliberate — at the requested tolerance a resolve off stale state still passes — but it is a tolerance tightened to make a test discriminate, which is worth a look.
- `warm_start = true` combined with `restart = false` throws at `init` on master (`Δx` is `similar(u, 0)`, so `mul!(w, A, Δx)` mismatches). `reinit_cacheval!` mirrors that setup rather than fixing it, so the behaviour is unchanged; it seemed out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEJxmtUSt6ugRbPFwbafEG
