### PR TITLE
Thread backend convergence metadata through the a-posteriori safety check

### DIFF
--- a/ext/LinearSolvePETScExt.jl
+++ b/ext/LinearSolvePETScExt.jl
@@ -617,14 +617,17 @@ function gather_petsc_vec_to_all!(u::AbstractVector, petsclib, petsc_x)
     return nothing
 end
 
-function postsolve_solution_check(cache, alg, pcache, A::AbstractMatrix, u::AbstractVector)
+function postsolve_solution_check(
+        cache, alg, pcache, A::AbstractMatrix, u::AbstractVector;
+        iters::Int = 0, resid = nothing
+    )
     if pcache.comm == MPI.COMM_SELF || A isa SparseMatrixCSC
-        return LinearSolve._check_residual_safety(cache, alg, A, u)
+        return LinearSolve._check_residual_safety(cache, alg, A, u; iters, resid)
     end
     return nothing
 end
 
-postsolve_solution_check(cache, alg, pcache, A, u) = nothing
+postsolve_solution_check(cache, alg, pcache, A, u; iters::Int = 0, resid = nothing) = nothing
 
 function run_ksp_mpi!(pcache, petsclib, alg, b::AbstractVector, u::AbstractVector)
     petsc_x = pcache.petsc_x
@@ -830,7 +833,7 @@ function SciMLBase.solve!(cache::LinearCache, alg::PETScAlgorithm; kwargs...)
         retcode = ReturnCode.Failure
     end
     if retcode === ReturnCode.Success
-        failed = postsolve_solution_check(cache, alg, pcache, cache.A, cache.u)
+        failed = postsolve_solution_check(cache, alg, pcache, cache.A, cache.u; iters, resid)
         failed !== nothing && return failed
     end
 

--- a/ext/LinearSolvePETScMPIExt.jl
+++ b/ext/LinearSolvePETScMPIExt.jl
@@ -362,7 +362,10 @@ function PETScExt.run_ksp!(pcache, petsclib, alg, b::PVector, u::PVector)
     return nothing
 end
 
-function PETScExt.postsolve_solution_check(cache, alg, pcache, A::PSparseMatrix, u::PVector)
+function PETScExt.postsolve_solution_check(
+        cache, alg, pcache, A::PSparseMatrix, u::PVector;
+        iters::Int = 0, resid = nothing
+    )
     u_consistent = consistent(u, partition(axes(A, 2))) |> fetch
     Au = similar(u_consistent, axes(A, 1))
     LinearAlgebra.mul!(Au, A, u_consistent)
@@ -385,8 +388,11 @@ function PETScExt.postsolve_solution_check(cache, alg, pcache, A::PSparseMatrix,
     tol = cache.abstol + cache.reltol * b_norm
 
     if res_norm > tol
+        # Unlike LinearSolve._check_residual_safety, falling back to res_norm is
+        # type-safe here: the sole call site always supplies the KSP residual.
         return SciMLBase.build_linear_solution(
-            alg, u, nothing, nothing; retcode = ReturnCode.APosterioriSafetyFailure
+            alg, u, something(resid, res_norm), nothing;
+            retcode = ReturnCode.APosterioriSafetyFailure, iters
         )
     end
     return nothing

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -109,16 +109,24 @@ function _copy_A_for_safety(cache::LinearCache)
 end
 
 """
-    _check_residual_safety(cache::LinearCache, alg, A_original, y)
+    _check_residual_safety(cache::LinearCache, alg, A_original, y; iters = 0, resid = nothing)
 
 Post-solve residual check for LU algorithms with `residualsafety=true`.
 Computes `‖A*y - b‖` and returns an `APosterioriSafetyFailure` solution if it
 exceeds `abstol + reltol * ‖b‖`. Returns `nothing` if the residual is acceptable.
 
+Iterative callers can pass their backend's convergence metadata through `iters`
+and `resid` so a failing check still reports it. The defaults keep the failure
+solution type-identical to the success path (`resid = nothing`): substituting the
+check's own `res_norm` here would put a `Float64`/`Nothing` union in `solve!`'s
+return type for every LU algorithm, breaking the concrete-return QA invariant.
+
 When inside `DefaultLinearSolver`, uses the pre-allocated `residual_buf` from
 `DefaultLinearSolverInit` (non-allocating). For standalone use, allocates a buffer.
 """
-function _check_residual_safety(cache::LinearCache, alg, A_original, y)
+function _check_residual_safety(
+        cache::LinearCache, alg, A_original, y; iters::Int = 0, resid = nothing
+    )
     b = cache.b
     if cache.alg isa DefaultLinearSolver
         buf = cache.cacheval.residual_buf
@@ -140,7 +148,8 @@ function _check_residual_safety(cache::LinearCache, alg, A_original, y)
             return "Residual safety check failed: ‖A*x - b‖ = $(res_norm), tol = $(tol) (abstol = $(cache.abstol), reltol = $(cache.reltol), ‖b‖ = $(b_norm), ratio = $(res_norm / tol))"
         end
         return SciMLBase.build_linear_solution(
-            alg, y, nothing, nothing; retcode = ReturnCode.APosterioriSafetyFailure
+            alg, y, resid, nothing;
+            retcode = ReturnCode.APosterioriSafetyFailure, iters
         )
     end
     return nothing

--- a/test/Core/default_algs.jl
+++ b/test/Core/default_algs.jl
@@ -461,6 +461,22 @@ sol_glu_rs = solve(
 )
 @test sol_glu_rs.retcode === ReturnCode.APosterioriSafetyFailure
 
+# Callers with backend convergence metadata pass it through the failing check (#1166)
+cache_meta = init(LinearProblem(copy(A_nearsing), copy(b_nearsing)), LUFactorization())
+sol_meta = LinearSolve._check_residual_safety(
+    cache_meta, cache_meta.alg, A_nearsing, ones(n); iters = 7, resid = 1.25
+)
+@test sol_meta.retcode === ReturnCode.APosterioriSafetyFailure
+@test sol_meta.iters == 7
+@test sol_meta.resid == 1.25
+# Defaults keep the failure solution type-identical to the success path
+sol_default_meta = LinearSolve._check_residual_safety(
+    cache_meta, cache_meta.alg, A_nearsing, ones(n)
+)
+@test sol_default_meta.retcode === ReturnCode.APosterioriSafetyFailure
+@test sol_default_meta.iters == 0
+@test sol_default_meta.resid === nothing
+
 # Default LUFactorization() on near-singular matrix → ReturnCode.Success (no check)
 sol_lu_default = solve(
     LinearProblem(copy(A_nearsing), copy(b_nearsing)),

--- a/test/LinearSolvePETSc/petsctests.jl
+++ b/test/LinearSolvePETSc/petsctests.jl
@@ -259,6 +259,30 @@ end
     PETScExt.cleanup_petsc_cache!(cache)
 end
 
+@testset "Serial: safety-check failure keeps convergence metadata" begin
+    # KSP converges by its own loose rtol, but the true residual fails
+    # LinearSolve's a-posteriori check; iters/resid must survive (#1166).
+    n = 100
+    A = sprand(n, n, 0.05) + 10I
+    A = A'A
+    b = rand(n)
+
+    cache = SciMLBase.init(
+        LinearProblem(A, b),
+        PETScAlgorithm(:gmres; ksp_options = (ksp_rtol = 0.9,));
+        abstol = 0.0,
+        reltol = 1.0e-12,
+        maxiters = 100
+    )
+    sol = solve!(cache)
+
+    @test sol.retcode == SciMLBase.ReturnCode.APosterioriSafetyFailure
+    @test sol.iters > 0
+    @test sol.resid isa Float64
+    @test sol.resid > 0
+    PETScExt.cleanup_petsc_cache!(cache)
+end
+
 @testset "Serial: Cleanup" begin
     n = 50
     A = sprand(n, n, 0.1) + 10I; A = A'A; b = rand(n)

--- a/test/LinearSolvePETSc/petsctests_mpi.jl
+++ b/test/LinearSolvePETSc/petsctests_mpi.jl
@@ -350,6 +350,10 @@ end
         )
         sol = solve!(cache)
         @test sol.retcode == SciMLBase.ReturnCode.APosterioriSafetyFailure
+        # Backend convergence metadata survives the failing safety check (#1166)
+        @test sol.iters > 0
+        @test sol.resid isa Float64
+        @test sol.resid > 0
         PETScExt.cleanup_petsc_cache!(cache)
     end
 end


### PR DESCRIPTION
Fixes #1166.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- _check_residual_safety now accepts iters and resid kwargs and puts them on the APosterioriSafetyFailure solution instead of dropping them.
- The PETSc extension forwards the KSP iteration count and residual norm through postsolve_solution_check, on both the serial and the MPI PSparseMatrix paths.
- The MPI path previously hardcoded nothing for resid even though it had just computed the distributed residual norm; it now reports the forwarded KSP norm with the computed norm as fallback.
- Defaults keep the failure solution type identical to the success path. Reporting the check's own res_norm by default would put a Float64/Nothing union in solve!'s return type for every LU algorithm and break the concrete-return QA tests in test/qa/jet.jl; this was measured, not guessed.
- Tests: metadata pass-through and unchanged defaults in test/Core/default_algs.jl, plus PETSc serial and MPI safety-failure tests asserting iters > 0 and a positive Float64 resid.
- Verified locally: solve! return types stay concrete for the default solver, LUFactorization and GenericLUFactorization; QA jet.jl and allocations suites green; Runic clean.

AI Disclosure: Used Opus 5