### PR TITLE
Orientation-specialized naive LU back-solve for Adjoint/Transpose factors

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -253,7 +253,9 @@ Has low overhead and is good for small matrices.
 The back-solve is a pure-Julia column-oriented triangular solve (apply `ipiv`, unit-lower
 forward, upper backward) rather than `ldiv!(::LU, ·)` / OpenBLAS `getrs!`. That avoids the
 ~290 ns BLAS call floor that otherwise dominates at the small-`N` sizes where this algorithm
-is the default (see SciML/LinearSolve.jl#1145).
+is the default (see SciML/LinearSolve.jl#1145). `Adjoint`/`Transpose` operators, whose
+factors are stored through the lazy wrapper, get an orientation-specialized kernel that
+traverses the underlying parent column-contiguously (see SciML/LinearSolve.jl#1159).
 
 ## Positional Arguments
 
@@ -329,6 +331,78 @@ end
             for i in 1:(j - 1)
                 B[i, col] = muladd(-fac[i, j], bj, B[i, col])
             end
+        end
+    end
+    return B
+end
+
+# Orientation-specialized back-solve for the Adjoint/Transpose-wrapped strided
+# factors that `init_cacheval` produces for adjoint/transpose operators (#1159).
+# The column-oriented sweeps above would walk the wrapper's parent at stride N;
+# these run the same solves in inner-product form so the parent is traversed
+# column-contiguously. Indexing through the wrapper keeps conj correct for
+# complex Adjoint factors.
+const _AdjTransStridedFactors = Union{
+    Adjoint{<:Any, <:StridedMatrix}, Transpose{<:Any, <:StridedMatrix},
+}
+
+@inline function _naive_lu_ldiv!(
+        fac::_AdjTransStridedFactors, ipiv::AbstractVector, b::AbstractVector
+    )
+    n = length(b)
+    @inbounds for i in eachindex(ipiv)
+        p = ipiv[i]
+        if p != i
+            b[i], b[p] = b[p], b[i]
+        end
+    end
+    @inbounds for i in 2:n
+        acc = b[i]
+        @simd for j in 1:(i - 1)
+            acc = muladd(-fac[i, j], b[j], acc)
+        end
+        b[i] = acc
+    end
+    @inbounds for i in n:-1:1
+        acc = b[i]
+        @simd for j in (i + 1):n
+            acc = muladd(-fac[i, j], b[j], acc)
+        end
+        b[i] = acc / fac[i, i]
+    end
+    return b
+end
+
+@inline function _naive_lu_ldiv!(
+        fac::_AdjTransStridedFactors, ipiv::AbstractVector, B::AbstractMatrix
+    )
+    n = size(B, 1)
+    nrhs = size(B, 2)
+    @inbounds for i in eachindex(ipiv)
+        p = ipiv[i]
+        if p != i
+            for col in 1:nrhs
+                B[i, col], B[p, col] = B[p, col], B[i, col]
+            end
+        end
+    end
+    @inbounds for i in 2:n
+        for col in 1:nrhs
+            acc = B[i, col]
+            @simd for j in 1:(i - 1)
+                acc = muladd(-fac[i, j], B[j, col], acc)
+            end
+            B[i, col] = acc
+        end
+    end
+    @inbounds for i in n:-1:1
+        invd = inv(fac[i, i])
+        for col in 1:nrhs
+            acc = B[i, col]
+            @simd for j in (i + 1):n
+                acc = muladd(-fac[i, j], B[j, col], acc)
+            end
+            B[i, col] = acc * invd
         end
     end
     return B

--- a/test/Core/genericlu_naive_ldiv.jl
+++ b/test/Core/genericlu_naive_ldiv.jl
@@ -75,3 +75,62 @@ end
     sol = solve(LinearProblem(copy(A), copy(b)), GenericLUFactorization(NoPivot()))
     @test sol.u ≈ A \ b rtol = 1.0e-12
 end
+
+@testset "GenericLU back-solve on Adjoint/Transpose operators" begin
+    for T in (Float64, Float32, ComplexF64, ComplexF32, BigFloat),
+            wrap in (adjoint, transpose)
+
+        @testset "$wrap $T" begin
+            rtol = 100 * eps(float(real(one(T))))
+            sizes = T === BigFloat ? (4, 16, 33) : (4, 16, 64, 96, 128)
+            for n in sizes
+                P = rand(T, n, n) + n * I
+                A = wrap(P)
+                b = rand(T, n)
+                B = rand(T, n, 3)
+                xref = Matrix(A) \ b
+                Xref = Matrix(A) \ B
+
+                cache = init(
+                    LinearProblem(wrap(copy(P)), copy(b)), GenericLUFactorization()
+                )
+                sol = solve!(cache)
+                @test SciMLBase.successful_retcode(sol)
+                @test sol.u ≈ xref rtol = rtol * n
+
+                F = first(cache.cacheval)
+                @test F.factors isa (wrap === adjoint ? Adjoint : Transpose)
+
+                x1 = copy(b)
+                LinearSolve._naive_lu_ldiv!(F.factors, F.ipiv, x1)
+                x2 = copy(b)
+                ldiv!(F, x2)
+                @test x1 ≈ x2 rtol = rtol * n
+
+                bnew = rand(T, n)
+                cache.b = bnew
+                sol2 = solve!(cache)
+                @test sol2.u ≈ Matrix(A) \ bnew rtol = rtol * n
+
+                solB = solve(
+                    LinearProblem(wrap(copy(P)), copy(B)), GenericLUFactorization()
+                )
+                @test SciMLBase.successful_retcode(solB)
+                @test solB.u ≈ Xref rtol = rtol * n
+            end
+        end
+    end
+end
+
+@testset "Adjoint/Transpose strided factors dispatch to the specialized kernel" begin
+    ipivT = Vector{LinearAlgebra.BlasInt}
+    for W in (Adjoint, Transpose), rhsT in (Vector{Float64}, Matrix{Float64})
+        @test which(
+            LinearSolve._naive_lu_ldiv!,
+            Tuple{W{Float64, Matrix{Float64}}, ipivT, rhsT}
+        ) !== which(
+            LinearSolve._naive_lu_ldiv!,
+            Tuple{Matrix{Float64}, ipivT, rhsT}
+        )
+    end
+end


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

Fixes #1159.

For adjoint/transpose operators, `GenericLUFactorization` factorizes through the lazy `Adjoint`/`Transpose` wrapper, so the #1151 back-solve's `fac[i, j]` reads the parent at stride `N` and falls behind BLAS `ldiv!` near N≈64 (2.8x slower at N=128, #1159). This adds orientation-specialized `_naive_lu_ldiv!` methods for `Adjoint`/`Transpose`-wrapped `StridedMatrix` factors (option 1 from the issue): the same pivot/forward/backward sweeps rewritten in inner-product form so the wrapper's parent is traversed column-contiguously, with `@simd` on the inner reductions. Indexing stays through the wrapper, which keeps `conj` correct for complex `Adjoint` factors (complex eltypes do reach this path and are tested); `Matrix` factors keep the existing kernel via unchanged dispatch, non-strided wrapped factors keep the generic fallback, and algorithm/default selection is untouched.

## Verification

AMD EPYC 7502, Julia 1.11.9, OpenBLAS, `BLAS.set_num_threads(1)`, pinned with `taskset -c 8`. Methodology mirrors #1159: both kernels and `ldiv!` interleaved in one process against the **same** factorization, per-call `time_ns` min-of-6000 (min-of-2000 above N=64), each call feeding a `Ref` sink, `copyto!` of the RHS outside the timed region.

### Kernel benchmark (the discriminating evidence for this perf bug)

Adjoint factors (`factors::Adjoint{Float64, Matrix{Float64}}` from the real `generic_lufact!` path) — old kernel = the generic column-oriented method (reached via `invoke`), new kernel = normal dispatch on this branch; ratios are vs BLAS `ldiv!(F, x)` on the same wrapped `LU`. Times in ns:

| N | adj `ldiv!` (BLAS) | adj old kernel | adj new kernel | old/ldiv | new/ldiv | normal `ldiv!` | normal kernel | ker/ldiv |
|---|---|---|---|---|---|---|---|---|
| 4 | 550 | 99 | 90 | 0.18x | 0.16x | 339 | 90 | 0.27x |
| 8 | 669 | 179 | 200 | 0.27x | 0.30x | 450 | 169 | 0.38x |
| 16 | 960 | 399 | 529 | 0.42x | 0.55x | 749 | 360 | 0.48x |
| 32 | 1850 | 1070 | 1310 | 0.58x | 0.71x | 1320 | 800 | 0.61x |
| 48 | 2800 | 2210 | 2150 | 0.79x | 0.77x | 1960 | 1310 | 0.67x |
| 64 | 3809 | 3890 | 3059 | 1.02x | 0.80x | 2660 | 1840 | 0.69x |
| 96 | 5889 | 8780 | 5140 | 1.49x | 0.87x | 4470 | 3160 | 0.71x |
| 128 | 8520 | 24800 | 7360 | 2.91x | 0.86x | 6480 | 4950 | 0.76x |
| 256 | 22360 | 142789 | 19999 | 6.39x | 0.89x | 18990 | 16010 | 0.84x |

The old kernel reproduces the issue's regression (1.02x at N=64, 2.91x at N=128 vs the issue's 0.95x/2.81x); the new kernel is faster than BLAS `ldiv!` at **every** size on adjoint factors, and small-N wins are retained (0.16x at N=4). The "normal" columns are `Matrix` factors: dispatch there is the unchanged pre-existing method (asserted by a `which` test), timed here to confirm the numbers match #1151's.

Multi-RHS (`nrhs = 4`) on adjoint factors, old → new: N=8: 410 → 340 ns, N=32: 3340 → 2580 ns, N=128: 99600 → 17320 ns.

```
Julia Version 1.11.9
Commit 53a02c0720c (2026-02-06 00:27 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 128 × AMD EPYC 7502 32-Core Processor
  WORD_SIZE: 64
  LLVM: libLLVM-16.0.6 (ORCJIT, znver2)
Threads: 1 default, 0 interactive, 1 GC (on 128 virtual cores)
```

### Tests

New coverage in `test/Core/genericlu_naive_ldiv.jl`: adjoint and transpose `LinearProblem` solves vs `Matrix(A) \ b` for `Float64/Float32/ComplexF64/ComplexF32` at N = 4, 16, 64, 96, 128 (`BigFloat` at 4, 16, 33), single and multi RHS, cached re-solve with a new `b`, kernel vs `ldiv!` on the same wrapped factorization, an assertion that the cacheval factors really are wrapper-typed, and a `which`-based check that wrapped strided factors dispatch to the specialized methods while `Matrix` keeps the generic one.

**To be explicit: the wrapped-operator correctness tests pass on unfixed master too** — the old kernel was correct on wrapped factors, just slow. The failing-before/passing-after discriminator in the suite is the dispatch testset; the regression itself is demonstrated by the benchmark above. With the fix stashed (`git stash push src/factorization.jl`):

```
Adjoint/Transpose strided factors dispatch to the specialized kernel: Test Failed at .../test/Core/genericlu_naive_ldiv.jl:128
  Expression: which(LinearSolve._naive_lu_ldiv!, Tuple{W{Float64, Matrix{Float64}}, ipivT, rhsT}) !== which(...)
   Evaluated: _naive_lu_ldiv!(fac::AbstractMatrix, ...) @ LinearSolve src/factorization.jl:303 !== _naive_lu_ldiv!(fac::AbstractMatrix, ...) @ src/factorization.jl:303
Test Summary:                                                        | Fail  Total  Time
Adjoint/Transpose strided factors dispatch to the specialized kernel |    4      4  2.2s
```

With the fix applied, the full test file on Julia 1.11.9 (identical result on 1.10.11):

```
Test Summary:                          | Pass  Total   Time
GenericLU naive back-solve correctness |  120    120  23.5s
Test Summary:                               | Pass  Total  Time
GenericLU naive back-solve kernel vs getrs! |   12     12  0.0s
Test Summary:                                            | Pass  Total  Time
GenericLU back-solve reuse (many RHS, one factorization) |   21     21  0.0s
Test Summary:                           | Pass  Total  Time
GenericLU naive back-solve with NoPivot |    1      1  0.3s
Test Summary:                                       | Pass  Total   Time
GenericLU back-solve on Adjoint/Transpose operators |  322    322  15.0s
Test Summary:                                                        | Pass  Total  Time
Adjoint/Transpose strided factors dispatch to the specialized kernel |    4      4  0.0s
```

Local runs before pushing (all on this branch):

- `GROUP=Core julia +1.11 --project=. -e 'using Pkg; Pkg.test()'`: 21 of the 30 Core files pass in-group, including `Basic Tests | 715 pass`, `GenericLU naive back-solve | 480 pass` (contains this PR's 326 new assertions), `Adjoint Sensitivity | 107 pass`, `Default Alg Tests | 111 pass`. The group run then aborts at `ForwardDiff GPU Arrays` with `Illegal conversion of a JLArray to a Ptr` from `ArrayInterface.lu_instance` inside `init_cacheval(::LUFactorization, ::JLArray, ...)` — **pre-existing: reproduced identically on unmodified `origin/main` (128d73c8)** in a clean env; unrelated to this diff (that path never reaches `_naive_lu_ldiv!`), being investigated separately. The 8 files after the abort point (Traits, Algorithm Interface, Verbosity, BandedMatrices, Butterfly, Mixed Precision, Resize, SpecializingFactorizations) were run standalone against this branch: all pass (Mixed Precision's `1 broken` is its pre-existing conditional `@test_skip` for MKL/Accelerate).
- `GROUP=QA julia +1.11 --project=. -e 'using Pkg; Pkg.test()'`: `JET Tests | 25 pass 17 broken` and `Allocation QA | 52 pass` clean; `SupernodalLU Allocation QA | 4 pass 2 fail` — **pre-existing on unmodified main** (Julia-1.11-specific stdlib `ldiv!` boxing, fix already open in #1158; reproduced on a clean `origin/main` checkout, unrelated to this diff). That in-group failure aborts before `qa/qa.jl`, so I ran `qa/qa.jl` standalone against this branch: 18 pass, 1 broken (the tracked `ei_broken` ExplicitImports marker), 1 fail in `Method ambiguity` — the 3 reported pairs are all `_ldiv!` CHOLMOD-vs-`SVector` (`ext/LinearSolveSparseArraysExt.jl:1095` × `src/factorization.jl:151-153`), none involve this PR's methods, and **the identical 3 pairs reproduce on unmodified `origin/main`** (latent because CI's QA job currently dies at the #1148 JET failure before reaching qa.jl; tracked in #1141). ExplicitImports, piracy, compat-bounds, public-API-docs, and reexport checks all pass with this diff.
- Docs build (`julia +1.11 --project=docs`, this PR touches the `GenericLUFactorization` docstring): builds clean through the deploy-skip stage, no errors; the updated docstring renders in `solvers/solvers/index.html`. Only the pre-existing warnings (missing `defaultalg` docs, duplicate `@docs` entries, 719 uncollected SciMLBase docstrings) appear.
- Runic format check on both changed files: clean. `typos` on both changed files: clean.

## Not verified

- GPU paths, downstream packages, and allowed-to-fail CI jobs (`julia pre` etc.).
- The full `GROUP=Core`/`GROUP=QA` runs were on Julia 1.11 only; on 1.10 I ran the GenericLU test file (all pass), not the full groups.
- End-to-end `solve!` master-vs-branch timings; the kernel-level interleaved comparison above is the measurement (it isolates exactly the code this PR changes, on the same factorization).

## Reviewer judgment calls

- **`@simd` on the inner reductions.** The inner-product form has a loop-carried dependence on the accumulator; without permission to reassociate it is latency-bound and does not recover the N≥64 regression. `@simd` changes the rounding order relative to the old kernel (both are valid triangular-solve orderings; tests compare against `\` with the same `100*eps*n` rtol scaling #1151 used).
- **No size-cutoff hybrid.** On adjoint factors at N≈8-32 the new kernel is somewhat slower than the old one was (399 → 529 ns at N=16, 1070 → 1310 ns at N=32) while still well ahead of BLAS `ldiv!` (0.55x/0.71x). I kept one kernel per orientation rather than adding a magic crossover constant; at the N≤10 sizes where GenericLU is the default the difference is ±10-20 ns.
- **Scope `{Adjoint,Transpose}{<:Any, <:StridedMatrix}`.** Strided views also take the fast orientation; non-strided wrapped parents keep the generic kernel. No eltype restriction, matching #1151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
