### PR TITLE
KLU: extract factor parts through concrete helpers, not getproperty recursion

### DIFF
--- a/src/KLU/klu.jl
+++ b/src/KLU/klu.jl
@@ -313,63 +313,21 @@ function getproperty(
     if s ∉ (:L, :U, :F, :p, :q, :R, :Rs, :(_L), :(_U), :(_F))
         return getfield(klu, s)
     end
-    # Factor parts: the sizes come from `_numeric_struct` rather than from
-    # `klu.lnz` etc., because reading them back through this same `getproperty`
-    # is a self-recursive call that inference abandons — the resulting `Any`
-    # sizes make the `_extract!` keyword calls below uninferable.
-    n = getfield(klu, :n)
+    # Factor parts live in concrete helper functions (`_extract_L` and friends)
+    # rather than inline: everything they need comes from `getfield`/
+    # `_numeric_struct` directly, because reading `klu.lnz` or `klu._L` back
+    # through this same `getproperty` is a self-recursive call that inference
+    # abandons — the resulting `Any` values made the `_extract!` keyword calls
+    # (and, in the `:L`/`:U`/`:F` branch below, the tuple destructure) uninferable,
+    # to the point of admitting scalar iteration of a `SparseMatrixCSC` (#1148).
     if s === :(_L)
-        lnz = Int(_numeric_struct(klu).lnz)
-        Lp = Vector{Ti}(undef, n + 1)
-        Li = Vector{Ti}(undef, lnz)
-        Lx = Vector{Float64}(undef, lnz)
-        Lz = Tv == Float64 ? C_NULL : Vector{Float64}(undef, lnz)
-        _extract!(klu; Lp, Li, Lx, Lz)
-        return Lp, Li, Lx, Lz
+        return _extract_L(klu)
     elseif s === :(_U)
-        unz = Int(_numeric_struct(klu).unz)
-        Up = Vector{Ti}(undef, n + 1)
-        Ui = Vector{Ti}(undef, unz)
-        Ux = Vector{Float64}(undef, unz)
-        Uz = Tv == Float64 ? C_NULL : Vector{Float64}(undef, unz)
-        _extract!(klu; Up, Ui, Ux, Uz)
-        return Up, Ui, Ux, Uz
+        return _extract_U(klu)
     elseif s === :(_F)
-        fnz = Int(_numeric_struct(klu).nzoff)
-        # We often don't have an F, so create the right vectors for an empty SparseMatrixCSC
-        if fnz == 0
-            Fp = zeros(Ti, n + 1)
-            Fi = Vector{Ti}()
-            Fx = Vector{Float64}()
-            Fz = Tv == Float64 ? C_NULL : Vector{Float64}()
-        else
-            Fp = Vector{Ti}(undef, n + 1)
-            Fi = Vector{Ti}(undef, fnz)
-            Fx = Vector{Float64}(undef, fnz)
-            Fz = Tv == Float64 ? C_NULL : Vector{Float64}(undef, fnz)
-            _extract!(klu; Fp, Fi, Fx, Fz)
-            # F is *not* sorted on output, so we'll have to do it here:
-            for i in 1:(length(Fp) - 1)
-                # find each segment
-                first = Fp[i] + 1
-                last = Fp[i + 1]
-                first > last && (continue)
-                first == length(Fi) && (break)
-                # sort each column of rowval, nzval, and Fz for complex numbers if necessary
-                #by the ascending permutation of rowval.
-                Fiview = view(Fi, first:last)
-                Fxview = view(Fx, first:last)
-                P = sortperm(Fiview)
-                Fiview .= Fiview[P]
-                Fxview .= Fxview[P]
-                if Fz != C_NULL && length(Fz) == length(Fx)
-                    Fzview = view(Fz, first:last)
-                    Fzview .= Fzview[P]
-                end
-            end
-        end
-        return Fp, Fi, Fx, Fz
+        return _extract_F(klu)
     end
+    n = getfield(klu, :n)
     # Each branch names its keyword literally: splatting a `NamedTuple{(s,)}`
     # built from a non-constant `s` makes the keyword call uninferable, and the
     # `pairs(::NamedTuple)` eltype computation it lands in dispatches at runtime.
@@ -391,20 +349,93 @@ function getproperty(
         return increment!(P)
     end
     return if s ∈ (:L, :U, :F)
+        # Call the concrete helpers directly rather than reading `klu._L` etc.
+        # back through this `getproperty`: that self-recursive read was inferred
+        # as a Union spanning every branch of this function — including the
+        # `SparseMatrixCSC` this branch returns — so the destructure admitted
+        # `indexed_iterate(::SparseMatrixCSC, ::Int)`, i.e. scalar iteration of a
+        # sparse matrix, and JET reported the whole downstream cascade (#1148).
         if s === :L
-            p, i, x, z = klu._L
+            _assemble_factor(klu, _extract_L(klu))
         elseif s === :U
-            p, i, x, z = klu._U
-        elseif s === :F
-            p, i, x, z = klu._F
-        end
-        if Tv == Float64
-            return SparseMatrixCSC(klu.n, klu.n, increment!(p), increment!(i), x)
+            _assemble_factor(klu, _extract_U(klu))
         else
-            return SparseMatrixCSC(
-                klu.n, klu.n, increment!(p), increment!(i), Complex.(x, z)
-            )
+            _assemble_factor(klu, _extract_F(klu))
         end
+    end
+end
+
+# Concrete factor-part extraction, shared by `getproperty`'s `:_L`/`:_U`/`:_F`
+# (raw tuples) and `:L`/`:U`/`:F` (assembled `SparseMatrixCSC`) branches. These
+# read sizes via `_numeric_struct`/`getfield` only — never through
+# `getproperty(klu, ...)`, which would be self-recursive and uninferable (#1148).
+function _extract_L(klu::AbstractKLUFactorization{Tv, Ti}) where {Tv, Ti}
+    n = getfield(klu, :n)
+    lnz = Int(_numeric_struct(klu).lnz)
+    Lp = Vector{Ti}(undef, n + 1)
+    Li = Vector{Ti}(undef, lnz)
+    Lx = Vector{Float64}(undef, lnz)
+    Lz = Tv == Float64 ? C_NULL : Vector{Float64}(undef, lnz)
+    _extract!(klu; Lp, Li, Lx, Lz)
+    return Lp, Li, Lx, Lz
+end
+
+function _extract_U(klu::AbstractKLUFactorization{Tv, Ti}) where {Tv, Ti}
+    n = getfield(klu, :n)
+    unz = Int(_numeric_struct(klu).unz)
+    Up = Vector{Ti}(undef, n + 1)
+    Ui = Vector{Ti}(undef, unz)
+    Ux = Vector{Float64}(undef, unz)
+    Uz = Tv == Float64 ? C_NULL : Vector{Float64}(undef, unz)
+    _extract!(klu; Up, Ui, Ux, Uz)
+    return Up, Ui, Ux, Uz
+end
+
+function _extract_F(klu::AbstractKLUFactorization{Tv, Ti}) where {Tv, Ti}
+    n = getfield(klu, :n)
+    fnz = Int(_numeric_struct(klu).nzoff)
+    # We often don't have an F, so create the right vectors for an empty SparseMatrixCSC
+    if fnz == 0
+        Fp = zeros(Ti, n + 1)
+        Fi = Vector{Ti}()
+        Fx = Vector{Float64}()
+        Fz = Tv == Float64 ? C_NULL : Vector{Float64}()
+    else
+        Fp = Vector{Ti}(undef, n + 1)
+        Fi = Vector{Ti}(undef, fnz)
+        Fx = Vector{Float64}(undef, fnz)
+        Fz = Tv == Float64 ? C_NULL : Vector{Float64}(undef, fnz)
+        _extract!(klu; Fp, Fi, Fx, Fz)
+        # F is *not* sorted on output, so we'll have to do it here:
+        for i in 1:(length(Fp) - 1)
+            # find each segment
+            first = Fp[i] + 1
+            last = Fp[i + 1]
+            first > last && (continue)
+            first == length(Fi) && (break)
+            # sort each column of rowval, nzval, and Fz for complex numbers if necessary
+            #by the ascending permutation of rowval.
+            Fiview = view(Fi, first:last)
+            Fxview = view(Fx, first:last)
+            P = sortperm(Fiview)
+            Fiview .= Fiview[P]
+            Fxview .= Fxview[P]
+            if Fz != C_NULL && length(Fz) == length(Fx)
+                Fzview = view(Fz, first:last)
+                Fzview .= Fzview[P]
+            end
+        end
+    end
+    return Fp, Fi, Fx, Fz
+end
+
+function _assemble_factor(klu::AbstractKLUFactorization{Tv}, parts) where {Tv}
+    p, i, x, z = parts
+    n = getfield(klu, :n)
+    return if Tv == Float64
+        SparseMatrixCSC(n, n, increment!(p), increment!(i), x)
+    else
+        SparseMatrixCSC(n, n, increment!(p), increment!(i), Complex.(x, z))
     end
 end
 

--- a/test/qa/jet.jl
+++ b/test/qa/jet.jl
@@ -172,7 +172,16 @@ end
 @testset "JET Tests for Default Solver" begin
     # Test the default solver selection
     # Julia 1.10 reports runtime dispatch through stdlib and Krylov fallback paths.
-    JET.@test_opt solve(prob) broken = VERSION < v"1.12.0-"
+    #
+    # `target_modules` for the same reason as the MKLLUFactorization test above:
+    # JET analyzes every branch of the generated DefaultLinearSolver `solve!`
+    # regardless of which one would run, and the MKL branch's failure-logging
+    # path (`get_blas_operation_info`'s `string(::Type)`) dispatches inside
+    # Base's `show` machinery. Those frames are stdlib-internal; real dispatch
+    # in LinearSolve/SciMLBase code is still reported. This was masked until
+    # the KLU getproperty fix (#1148) let the suite get past the sparse testset.
+    JET.@test_opt target_modules = (LinearSolve, SciMLBase) solve(prob) broken =
+        VERSION < v"1.12.0-"
     # Sparse has runtime dispatch in SparseArrays stdlib, Base.show, etc.
     JET.@test_opt solve(prob_sparse) broken = true
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #1148. This is what has been keeping the QA job red: the failure at `test/qa/jet.jl:136` aborts the QA group before anything behind it runs.

- `getproperty(::AbstractKLUFactorization)` read `klu._L` and `klu.n` back through itself; inference abandons the self-recursive call, so the destructure was inferred against a Union spanning every branch, admitting `indexed_iterate(::SparseMatrixCSC, ::Int)` and failing `JET.@test_opt solve(prob_sparse, KLUFactorization())` with a 40-error cascade.
- The `:_L`/`:_U`/`:_F` bodies move verbatim into concrete helpers (`_extract_L`/`_extract_U`/`_extract_F`) that read only through `getfield`/`_numeric_struct`, and the `:L`/`:U`/`:F` branch calls them directly via `_assemble_factor`. Same fix the file already applied once for the factor sizes, finished for the factor parts. Each access still extracts fresh buffers, so `increment!` cannot be applied twice.
- Getting past `jet.jl:136` unmasked one failure CI has never reached: `JET.@test_opt solve(prob)` at `jet.jl:175` flags the MKL branch of the generated `solve!` (JET analyzes every branch regardless of which runs), whose failure-logging path does `string(::Type)` inside Base's `show` machinery. Scoped with `target_modules = (LinearSolve, SciMLBase)`, the treatment the file already uses for the direct MKL test; real dispatch in package code is still reported.
- With both, the entire QA group passes locally for the first time: `jet.jl` (34 pass, 8 expected-broken), `allocations.jl`, `supernodal_allocations.jl`, `qa.jl` (19 pass, 1 broken tracked in #1058).
- KLU factor reconstruction `(Rs .\ A)[p, q] == L*U + F` verified for real, block-triangular, and complex matrices; the complex path exercises the non-Float64 helper branches. No test additions needed: `jet.jl:136` is the regression test, and the existing `KLU factor parts` testset covers reconstruction.
- The local `Core` run aborts in `test/Core/forwarddiff_gpu.jl` with JLArrays 0.3.2, reproduced identically on pristine `main`; that is the pre-existing breakage `fix/forwarddiff-gpu-jlarrays-032` addresses, unrelated to this change.
