### PR TITLE
Enforce the LU backsolve-selection policy: GenericLU stays generic, LUFactorization gets the size-aware back-solve

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -228,6 +228,12 @@ Julia's built in `lu`. Equivalent to calling `lu!(A)`
   - On CuMatrix, it will use a CUDA-accelerated LU from CuSolver.
   - On BandedMatrix and BlockBandedMatrix, it will use a banded LU.
 
+The back-solve is size-aware for LAPACK-eligible dense factors: single-vector solves at
+or below a measured crossover (`N = 256` for `Matrix` factors) use the same pure-Julia
+triangular sweeps as `GenericLUFactorization`, which beat `getrs!`'s call and blocking
+overhead at those sizes; larger vectors and matrix right-hand sides use `ldiv!`
+(LAPACK `getrs!`).
+
 ## Positional Arguments
 
   - pivot: The choice of pivoting. Defaults to `LinearAlgebra.RowMaximum()`. The other choice is
@@ -263,6 +269,12 @@ forward, upper backward) rather than `ldiv!(::LU, ·)` / OpenBLAS `getrs!`. That
 is the default (see SciML/LinearSolve.jl#1145). `Adjoint`/`Transpose` operators, whose
 factors are stored through the lazy wrapper, get an orientation-specialized kernel that
 traverses the underlying parent column-contiguously (see SciML/LinearSolve.jl#1159).
+
+The generic back-solve is used at every size, with no BLAS deferral: explicitly selecting
+this algorithm selects the pure-Julia path for both the factorization and the solve. Note
+that above `N ≈ 400` a single-vector generic sweep is slower than `getrs!`; if BLAS is
+acceptable at large sizes, use `LUFactorization` (whose back-solve is size-aware) or the
+default algorithm instead.
 
 ## Positional Arguments
 
@@ -416,10 +428,38 @@ end
 end
 
 # 3-arg form matching `ldiv!(x, F, b)`: copy when `x !== b`, then in-place solve.
+# No size cutoff here, ever: choosing `GenericLUFactorization` is choosing the
+# generic back-solve; the size-aware path is `_smart_lu_ldiv!` below.
 function _generic_lu_ldiv!(x, F::LU, b)
     if x !== b
         copyto!(x, b)
     end
+    return _naive_lu_ldiv!(F.factors, F.ipiv, x)
+end
+
+# Measured single-vector crossover vs `ldiv!` (min-times, 1 BLAS thread, EPYC
+# 7502): naive wins to ≈ N 400 on `Matrix` factors and ≈ 900 on the wrapped
+# orientations, then loses 1.14x/1.24x/1.35x at N = 512/1000/2000 (`Matrix`).
+_naive_ldiv_cutoff(::AbstractMatrix) = 256
+_naive_ldiv_cutoff(::_AdjTransStridedFactors) = 512
+
+# Size-aware back-solve for `ldiv!`-baseline algorithms (`LUFactorization` and
+# the defaults routed to it): single vectors at or below the crossover take the
+# naive kernel; everything else (larger vectors, multi-RHS, non-BLAS/GPU) keeps
+# `ldiv!`. Explicit generic selections never consult this cutoff.
+_smart_lu_ldiv!(x, F, b) = _ldiv!(x, F, b)
+
+function _smart_lu_ldiv!(
+        x::StridedVector{T},
+        F::LU{T, <:Union{StridedMatrix{T}, _AdjTransStridedFactors}},
+        b::StridedVector{T}
+    ) where {T <: BLASELTYPES}
+    if x isa GPUArraysCore.AnyGPUArray || b isa GPUArraysCore.AnyGPUArray ||
+            F.factors isa GPUArraysCore.AnyGPUArray ||
+            length(x) > _naive_ldiv_cutoff(F.factors)
+        return _ldiv!(x, F, b)
+    end
+    x !== b && copyto!(x, b)
     return _naive_lu_ldiv!(F.factors, F.ipiv, x)
 end
 
@@ -537,7 +577,7 @@ function SciMLBase.solve!(cache::LinearCache, alg::LUFactorization; kwargs...)
     end
 
     F = @get_cacheval(cache, :LUFactorization)
-    y = _ldiv!(cache.u, F, cache.b)
+    y = _smart_lu_ldiv!(cache.u, F, cache.b)
 
     if check_safety
         failed = _check_residual_safety(cache, alg, A_original, y)

--- a/test/Core/genericlu_naive_ldiv.jl
+++ b/test/Core/genericlu_naive_ldiv.jl
@@ -76,6 +76,65 @@ end
     @test sol.u ≈ A \ b rtol = 1.0e-12
 end
 
+@testset "GenericLU keeps the naive kernel at every size (no BLAS deferral)" begin
+    # Path discrimination is against the `ldiv!` reference, whose bits are
+    # stable across call contexts (LAPACK ccall / plain-op generic path): a
+    # size-based deferral would make `sol.u` bitwise-equal to it, while the
+    # naive kernel differs in the last ulps at these sizes. Comparing bitwise
+    # against the kernel itself is not portable — its `muladd`/`@simd` loops
+    # may contract differently standalone vs inlined (observed on Julia 1.11).
+    # N = 600 exceeds both cutoffs (256 `Matrix` / 512 wrapped) in
+    # `_naive_ldiv_cutoff`, which `_generic_lu_ldiv!` must never consult.
+    for (mk, n) in ((identity, 600), (adjoint, 600))
+        A = rand(n, n) + n * I
+        b = rand(n)
+        cache = init(LinearProblem(mk(copy(A)), copy(b)), GenericLUFactorization())
+        sol = solve!(cache)
+        F = first(cache.cacheval)
+        xldiv = copy(b)
+        ldiv!(F, xldiv)
+        @test sol.u != xldiv
+        @test sol.u ≈ Matrix(mk(A)) \ b rtol = 1.0e-10 * n
+
+        B = rand(n, 3)
+        solB = solve(LinearProblem(mk(copy(A)), copy(B)), GenericLUFactorization())
+        @test solB.u ≈ Matrix(mk(A)) \ B rtol = 1.0e-10 * n
+    end
+end
+
+@testset "LUFactorization back-solve is size-aware (naive below cutoff, getrs! above)" begin
+    for n in (64, 256)
+        A = rand(n, n) + n * I
+        b = rand(n)
+        cache = init(LinearProblem(copy(A), copy(b)), LUFactorization())
+        sol = solve!(cache)
+        F = cache.cacheval
+        xldiv = ldiv!(similar(b), F, copy(b))
+        @test sol.u != xldiv
+        @test sol.u ≈ A \ b rtol = 1.0e-10 * n
+    end
+    for n in (257, 600)
+        A = rand(n, n) + n * I
+        b = rand(n)
+        cache = init(LinearProblem(copy(A), copy(b)), LUFactorization())
+        sol = solve!(cache)
+        F = cache.cacheval
+        xldiv = ldiv!(similar(b), F, copy(b))
+        @test sol.u == xldiv
+        @test sol.u ≈ A \ b rtol = 1.0e-10 * n
+    end
+    # Matrix right-hand sides keep the BLAS-3 path at every size
+    n = 100
+    A = rand(n, n) + n * I
+    B = rand(n, 4)
+    cacheB = init(LinearProblem(copy(A), copy(B)), LUFactorization())
+    solB = solve!(cacheB)
+    FB = cacheB.cacheval
+    Xldiv = ldiv!(similar(B), FB, copy(B))
+    @test solB.u == Xldiv
+    @test solB.u ≈ A \ B rtol = 1.0e-8
+end
+
 @testset "GenericLU back-solve on Adjoint/Transpose operators" begin
     for T in (Float64, Float32, ComplexF64, ComplexF32, BigFloat),
             wrap in (adjoint, transpose)
@@ -133,4 +192,23 @@ end
             Tuple{Matrix{Float64}, ipivT, rhsT}
         )
     end
+end
+
+@testset "smart helper is specialized only for BLAS-eligible strided vector solves" begin
+    ipivT = Vector{LinearAlgebra.BlasInt}
+    for T in (Float64, ComplexF32)
+        luT = LU{T, Matrix{T}, ipivT}
+        @test which(
+            LinearSolve._smart_lu_ldiv!, Tuple{Vector{T}, luT, Vector{T}}
+        ) !== which(
+            LinearSolve._smart_lu_ldiv!, Tuple{Matrix{T}, luT, Matrix{T}}
+        )
+    end
+    # No measured BLAS crossover for BigFloat: it keeps `_ldiv!` unconditionally
+    luB = LU{BigFloat, Matrix{BigFloat}, Vector{Int}}
+    @test which(
+        LinearSolve._smart_lu_ldiv!, Tuple{Vector{BigFloat}, luB, Vector{BigFloat}}
+    ) === which(
+        LinearSolve._smart_lu_ldiv!, Tuple{Matrix{BigFloat}, luB, Matrix{BigFloat}}
+    )
 end


### PR DESCRIPTION
⚠️ **Draft — please ignore until reviewed by @ChrisRackauckas.**

Rework of this branch's earlier draft ("defer large single-vector naive back-solves to `ldiv!`"), which put the size cutoff inside `_generic_lu_ldiv!` — GenericLUFactorization's solve path. Same measured data, opposite placement, per the backsolve-selection policy:

> If a user is choosing an LU, they are also choosing a backsolve; the defaults should try to be smart.

- **`GenericLUFactorization()`** = the user explicitly chose the generic route → its backsolve is **always** the pure-Julia naive kernel, at every size, with no BLAS deferral.
- **`LUFactorization()`** chose the LAPACK-flavored algorithm → `ldiv!`/getrs! is its baseline, and a smart helper (`_smart_lu_ldiv!`) may use the naive kernel below the measured crossover: single vectors at `N ≤ 256` (`Matrix` factors) / `≤ 512` (wrapped strided factors) take the naive kernel; larger vectors, matrix RHS, sparse, GPU, and non-BLAS eltypes keep `ldiv!` exactly as before.
- **Vendor selections** (MKL/OpenBLAS/AppleAccelerate/BLIS/CUDA/Metal, mixed-precision variants) use the chosen vendor's methods — no naive-kernel second-guessing.
- **Defaults** are smart by *picking* algorithms, and inherit each algorithm's own backsolve (including the smart helper when they pick `LUFactorization`); no explicit choice is overridden.

## What changed

- `src/factorization.jl`: `_generic_lu_ldiv!` stays unconditional (comment now says so); new `_naive_ldiv_cutoff` constants + `_smart_lu_ldiv!` helper; `LUFactorization`'s `solve!` now calls `_smart_lu_ldiv!` instead of `_ldiv!`; docstrings for both algorithms document their backsolve behavior.
- `test/Core/genericlu_naive_ldiv.jl`: three new testsets enforcing the policy by bitwise path discrimination and `which`-based dispatch checks (details below).

## Policy-conformance table (all LU-flavored solve paths in src/ + ext/)

| Algorithm | Backsolve used | Conforms |
|---|---|---|
| `GenericLUFactorization` | `_generic_lu_ldiv!` → naive kernel unconditionally (orientation-specialized for wrapped factors); non-stdlib LU cachevals (StaticArrays) keep their own `ldiv!` | ✅ (this PR keeps it unconditional; the previous draft here would have violated it) |
| `LUFactorization` | `_smart_lu_ldiv!`: naive kernel for BLAS-eltype strided vectors at/below crossover, `ldiv!` (getrs!) otherwise; sparse→UMFPACK, GPU→CUSOLVER, banded→banded LU all fall through to `ldiv!` untouched | ✅ (this PR; was plain `ldiv!` at every size) |
| `DefaultLinearSolver` | dispatches to the chosen algorithm's own `solve!` (GenericLU at `N ≤ 10`, RFLU/vendor/LU ladder above) — inherits each backsolve | ✅ smartness by selection |
| `RFLUFactorization` | RecursiveFactorization `lu!`; matrix RHS (`nrhs ≥ 2`, BLAS floats) → `TriangularSolve.ldiv!` both legs; vector RHS → LinearAlgebra `ldiv!` per the [#1161](https://github.com/SciML/LinearSolve.jl/issues/1161) measurements (TriangularSolve has no vector kernel) | ✅ LinearSolve-side routes to TriangularSolve; no cutoffs added here (RF internals under separate audit) |
| `RF32MixedLUFactorization` | RF `lu!` in Float32 + `ldiv!` + convert | ➖ same audit scope as above |
| `MKLLUFactorization` / `MKL32Mixed` | direct `getrs!` ccall into libmkl_rt | ✅ vendor |
| `OpenBLASLUFactorization` / `OpenBLAS32Mixed` | `openblas_getrs!` via dlsym | ✅ vendor |
| `AppleAccelerateLUFactorization` / `32Mixed` | `aa_getrs!` into libacc | ✅ vendor |
| `BLISLUFactorization` | reference-LAPACK `getrs!` via dlsym | ✅ vendor |
| `CudaOffloadLUFactorization` / `CUDAOffload32Mixed` | `ldiv!` on CuArrays (CUSOLVER) | ✅ vendor/GPU |
| `AMDGPUOffloadLUFactorization` | rocSOLVER `getrf!`/`getrs!` | ✅ vendor/GPU |
| `MetalLUFactorization` / `MetalOffload32Mixed` | `ldiv!` on Metal arrays | ✅ vendor/GPU |
| `GESVFactorization` | LAPACK getrf!/getrs! driver | ✅ explicit LAPACK choice |
| `FastLUFactorization` (FastLapackInterface) | `ldiv!` on workspace LU (LAPACK) | ✅ vendor |
| `SimpleLUFactorization` | own pure-Julia `simplelu_solve!` always | ✅ explicit generic choice |
| `SpecializedLUFactorization` (SpecializingFactorizations.jl) | `specializinglu` factor + that package's `ldiv!` | ✅ explicit choice of that package's kernels |
| Sparse LU family (UMFPACK/KLU/PureKLU/Supernodal/SuperLUDIST/…) | sparse solvers' own backsolves | ✅ (dense naive-kernel policy does not apply) |

The smart helper's specialized method is gated to `StridedVector{T}` RHS + `LU{T, <:Union{StridedMatrix{T}, Adjoint/Transpose-of-strided}}` + `T <: BLASELTYPES`, with an explicit `GPUArraysCore.AnyGPUArray` runtime guard (GPU arrays are `StridedMatrix` typewise); everything else takes the `_ldiv!` fallback, i.e. exactly the pre-PR behavior.

## Default-selection review (report only, no redesign)

The dense well-conditioned ladder in `src/default.jl` (`N ≤ 10` → GenericLU; autotune preference; AppleAccelerate if available; RFLU at `N ≤ 100` / `≤ 500` OpenBLAS / `≤ 200` MKL when RecursiveFactorization is loaded; MKL; else LUFactorization) is consistent with the policy — it picks algorithms and never overrides a chosen algorithm's backsolve. Two observations, no changes made:

1. When RecursiveFactorization is **not** loaded and MKL **is**, defaults pick `MKLLUFactorization` for all `N > 10`; MKL getrs! carries the ~290 ns call floor at small `N` where the naive kernel wins ~0.64x. If that ladder is ever revisited, small-`N` MKL picks could route to `LUFactorization` (now size-aware). Autotune preferences already paper over this where they exist.
2. The default's RFLU picks (`10 < N ≤ 100/200/500`) do single-vector backsolves through LinearAlgebra `ldiv!` (getrs!) per the [#1161](https://github.com/SciML/LinearSolve.jl/issues/1161) measurements — under this policy that's RF's call, and the RF/TriangularSolve side is under a separate audit; nothing changed here.

## Measured data

Single-vector naive kernel vs `ldiv!` on cached factors (from the earlier draft, unchanged; min-times, EPYC 7502, 1 BLAS thread, interleaved, μs — this is what sets the 256/512 cutoffs):

```
   N  | ldiv!-normal  naive-normal  ratio | ldiv!-adjoint  naive-adjoint  ratio
  256 |     17.8          16.6      0.93  |     21.1           19.5       0.93
  512 |     59.7          68.0      1.14  |     67.7           64.6       0.95
 1000 |    211.2         262.3      1.24  |     211.2          221.6      1.05
 2000 |   2577.4        3480.7      1.35  |    2177.5         3051.2      1.40
```

Multi-RHS naive sweeps won at every size measured (0.68–0.92x through N = 1000 at nrhs = 4), which is why `GenericLUFactorization` keeps them and why nothing multi-RHS defers.

New: `LUFactorization` backsolve **through `solve!`** before/after this PR (min-times over ≥300 samples, EPYC 7502, 1 BLAS thread, Julia 1.12.6; N = 512/1000 are min over 4 interleaved process pairs):

```
                       before (ldiv! always)   after (smart helper)   ratio
LU vector  N=16              0.611 us               0.389 us          0.64
LU vector  N=32              1.137 us               0.847 us          0.74
LU vector  N=64              2.437 us               1.986 us          0.81
LU vector  N=128             5.971 us               5.284 us          0.88
LU vector  N=256            17.863 us              16.322 us          0.91
LU vector  N=512            61.898 us              60.023 us          0.97 (deferred path, parity)
LU vector  N=1000          203.079 us             204.709 us          1.01 (deferred path, parity)
LU nrhs=4  N=100            13.083 us              13.156 us          1.01 (unchanged path)
LU nrhs=4  N=256            90.194 us              89.664 us          0.99 (unchanged path)
GenericLU  N=600            97.080 us              92.520 us          (unchanged path; shows the ±5% process noise floor)
```

Commands: `~/.juliaup/bin/julia +1.12 --project=<env> bench_lusolve.jl <TAG>` with the branch vs `origin/main` dev'd into two otherwise-identical environments.

## Tests (all discriminate: shown failing on the code they guard against)

Path discrimination compares `solve!` output **bitwise against the `ldiv!` reference**, whose bits are call-context-stable (LAPACK ccall for `Matrix` factors, plain-op generic substitution for wrapped factors). A first iteration compared bitwise against the naive kernel instead; that is not portable — the kernel's `muladd`/`@simd` loops contracted differently standalone vs inlined into `solve!` on Julia 1.11 (~4-ulp differences, adjoint cases only), so the shipped form asserts against `ldiv!`:

1. **"GenericLU keeps the naive kernel at every size"** — N = 600 (`Matrix` and adjoint; above both cutoffs): `sol.u != ldiv!`-bits (no BLAS deferral — a deferral makes them equal) plus `\`-correctness and large-N multi-RHS coverage.
   - On this branch's **previous** (guarded) code: fails (2/4, the guard's output *is* the `ldiv!` bits).
   - On this PR: pass.
2. **"LUFactorization back-solve is size-aware"** — below cutoff (N = 64, 256): `sol.u != ldiv!`-bits (must be the naive kernel); above (N = 257, 600) and matrix RHS (N = 100, nrhs = 4): `sol.u ==` the `ldiv!` bits exactly.
   - On `main` (no smart helper): fails (2/4, main's output *is* the `ldiv!` bits below the cutoff).
   - On this PR: pass.
3. **`which`-based dispatch checks** — `_smart_lu_ldiv!` has the specialized method for BLAS-eltype strided vector solves and only those (BigFloat resolves to the generic fallback); pre-existing checks for the orientation-specialized `_naive_lu_ldiv!` methods unchanged.

## Verification

Branch was rebased onto current `main` at 6bbb233d — past [#1173](https://github.com/SciML/LinearSolve.jl/pull/1173) (blocked pure-Julia `generic_lufact!` kernel for GenericLU) and [#1174](https://github.com/SciML/LinearSolve.jl/pull/1174) — before the final runs below. #1173 swaps GenericLU's **factorization** kernel and keeps the naive backsolve family, so it composes with this PR (which governs **backsolve** selection); the docstring hunks merged cleanly and the discriminating tests re-ran green on top of it.

- `test/Core/genericlu_naive_ldiv.jl`, **all 9 testsets / 499 assertions green** on the final rebased tree (Julia 1.12.6, `--check-bounds=auto`):
  ```
  GenericLU naive back-solve correctness |  120    120
  GenericLU naive back-solve kernel vs getrs! |   12     12
  GenericLU back-solve reuse (many RHS, one factorization) |   21     21
  GenericLU naive back-solve with NoPivot |    1      1
  GenericLU keeps the naive kernel at every size (no BLAS deferral) |    6      6
  LUFactorization back-solve is size-aware (naive below cutoff, getrs! above) |   10     10
  GenericLU back-solve on Adjoint/Transpose operators |  322    322
  Adjoint/Transpose strided factors dispatch to the specialized kernel |    4      4
  smart helper is specialized only for BLAS-eligible strided vector solves |    3      3
  ```
  Same file also green on Julia 1.10, 1.11, 1.12.4 (`--check-bounds=auto`) and 1.12.6 (`--check-bounds=auto` twice and `--check-bounds=yes`) pre-rebase.
- `GROUP=Core` via `Pkg.test()` (Julia 1.12.6), **on the final rebased tree**: `Testing LinearSolve tests passed`, exit 0 (includes basictests, the new `blocked_lufact` tests from #1173, and this PR's file: `GenericLU naive back-solve | 499 499`). Also passed on the two earlier bases this branch sat on (pre-rebase and on fbc5d0af), exit 0 each time.
- `GROUP=QA` via `Pkg.test()` (Julia 1.12.6, JET 0.11.6), **on the final rebased tree**: `Quality Assurance | 48 pass, 1 broken — Testing LinearSolve tests passed` (JET: 34 pass, 8 broken, 0 fail). Also green on the fbc5d0af base (`Quality Assurance | 48 pass, 1 broken`; JET 34 pass, 8 broken, 0 fail). On the oldest base the one QA failure was the KLU JET `@test_opt` at `test/qa/jet.jl:136`, which reproduced identically on a clean checkout of unmodified main in the same environment — the known [#1098](https://github.com/SciML/LinearSolve.jl/issues/1098), resolved on `main` by [#1163](https://github.com/SciML/LinearSolve.jl/pull/1163) (this diff touches no sparse/KLU code).
- Docs build (`julia --project=docs docs/make.jl`) on the final rebased tree, i.e. including the merged #1173 + policy docstring text: exit 0.
- Runic `--check` on both changed files: clean. `typos` over the final diff vs `origin/main`: clean.

## Pre-existing Julia 1.11–1.12 GC crash (not introduced here)

Extending the GenericLU testset to N = 1200 (adjoint) can crash nondeterministically with `GC error (probable corruption)`. This **reproduces on unmodified `main`** (clean checkout at cb7c181a; 27 crashes observed across the investigation), affects Julia 1.11.9 (2/3), 1.12.4 (1/3), 1.12.5 (1/3), and 1.12.6 (9/15) while 1.10.11 and 1.13.0-rc1 stayed clean (0/4 each), crashes under both `--check-bounds=auto` and `--check-bounds=yes` with zero `BoundsError`s ever thrown, and shows a corrupt object tag equal to the matrix dimension (`0x4b0` = 1200) in 19 of 24 readable headers. OpenBLAS threading, pkgimages, individual `@inbounds`/`@simd` annotations, and hardware were ruled out; a SciML-free standalone reproducer has not been achieved yet (0/12 across two vendored-kernel attempts). The shipped testset therefore stops at N = 600 — which already exceeds both cutoffs, so policy coverage is complete — and the 600-only workload was green in all 9 version/flag lanes. Tracked in https://github.com/SciML/LinearSolve.jl/issues/1170.

## Not verified

- macOS AppleAccelerate, Metal, CUDA, BLIS lanes (no hardware/local setup) — but none of their code is touched.
- Julia pre/nightly locally; CI will cover.
- Downstream packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
