### PR TITLE
RFLU: pure-Julia naive back-solve for single right-hand sides

### DIFF
--- a/ext/LinearSolveRecursiveFactorizationExt.jl
+++ b/ext/LinearSolveRecursiveFactorizationExt.jl
@@ -11,6 +11,15 @@ using SciMLLogging: @SciMLMessage
 
 LinearSolve.userecursivefactorization(A::Union{Nothing, AbstractMatrix}) = true
 
+# `RecursiveFactorization.lu!(A, ipiv, Val(false), ...)` only fills a
+# caller-supplied `ipiv` on Julia < 1.8; on newer releases it expects its own
+# `NotIPIV` sentinel for the unpivoted case and leaves this vector undefined.
+# The resulting `LU` is then handed to consumers (`getrs!`, `_ipiv_rows!`, the
+# naive kernel) that all apply `ipiv` unconditionally, so seed the identity
+# permutation ourselves.
+@inline _init_unpivoted!(ipiv, ::Val{true}) = ipiv
+@inline _init_unpivoted!(ipiv, ::Val{false}) = copyto!(ipiv, eachindex(ipiv))
+
 function SciMLBase.solve!(
         cache::LinearSolve.LinearCache, alg::RFLUFactorization{P, T};
         kwargs...
@@ -22,6 +31,7 @@ function SciMLBase.solve!(
         if length(ipiv) != min(size(A)...)
             ipiv = Vector{LinearAlgebra.BlasInt}(undef, min(size(A)...))
         end
+        _init_unpivoted!(ipiv, Val(P))
         fact = RecursiveFactorization.lu!(A, ipiv, Val(P), Val(T), check = false)
         cache.cacheval = (fact, ipiv)
         if !LinearAlgebra.issuccess(fact)
@@ -133,6 +143,7 @@ function SciMLBase.solve!(
             resize!(ipiv, min(size(A_32)...))
         end
 
+        _init_unpivoted!(ipiv, Val(P))
         fact = RecursiveFactorization.lu!(A_32, ipiv, Val(P), Val(T), check = false)
         cache.cacheval = (fact, ipiv, A_32, b_32, u_32)
 

--- a/ext/LinearSolveRecursiveFactorizationExt.jl
+++ b/ext/LinearSolveRecursiveFactorizationExt.jl
@@ -68,9 +68,39 @@ end
 #   256    49.18 us   22.04 us       48.93 us   19.08 us
 #   500   154.79 us   79.64 us      150.16 us   75.22 us
 #
-# For a single vector right-hand side TriangularSolve has no advantage (it has
-# no vector kernel, and reshaping to n x 1 measured 1.09x at n=128 but 0.88x by
-# n=256), so vectors keep the stdlib path.
+# A single right-hand side is a different problem: `ldiv!(u, ::LU, b)` reaches
+# OpenBLAS `getrs!`, whose ~290 ns call floor dominates the whole solve at the
+# sizes where RFLU is the dense default (10 < N <= 100).  LinearSolve's in-tree
+# naive kernel (#1151, orientation-specialized in #1162) applies the pivots and
+# both triangular sweeps in one pass and wins until its unblocked sweep falls
+# out of cache; TriangularSolve 0.2.4's vector `ldiv!` also beats `getrs!`, but
+# is 0-8% behind the naive kernel at every size and stops at its own n = 128
+# cutoff.  Vector back-solve, min-of-N ns, RF's pivoted `lu!` in every arm and
+# only the back-solve differing:
+#
+#   n     getrs!   naive kernel   TriangularSolve 0.2.4
+#     8      459     169 (0.37x)      220 (0.48x)
+#    20      829     439 (0.53x)      499 (0.60x)
+#    64     2620    1830 (0.70x)     1890 (0.72x)
+#   128     6080    4810 (0.79x)     4830 (0.79x)
+#   256    17710   15750 (0.89x)    18160 (1.03x)
+#   400    38900   40660 (1.05x)    39320 (1.01x)
+const NAIVE_LDIV_MAXSIZE = 256
+
+# The kernel is `@inbounds`, so restrict it to a square factorization whose
+# pivot vector matches the right-hand side; anything else keeps the stdlib path.
+@inline function _rf_ldiv!(
+        u::StridedVector{T}, fact::LinearAlgebra.LU{T, <:StridedMatrix{T}},
+        b::StridedVector{T}, ::Val
+    ) where {T <: LinearAlgebra.BlasFloat}
+    m, k = size(fact.factors)
+    n = length(b)
+    usable = m == k == n == length(u) == length(fact.ipiv) && n <= NAIVE_LDIV_MAXSIZE
+    usable || return ldiv!(u, fact, b)
+    u === b || copyto!(u, b)
+    return LinearSolve._naive_lu_ldiv!(fact.factors, fact.ipiv, u)
+end
+
 @inline function _rf_ldiv!(
         u::AbstractVector, fact::LinearAlgebra.LU, b::AbstractVector, ::Val
     )
@@ -81,9 +111,12 @@ function _rf_ldiv!(
         U::AbstractMatrix{T}, fact::LinearAlgebra.LU{T, <:StridedMatrix{T}},
         B::AbstractMatrix{T}, ::Val{Thread}
     ) where {T <: LinearAlgebra.BlasFloat, Thread}
-    # A single column is the vector case in disguise: measured 0.87-0.90x at
-    # n >= 256, so it keeps the stdlib path.
-    size(B, 2) == 1 && return ldiv!(U, fact, B)
+    # A single column is the vector case in disguise, so it goes to the vector
+    # method rather than to `trsm`-sized kernels.
+    if size(B, 2) == 1 && size(U, 2) == 1
+        _rf_ldiv!(view(U, :, 1), fact, view(B, :, 1), Val(Thread))
+        return U
+    end
     U === B || copyto!(U, B)
     LinearAlgebra._ipiv_rows!(fact, 1:length(fact.ipiv), U)
     F = fact.factors

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -472,6 +472,10 @@ is in the works.
 - Optimized specifically for Float32 and Float64 element types
 - Recursive blocking strategy provides excellent cache performance
 - Multi-threading can provide significant speedups on multi-core systems
+- Back-solves avoid BLAS: a matrix right-hand side runs TriangularSolve's blocked
+  kernels, and a single right-hand side up to size 256 runs the same pure-Julia
+  triangular solve `GenericLUFactorization` uses, which skips the ~290 ns
+  `getrs!` call floor (see SciML/LinearSolve.jl#1161)
 
 ## Requirements
 Using this solver requires that RecursiveFactorization.jl is loaded: `using RecursiveFactorization`

--- a/test/Core/rflu_naive_ldiv.jl
+++ b/test/Core/rflu_naive_ldiv.jl
@@ -1,0 +1,107 @@
+using LinearSolve, LinearAlgebra, RecursiveFactorization, Test, Random
+
+Random.seed!(1161)
+
+const RFExt = Base.get_extension(LinearSolve, :LinearSolveRecursiveFactorizationExt)
+const CUTOFF = RFExt.NAIVE_LDIV_MAXSIZE
+
+# A row-reversed diagonally dominant matrix: well conditioned, but partial
+# pivoting has to undo the reversal, so a back-solve that skips the row
+# interchanges gets a wrong answer rather than the same answer.
+pivoting_matrix(T, n) = (rand(T, n, n) + n * I)[n:-1:1, :]
+
+rf_lu(A) = RecursiveFactorization.lu!(
+    copy(A), Vector{LinearAlgebra.BlasInt}(undef, min(size(A)...)),
+    Val(true), Val(true), check = false
+)
+
+@testset "RFLU back-solve correctness across the naive-kernel cutoff" begin
+    for T in (Float64, Float32, ComplexF64, ComplexF32)
+        @testset "$T" begin
+            rtol = 100 * eps(float(real(one(T))))
+            sizes = T === Float64 ? (2, 5, 20, 64, CUTOFF, CUTOFF + 1) : (2, 5, 20, 64)
+            for n in sizes
+                A = pivoting_matrix(T, n)
+                # The pivot-sensitivity of this testset rests on interchanges
+                # actually firing.
+                @test rf_lu(A).ipiv != collect(1:n)
+                for rhs in (rand(T, n), rand(T, n, 1), rand(T, n, 4))
+                    sol = solve(LinearProblem(copy(A), copy(rhs)), RFLUFactorization())
+                    @test SciMLBase.successful_retcode(sol)
+                    @test sol.u ≈ A \ rhs rtol = rtol * n
+                end
+            end
+        end
+    end
+end
+
+# Discriminator for #1161: at or below the cutoff the single-RHS path must
+# produce exactly what the naive kernel produces, bit for bit. `getrs!` solves
+# the same system to a different rounding, so this fails if the path reverts to
+# `ldiv!`.
+@testset "RFLU single-RHS back-solve runs the naive kernel" begin
+    for n in (2, 5, 20, 64, 128, CUTOFF)
+        A = pivoting_matrix(Float64, n)
+        b = rand(n)
+        fact = rf_lu(A)
+        @test fact.ipiv != collect(1:n)
+
+        ref = copy(b)
+        LinearSolve._naive_lu_ldiv!(fact.factors, fact.ipiv, ref)
+        @test ref ≈ A \ b rtol = 1.0e-10
+
+        u = similar(b)
+        RFExt._rf_ldiv!(u, fact, b, Val(true))
+        @test u == ref
+
+        U = similar(b, n, 1)
+        RFExt._rf_ldiv!(U, fact, reshape(b, n, 1), Val(true))
+        @test vec(U) == ref
+
+        # In-place aliasing (`u === b`) must solve rather than zero the RHS.
+        aliased = copy(b)
+        RFExt._rf_ldiv!(aliased, fact, aliased, Val(true))
+        @test aliased == ref
+    end
+end
+
+@testset "RFLU keeps the stdlib path above the cutoff" begin
+    n = CUTOFF + 1
+    A = pivoting_matrix(Float64, n)
+    b = rand(n)
+    fact = rf_lu(A)
+
+    ref = similar(b)
+    ldiv!(ref, fact, b)
+
+    u = similar(b)
+    RFExt._rf_ldiv!(u, fact, b, Val(true))
+    @test u == ref
+
+    U = similar(b, n, 1)
+    RFExt._rf_ldiv!(U, fact, reshape(b, n, 1), Val(true))
+    @test vec(U) == ref
+end
+
+# The naive kernel is `@inbounds` and assumes a square factorization, so a
+# non-square `LU` has to stay on the stdlib path (which reports the mismatch)
+# rather than walking off the end of `factors`.
+@testset "RFLU non-square factorization keeps the stdlib path" begin
+    fact = rf_lu(rand(6, 4))
+    @test_throws DimensionMismatch RFExt._rf_ldiv!(zeros(6), fact, rand(6), Val(true))
+end
+
+@testset "RFLU cached re-solve with a new b" begin
+    n = 20
+    A0 = pivoting_matrix(Float64, n)
+    cache = init(
+        LinearProblem(copy(A0), rand(n)), RFLUFactorization();
+        alias = LinearAliasSpecifier(alias_A = false, alias_b = false)
+    )
+    for _ in 1:10
+        bnew = rand(n)
+        cache.b = bnew
+        solve!(cache)
+        @test A0 * cache.u ≈ bnew rtol = 1.0e-10
+    end
+end

--- a/test/Core/rflu_nopivot_ipiv.jl
+++ b/test/Core/rflu_nopivot_ipiv.jl
@@ -1,0 +1,37 @@
+using LinearSolve, LinearAlgebra, RecursiveFactorization, Test, Random
+
+Random.seed!(1161)
+
+# `RecursiveFactorization.lu!(A, ipiv, Val(false), ...)` leaves a
+# caller-supplied `ipiv` undefined on Julia >= 1.8, so the pivot buffer reaching
+# the back-solve holds whatever the allocator left behind. Seeding it with a
+# valid-but-wrong permutation makes that observable as a wrong answer instead of
+# as an out-of-bounds read.
+poison(n) = fill(LinearAlgebra.BlasInt(n), n)
+
+@testset "RFLU pivot = Val(false) ignores stale pivots" begin
+    for n in (5, 20, 64)
+        # Diagonally dominant, so the unpivoted factorization is stable and the
+        # identity permutation is the right answer.
+        A = rand(n, n) + n * I
+        b = rand(n)
+        xref = A \ b
+
+        cache = init(LinearProblem(copy(A), copy(b)), RFLUFactorization(pivot = Val(false)))
+        cache.cacheval = (cache.cacheval[1], poison(n))
+        sol = solve!(cache)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u ≈ xref rtol = 1.0e-10
+        @test cache.cacheval[2] == 1:n
+
+        cache32 = init(
+            LinearProblem(copy(A), copy(b)), RF32MixedLUFactorization(pivot = Val(false))
+        )
+        cv = cache32.cacheval
+        cache32.cacheval = (cv[1], poison(n), cv[3], cv[4], cv[5])
+        sol32 = solve!(cache32)
+        @test SciMLBase.successful_retcode(sol32)
+        @test sol32.u ≈ xref rtol = 1.0e-4
+        @test cache32.cacheval[2] == 1:n
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ else
             @time @safetestset "EigenvalueProblem" include("Core/eigenvalue.jl")
             @time @safetestset "Batched RHS" include("Core/batch.jl")
             @time @safetestset "GenericLU naive back-solve" include("Core/genericlu_naive_ldiv.jl")
+            @time @safetestset "RFLU unpivoted ipiv" include("Core/rflu_nopivot_ipiv.jl")
             @time @safetestset "GESV Factorization" include("Core/gesv.jl")
             @time @safetestset "LU Refactorization Reuse" include("Core/lu_refactorization.jl")
             @time @safetestset "Direct BLAS Refactorization Reuse" include("Core/direct_blas_refactorization.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ else
             @time @safetestset "Batched RHS" include("Core/batch.jl")
             @time @safetestset "GenericLU naive back-solve" include("Core/genericlu_naive_ldiv.jl")
             @time @safetestset "RFLU unpivoted ipiv" include("Core/rflu_nopivot_ipiv.jl")
+            @time @safetestset "RFLU naive back-solve" include("Core/rflu_naive_ldiv.jl")
             @time @safetestset "GESV Factorization" include("Core/gesv.jl")
             @time @safetestset "LU Refactorization Reuse" include("Core/lu_refactorization.jl")
             @time @safetestset "Direct BLAS Refactorization Reuse" include("Core/direct_blas_refactorization.jl")


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

Fixes #1161.

Two commits. The first is a prerequisite bug fix I hit while doing the second; it is
independently reviewable and can be split into its own PR if you prefer.

## Commit 1 — `pivot = Val(false)` was consuming uninitialized pivots

`RecursiveFactorization.lu!(A, ipiv, Val(false), ...)` only fills a caller-supplied `ipiv`
when `CUSTOMIZABLE_PIVOT` is false, i.e. on Julia < 1.8
([`RecursiveFactorization/src/lu.jl:103`](https://github.com/JuliaLinearAlgebra/RecursiveFactorization.jl/blob/master/src/lu.jl)).
On Julia >= 1.8 it expects its own `NotIPIV` sentinel for the unpivoted case and leaves a
passed vector alone. LinearSolve passes `Vector{BlasInt}(undef, n)`, so the `LU`
that comes back carries **undefined** pivots — and `getrs!`, `_ipiv_rows!` and the naive
kernel all apply `ipiv` unconditionally. On main, Julia 1.11.9:

```
julia> ldiv!(u, fact, b)   # fact from RFLU's pivot = Val(false) path
ERROR: ReadOnlyMemoryError()
Stacktrace:
 [1] getrs!(trans::Char, A::Matrix{Float64}, ipiv::Vector{Int64}, B::Vector{Float64})
   @ LinearAlgebra.LAPACK .../stdlib/v1.11/LinearAlgebra/src/lapack.jl:1056
```

The fix seeds the identity permutation before factorizing, for both `RFLUFactorization` and
`RF32MixedLUFactorization`. Test (`test/Core/rflu_nopivot_ipiv.jl`) seeds the cache's pivot
buffer with a *valid but wrong* permutation (`fill(n, n)`) so the failure is a wrong answer
rather than an out-of-bounds read, making it safe to run in CI. With the fix reverted, 4 of
the 6 assertions per size fail (the solution check and the `ipiv == 1:n` check, for both
`RFLUFactorization` and `RF32MixedLUFactorization`); with the fix, 18/18 pass.

This is arguably an upstream footgun — `lu!` accepting an explicit `ipiv` and silently not
writing it is easy to get wrong — but LinearSolve can defend itself in two lines. I have not
filed anything upstream.

## Commit 2 — what changed and why

`RFLUFactorization` is the dense default for `10 < N <= 100` once RecursiveFactorization is
loaded, but its **single**-right-hand-side back-solve still went `ldiv!(u, fact, b)` →
`LinearAlgebra` → OpenBLAS `getrs!`, paying the ~290 ns call floor that #1151 removed for
`GenericLUFactorization`. #1151 only covered `GenericLU`.

Single-RHS solves at or below `N = 256` now run LinearSolve's in-tree `_naive_lu_ldiv!`
(added in #1151, orientation-specialized in #1162), and the matrix method's
`size(B, 2) == 1 && return ldiv!(U, fact, B)` bail is replaced by a route to that same vector
path — a one-column matrix was the worst-served case of all, since it bailed to `getrs!`
*and* skipped TriangularSolve. Multi-RHS (`nrhs >= 2`) is untouched: TriangularSolve's blocked
kernels still win there by 2-3x.

The stale comment claiming *"For a single vector right-hand side TriangularSolve has no
advantage (it has no vector kernel...)"* is replaced with the measurement below.

## Design choice: the in-tree naive kernel, not TriangularSolve 0.2.4

TriangularSolve 0.2.4 (JuliaSIMD/TriangularSolve.jl#47) does now have a native vector
`ldiv!` dispatch, so it was a real candidate. It loses on the measurement. Back-solve only,
RecursiveFactorization's own pivoted `lu!` in every arm and *only* the back-solve differing,
interleaved in one process, min-of-N per-call `time_ns`, each call feeding a `Ref` sink,
`BLAS.set_num_threads(1)`, `taskset -c 8`. Times in ns:

| n | `ldiv!` (getrs!) | naive kernel | TriangularSolve 0.2.4 vector `ldiv!` |
|---|---|---|---|
| 4 | 349 | **90 (0.26x)** | 149 (0.43x) |
| 8 | 459 | **169 (0.37x)** | 220 (0.48x) |
| 16 | 740 | **349 (0.47x)** | 410 (0.55x) |
| 20 | 829 | **439 (0.53x)** | 499 (0.60x) |
| 32 | 1280 | **789 (0.62x)** | 880 (0.69x) |
| 64 | 2620 | **1830 (0.70x)** | 1890 (0.72x) |
| 128 | 6080 | **4810 (0.79x)** | 4830 (0.79x) |
| 256 | 17710 | **15750 (0.89x)** | 18160 (1.03x) |
| 400 | 38900 | 40660 (1.05x) | 39320 (1.01x) |

The naive kernel is ahead of TriangularSolve at **every** size, by 0-8%. Two structural
reasons on top of the raw numbers:

1. TriangularSolve's vector path carries its own `VECTOR_RHS_CUTOFF = 128`, above which it
   falls back to `LinearAlgebra.ldiv!` per leg. Composed with the separate
   `_ipiv_rows!` pass that the RFLU path needs, that is **slower than the `getrs!` we started
   from** (1.02-1.04x at n = 160-256) — i.e. routing through TriangularSolve would mean either
   duplicating its cutoff in LinearSolve or shipping a regression in `128 < N <= 256`.
2. The naive kernel needs no TriangularSolve version bump (the `TriangularSolve = "0.2.2"`
   compat entry is unchanged), and it is the machinery #1151/#1162 already established and
   tested.

Also measured and rejected: TriangularSolve reached through `reshape(b, :, 1)`, which was the
route the stale comment had evaluated. It is the slowest of the three fast arms at every size
(0.48x at n=4, 0.81x at n=128, 1.12x at n=256).

**Cutoff = 256.** The unblocked sweep falls out of cache and loses to `getrs!`'s blocked one
above that. Crossover run separately at 12 interleaved trials × min-of-3000 per cell:

| n | 128 | 160 | 192 | 224 | 256 | 288 | 320 | 400 |
|---|---|---|---|---|---|---|---|---|
| naive / `getrs!` | 0.80x | 0.93x | 0.82x | 0.90x | 0.90x | **1.01x** | 1.07x | 1.06x |

## Before / after on the shipped function

`after` is the branch's `_rf_ldiv!`; `before` is `ldiv!(u, fact, b)`, which is main's vector
`_rf_ldiv!` body verbatim (and, for `nrhs = 1`, main's matrix bail verbatim). Both arms
interleaved in one process against the same factorization, min-of-N per-call `time_ns`, sink-
guarded, `taskset -c 12`, 1 BLAS thread. `err` is max relative error vs `A \ b`.

**Vector RHS** (this is the ODE/Newton hot path):

| N | before (ns) | after (ns) | ratio | err before | err after |
|---|---|---|---|---|---|
| 4 | 349 | 89 | **0.26x** | 0.0 | 2.2e-17 |
| 8 | 460 | 169 | **0.37x** | 1.5e-16 | 1.5e-16 |
| 16 | 750 | 349 | **0.47x** | 2.8e-16 | 2.8e-16 |
| 20 | 839 | 440 | **0.52x** | 3.7e-16 | 3.7e-16 |
| 32 | 1299 | 790 | **0.61x** | 5.5e-16 | 4.2e-16 |
| 40 | 1590 | 1019 | **0.64x** | 4.0e-16 | 4.0e-16 |
| 64 | 2699 | 2000 | **0.74x** | 4.0e-16 | 4.0e-16 |
| 80 | 3580 | 2560 | **0.72x** | 4.2e-16 | 6.7e-16 |
| 96 | 4340 | 3190 | **0.74x** | 4.0e-16 | 7.0e-16 |
| 128 | 6249 | 4970 | **0.80x** | 4.1e-16 | 1.1e-15 |
| 200 | 12160 | 10350 | **0.85x** | 3.1e-16 | 1.2e-15 |
| 256 | 20190 | 25450 | 1.26x (noise, see below) | 4.1e-16 | 1.4e-15 |
| 257 | 19700 | 19780 | 1.00x | 6.7e-16 | 6.7e-16 |
| 400 | 41310 | 41389 | 1.00x | 3.1e-16 | 3.1e-16 |

**On that N = 256 cell:** it disagrees with three other measurements of the identical code
path, including the `nrhs = 1` row at N = 256 *in the same process* (0.89x), two earlier
processes (0.89x, 0.89x), and the 12 × 3000 crossover run above (0.90x). The box is shared and
was at load ~46; I am reading it as interference on that one arm, not as a real cliff at the
cutoff, and the crossover run is the number I would trust. Flagging rather than deleting it.

**Matrix RHS, `nrhs = 1`** (the removed `size(B, 2) == 1` bail):

| N | 4 | 8 | 16 | 20 | 32 | 40 | 64 | 80 | 96 | 128 | 200 | 256 | 257 | 400 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| before (ns) | 379 | 489 | 760 | 859 | 1319 | 1619 | 2640 | 3570 | 4429 | 6230 | 12350 | 17420 | 20540 | 41840 |
| after (ns) | 119 | 199 | 409 | 509 | 869 | 1100 | 1950 | 2590 | 3300 | 4920 | 10790 | 15480 | 20950 | 42350 |
| ratio | 0.31x | 0.41x | 0.54x | 0.59x | 0.66x | 0.68x | 0.74x | 0.73x | 0.75x | 0.79x | 0.87x | 0.89x | 1.02x | 1.01x |

**Matrix RHS, `nrhs = 8`** — untouched path, timed as a regression check. Identical before and
after within noise, 0.30x-0.47x vs `getrs!` in both (that is TriangularSolve, already on main
from #1153).

Accuracy: the unblocked sweep accumulates a bit more rounding than `getrs!` — at the cutoff
the max relative error goes 4.1e-16 → 1.4e-15, i.e. still ~n·eps. Above the cutoff the errors
are bit-identical because the path is unchanged.

## Correctness and the discriminating tests

New `test/Core/rflu_naive_ldiv.jl`, registered in the `Core` group. Coverage: `RFLUFactorization`
vs `A \ b` for `Float64/Float32/ComplexF64/ComplexF32` with vector, `n × 1` and `n × 4` RHS at
sizes spanning the cutoff (2, 5, 20, 64, 256, 257); bitwise agreement between the single-RHS
path and the naive kernel at/below the cutoff; bitwise agreement with `ldiv!` *above* the
cutoff; the `u === b` aliasing case; a cached re-solve loop with fresh `b`; and a non-square
`LU`, which must stay on the stdlib path because the kernel is `@inbounds`.

Test matrices are **row-reversed** diagonally dominant matrices, and every size asserts
`fact.ipiv != collect(1:n)`. That matters: my first draft used plain `rand(n,n) + n*I`, whose
pivots are all trivial, and it **passed with the row interchanges deleted from the kernel**.
The same weakness exists in `test/Core/genericlu_naive_ldiv.jl` on main — worth a follow-up,
not touched here.

Two mutations, each run against the final test file:

**A — the fix removed** (vector fast path reverted to `return ldiv!(u, fact, b)`, i.e. main's
behavior):

```
Test Summary:                                              | Pass  Total   Time
RFLU back-solve correctness across the naive-kernel cutoff |  126    126  44.7s
Test Summary:                                    | Pass  Fail  Total  Time
RFLU single-RHS back-solve runs the naive kernel |   12    18     30  2.9s
ERROR: LoadError: Some tests did not pass: 12 passed, 18 failed, 0 errored, 0 broken.
```

**B — the kernel broken** (row interchanges deleted from `_naive_lu_ldiv!`):

```
Test Summary:                                              | Pass  Fail  Total   Time
RFLU back-solve correctness across the naive-kernel cutoff |   92    34    126  42.7s
ERROR: LoadError: Some tests did not pass: 92 passed, 34 failed, 0 errored, 0 broken.
```

Unmutated, all five testsets pass (126 + 30 + 2 + 1 + 10).

## On the #1159 / #1162 Adjoint hazard

It does not reach this path, for two independent reasons, and the fix is written so it stays
that way:

- `RFLUFactorization` cannot take an `Adjoint`/`Transpose` operator at all today —
  `RecursiveFactorization.lu!(::Adjoint{Float64,Matrix{Float64}}, ::Vector{Int64}, ::Val{true},
  ::Val{true})` is an ambiguous `MethodError` on main, before any back-solve runs. (The default
  algorithm picks `KrylovJL_GMRES` for wrapped operators, so users do not hit this.)
- `Adjoint{Float64,Matrix{Float64}} <: StridedMatrix` is `false`, so the new method's
  `LU{T,<:StridedMatrix{T}}` bound excludes wrapped factors regardless.

And if wrapped factors ever did reach it, `_naive_lu_ldiv!` dispatches to #1162's
orientation-specialized methods rather than the stride-N-walking generic one, which is why
this reuses that function instead of inlining a private copy.

## Verification

- `GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` on Julia 1.11.9 — tail below.
- `test/Core/rflu_naive_ldiv.jl` also run standalone on Julia 1.10.11 (the `lts` CI cell):
  126 + 30 + 2 + 1 + 10 pass, 0 fail.
- `runic --check` on all touched files: clean.
- `typos` on all touched files: clean.

## Not verified

- Only OpenBLAS, only x86-64 (AMD EPYC 7502). No MKL, Apple Accelerate, or BLIS timing; the
  `getrs!` call floor that motivates this is a property of the BLAS call, not of OpenBLAS
  specifically, but the crossover size could move.
- No Julia 1.12/`pre` run, and no GPU, Downstream, or AD group.
- No end-to-end ODE/Newton benchmark. #1161's motivating POLLU (N=20) number is not
  re-measured here; this PR only claims the back-solve.
- `RF32MixedLUFactorization` still uses `ldiv!` for its 32-bit inner solve (it does get the
  commit-1 `ipiv` fix). The back-solve argument applies to it too; deliberately out of scope.
- The commit-1 `ipiv` bug is only *demonstrated* on Julia 1.11.9. The gating constant is
  `VERSION >= v"1.8.0-DEV.1507"`, so 1.10 and 1.12 are affected by inspection, not by a run.
- The `NAIVE_LDIV_MAXSIZE = 256` cutoff is tuned on one machine. Reviewers who think the
  measured 0.90x-at-256 / 1.01x-at-288 crossover is too close to call should say so — 128 is
  the obvious conservative alternative and costs the 0.85x-0.90x band.

## Things to push back on

- The cutoff constant is a magic number tuned on one box (see above).
- The added guard `m == k == n == length(u) == length(fact.ipiv)` on the hot path costs a few
  comparisons per solve; it exists because the kernel is `@inbounds` and would otherwise read
  off the end of `factors` for a non-square `LU`. It is measurable only as noise here, but it
  is a judgment call.
- Removing the `size(B, 2) == 1` bail changes which numbers a one-column matrix RHS produces
  (naive kernel rounding rather than `getrs!` rounding), for anyone comparing bitwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bHrkkvJzfYPMMJMRJ5GqX

---

## Independent verification (second pass, after rebase)

Rebased onto current `main` (`fbc5d0a`) and re-checked from scratch:

- **The new test discriminates.** Deleting the row-interchange sweep from `_naive_lu_ldiv!`
  takes `test/Core/rflu_naive_ldiv.jl` from **0 failures to 34**. Both new test files pass on
  the rebased branch.
- **Aqua ambiguities: 0.** An earlier QA run on this branch showed 3 method ambiguities, all
  between `LinearSolveSparseArraysExt.jl:1095` and the `SVector` `_ldiv!` methods in
  `factorization.jl`. Those were **pre-existing on unmodified `main`** — verified by running
  the same check on a clean checkout, which reported the identical 3 — and are resolved by
  #1168, now in `main`. Nothing in this branch contributed to them.
- No local paths or environment artifacts are in the commits (the `test/qa/Project.toml`
  rewrite Pkg performs when running the QA env locally is not committed).

## Relationship to #1164

#1164 is complementary rather than overlapping: it adds an orientation-specific cutoff to
`_generic_lu_ldiv!` in `src/factorization.jl`, i.e. the `GenericLUFactorization` path. This PR
adds the kernel to the **RecursiveFactorization extension**, which `GenericLU`'s path never
touches. Its measurements independently support the cutoff chosen here — it finds the naive
vector kernel losing above N ≈ 512, and this PR defers to `ldiv!` above 256.

Worth a reviewer's judgment: after both land there are two separate cutoff constants for the
same underlying tradeoff (`NAIVE_LDIV_MAXSIZE` here, `_generic_lu_ldiv!`'s in `src/`). Sharing
one constant would be tidier, but it is a cross-PR change and I have not attempted it here.
