### PR TITLE
Resolve the Julia 1.10/1.11 CHOLMOD-SVector ldiv ambiguities with per-type methods

### DIFF
--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -1124,15 +1124,17 @@ end
             )
             (A \ b)
         end
+        # SPQR's `\`, like CHOLMOD's, has no method for an `SVector`
+        # right-hand side, so solve against a `Vector` copy.
         function LinearSolve._ldiv!(
                 ::SVector, A::SparseArrays.SPQR.QRSparse, b::SVector
             )
-            (A \ b)
+            (A \ Vector(b))
         end
         function LinearSolve._ldiv!(
                 x::AbstractVector, A::SparseArrays.SPQR.QRSparse, b::SVector
             )
-            x .= A \ b
+            x .= A \ Vector(b)
         end
     end
 
@@ -1145,19 +1147,28 @@ end
         x .= A \ b
     end
 
+    # Disambiguate the CHOLMOD `_ldiv!(::AbstractVecOrMat, ::Factor,
+    # ::AbstractVecOrMat)` above against LinearSolve's generic `SVector`
+    # methods (src/factorization.jl), mirroring the SPQR trio. These must be
+    # per-type: a `Union` in the factor position is less specific than
+    # `CHOLMOD.Factor`, so a Union-typed method covers the intersections
+    # without resolving them (LinearSolve.jl#1141).
+    # CHOLMOD's `\` has no method for an `SVector` right-hand side, so those
+    # bodies solve against a `Vector` copy.
     function LinearSolve._ldiv!(
-            ::SVector,
-            A::Union{SparseArrays.CHOLMOD.Factor, SparseArrays.SPQR.QRSparse},
-            b::AbstractVector
+            ::SVector, A::SparseArrays.CHOLMOD.Factor, b::AbstractVecOrMat
         )
         (A \ b)
     end
     function LinearSolve._ldiv!(
-            ::SVector,
-            A::Union{SparseArrays.CHOLMOD.Factor, SparseArrays.SPQR.QRSparse},
-            b::SVector
+            ::SVector, A::SparseArrays.CHOLMOD.Factor, b::SVector
         )
-        (A \ b)
+        (A \ Vector(b))
+    end
+    function LinearSolve._ldiv!(
+            x::AbstractVecOrMat, A::SparseArrays.CHOLMOD.Factor, b::SVector
+        )
+        x .= A \ Vector(b)
     end
 end # @static if Base.USE_GPL_LIBS
 


### PR DESCRIPTION
Fixes #1141.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- Root cause: the Union{CHOLMOD.Factor, SPQR.QRSparse} SVector disambiguators are less specific than CHOLMOD.Factor in the factor position, so they cover the intersections with the VERSION < 1.12 CHOLMOD _ldiv! method without resolving them. That CHOLMOD method does not exist on 1.12+, which is why CI (QA on julia 1) never sees the failure.
- Fix: replace the Union methods with a per-type CHOLMOD trio, mirroring the SPQR trio from #1149. Aqua's suggested signatures match these exactly.
- Drive-by: CHOLMOD and SPQR \ have no SVector RHS method, so the SVector-b bodies now solve against a Vector copy. The old Union bodies threw a MethodError if ever called; verified by direct calls on 1.10 and 1.12.
- Of the 16 ambiguities in the issue report, 13 were already fixed by #1149; pristine main today shows exactly 3 on both 1.10.11 and 1.11.9.
- Verified: Aqua ambiguities FAIL (3 pairs) on pristine main and PASS with this branch, on Julia 1.10.11 and 1.11.9; 1.12.6 stays clean. qa.jl (19 pass, 1 known broken) and jet.jl unchanged on 1.12. Runic clean.
- Existing strict Aqua ambiguity check in test/qa/qa.jl is the regression test; it guards whichever Julia version runs the QA group.

AI Disclosure: Used Opus 5