### PR TITLE
Blocked pure-Julia LU kernel for GenericLUFactorization float paths

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.6.1"
+version = "5.6.2"
 authors = ["SciML"]
 
 [deps]

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -436,6 +436,7 @@ function defaultalg_symbol end
 include("verbosity.jl")
 include("blas_logging.jl")
 include("generic_lufact.jl")
+include("blocked_lufact.jl")
 include("eigenvalue.jl")
 include("common.jl")
 include("interface.jl")

--- a/src/blocked_lufact.jl
+++ b/src/blocked_lufact.jl
@@ -1,0 +1,492 @@
+# Blocked, partially pivoted LU for real strided float matrices, in plain
+# Julia (`@inbounds` + `@simd ivdep` + `muladd` only — no LoopVectorization,
+# no CPU-specific code). Same blocked/panel structure as LAPACK getrf
+# (getf2 + laswp + trsm + gemm), which keeps the trailing matrix in cache and
+# gives LLVM's auto-vectorizer long contiguous inner loops. Dispatch-selected
+# specialization of `generic_lufact!`, so `GenericLUFactorization` uses it for
+# `StridedMatrix{Float64/Float32}` with `RowMaximum` pivoting; every other
+# eltype/pivot/container keeps the scalar `generic_lufact!` path.
+
+const _BLOCKED_LU_UNBLOCKED_CUTOFF = 8
+const _BLOCKED_LU_ROWBLOCK = 384
+
+# Narrow panels win while the trailing matrix is cache-resident; wider ones
+# amortize panel/trsm overhead once the Schur update dominates.
+_blocked_lu_default_panel(minmn::Int) = minmn <= 160 ? 8 : 16
+
+# Row-maximum pivot search in two passes: a `>`-select max reduction that
+# vectorizes (NaN compares false, so NaNs are ignored exactly like the
+# scalar stdlib/LAPACK search), then first-index-of-max, matching the
+# stdlib's first-occurrence tie-breaking. `kp == k` with `amax == 0` marks an
+# all-zero (or all-NaN) subcolumn.
+@inline function _blocked_lu_find_pivot(A::AbstractMatrix{T}, k::Int, m::Int) where {T}
+    amax = zero(T)
+    @inbounds @simd for i in k:m
+        absi = abs(A[i, k])
+        amax = ifelse(absi > amax, absi, amax)
+    end
+    kp = k
+    if !iszero(amax)
+        @inbounds for i in k:m
+            if abs(A[i, k]) == amax
+                kp = i
+                break
+            end
+        end
+    end
+    return kp, amax
+end
+
+# Unblocked factorization for the whole matrix at small sizes. Identical
+# control flow to the scalar `generic_lufact!` RowMaximum path, with hoisted
+# multipliers, `muladd`, and `@simd ivdep` on the column updates.
+function _blocked_lu_unblocked!(A::AbstractMatrix{T}, ipiv, m::Int, n::Int) where {T}
+    minmn = min(m, n)
+    info = 0
+    @inbounds for k in 1:minmn
+        kp, _ = _blocked_lu_find_pivot(A, k, m)
+        ipiv[k] = kp
+        if !iszero(A[kp, k])
+            if k != kp
+                for j in 1:n
+                    tmp = A[k, j]
+                    A[k, j] = A[kp, j]
+                    A[kp, j] = tmp
+                end
+            end
+            Akkinv = inv(A[k, k])
+            @simd ivdep for i in (k + 1):m
+                A[i, k] *= Akkinv
+            end
+        elseif info == 0
+            info = k
+        end
+        for j in (k + 1):n
+            Akj = A[k, j]
+            @simd ivdep for i in (k + 1):m
+                A[i, j] = muladd(-A[i, k], Akj, A[i, j])
+            end
+        end
+    end
+    return info
+end
+
+# Panel factorization: unblocked LU of A[j0:m, j0:j1] with pivot search over
+# all remaining rows. Row swaps are applied only inside the panel; the driver
+# applies them to the rest of the matrix afterwards (getrf structure).
+function _blocked_lu_panel!(
+        A::AbstractMatrix{T}, ipiv, m::Int, j0::Int, j1::Int, info::Int
+    ) where {T}
+    @inbounds for k in j0:j1
+        kp, _ = _blocked_lu_find_pivot(A, k, m)
+        ipiv[k] = kp
+        if !iszero(A[kp, k])
+            if k != kp
+                for j in j0:j1
+                    tmp = A[k, j]
+                    A[k, j] = A[kp, j]
+                    A[kp, j] = tmp
+                end
+            end
+            Akkinv = inv(A[k, k])
+            @simd ivdep for i in (k + 1):m
+                A[i, k] *= Akkinv
+            end
+        elseif info == 0
+            info = k
+        end
+        for j in (k + 1):j1
+            Akj = A[k, j]
+            @simd ivdep for i in (k + 1):m
+                A[i, j] = muladd(-A[i, k], Akj, A[i, j])
+            end
+        end
+    end
+    return info
+end
+
+# Apply the interchanges recorded in ipiv[k0:k1] to columns c0:c1, column-outer
+# so each contiguous column stays cache-resident across all of the swaps.
+function _blocked_lu_swap_rows!(
+        A::AbstractMatrix, ipiv, k0::Int, k1::Int, c0::Int, c1::Int
+    )
+    c0 > c1 && return nothing
+    @inbounds for j in c0:c1
+        for k in k0:k1
+            kp = ipiv[k]
+            if kp != k
+                tmp = A[k, j]
+                A[k, j] = A[kp, j]
+                A[kp, j] = tmp
+            end
+        end
+    end
+    return nothing
+end
+
+# U12 := L11 \ A12 with L11 the unit-lower triangle of A[j0:j1, j0:j1],
+# forward substitution on columns c0:c1, four right-hand-side columns at a
+# time so each L column load is amortized.
+function _blocked_lu_trsm_unit_lower!(
+        A::AbstractMatrix{T}, j0::Int, j1::Int, c0::Int, c1::Int
+    ) where {T}
+    @inbounds begin
+        c = c0
+        while c + 3 <= c1
+            for k in j0:j1
+                b1 = A[k, c]
+                b2 = A[k, c + 1]
+                b3 = A[k, c + 2]
+                b4 = A[k, c + 3]
+                @simd ivdep for i in (k + 1):j1
+                    aik = A[i, k]
+                    A[i, c] = muladd(-aik, b1, A[i, c])
+                    A[i, c + 1] = muladd(-aik, b2, A[i, c + 1])
+                    A[i, c + 2] = muladd(-aik, b3, A[i, c + 2])
+                    A[i, c + 3] = muladd(-aik, b4, A[i, c + 3])
+                end
+            end
+            c += 4
+        end
+        while c <= c1
+            for k in j0:j1
+                bk = A[k, c]
+                @simd ivdep for i in (k + 1):j1
+                    A[i, c] = muladd(-A[i, k], bk, A[i, c])
+                end
+            end
+            c += 1
+        end
+    end
+    return nothing
+end
+
+# Schur complement update A[i0:m, c0:c1] -= A[i0:m, j0:j1] * A[j0:j1, c0:c1]
+# (C -= L21 * U12); ~all the flops at mid/large N live here. Register
+# blocking: 4 columns of C by 4 pivot columns per inner loop (16 fused
+# multiply-adds per vectorized i-iteration). Cache blocking: rows in chunks of
+# `rowblock` so the active C tile stays L1-resident across the k-chunks. All
+# columns touched in an inner loop are distinct, so `ivdep` is exact.
+function _blocked_lu_schur_unpacked!(
+        A::AbstractMatrix{T}, m::Int, j0::Int, j1::Int,
+        c0::Int, c1::Int, rowblock::Int
+    ) where {T}
+    i0 = j1 + 1
+    @inbounds begin
+        ib = i0
+        while ib <= m
+            ie = min(ib + rowblock - 1, m)
+            c = c0
+            while c + 3 <= c1
+                k = j0
+                while k + 3 <= j1
+                    b11 = A[k, c]
+                    b21 = A[k + 1, c]
+                    b31 = A[k + 2, c]
+                    b41 = A[k + 3, c]
+                    b12 = A[k, c + 1]
+                    b22 = A[k + 1, c + 1]
+                    b32 = A[k + 2, c + 1]
+                    b42 = A[k + 3, c + 1]
+                    b13 = A[k, c + 2]
+                    b23 = A[k + 1, c + 2]
+                    b33 = A[k + 2, c + 2]
+                    b43 = A[k + 3, c + 2]
+                    b14 = A[k, c + 3]
+                    b24 = A[k + 1, c + 3]
+                    b34 = A[k + 2, c + 3]
+                    b44 = A[k + 3, c + 3]
+                    @simd ivdep for i in ib:ie
+                        a1 = A[i, k]
+                        a2 = A[i, k + 1]
+                        a3 = A[i, k + 2]
+                        a4 = A[i, k + 3]
+                        c1v = A[i, c]
+                        c1v = muladd(-a1, b11, c1v)
+                        c1v = muladd(-a2, b21, c1v)
+                        c1v = muladd(-a3, b31, c1v)
+                        c1v = muladd(-a4, b41, c1v)
+                        A[i, c] = c1v
+                        c2v = A[i, c + 1]
+                        c2v = muladd(-a1, b12, c2v)
+                        c2v = muladd(-a2, b22, c2v)
+                        c2v = muladd(-a3, b32, c2v)
+                        c2v = muladd(-a4, b42, c2v)
+                        A[i, c + 1] = c2v
+                        c3v = A[i, c + 2]
+                        c3v = muladd(-a1, b13, c3v)
+                        c3v = muladd(-a2, b23, c3v)
+                        c3v = muladd(-a3, b33, c3v)
+                        c3v = muladd(-a4, b43, c3v)
+                        A[i, c + 2] = c3v
+                        c4v = A[i, c + 3]
+                        c4v = muladd(-a1, b14, c4v)
+                        c4v = muladd(-a2, b24, c4v)
+                        c4v = muladd(-a3, b34, c4v)
+                        c4v = muladd(-a4, b44, c4v)
+                        A[i, c + 3] = c4v
+                    end
+                    k += 4
+                end
+                while k <= j1
+                    b1 = A[k, c]
+                    b2 = A[k, c + 1]
+                    b3 = A[k, c + 2]
+                    b4 = A[k, c + 3]
+                    @simd ivdep for i in ib:ie
+                        a = A[i, k]
+                        A[i, c] = muladd(-a, b1, A[i, c])
+                        A[i, c + 1] = muladd(-a, b2, A[i, c + 1])
+                        A[i, c + 2] = muladd(-a, b3, A[i, c + 2])
+                        A[i, c + 3] = muladd(-a, b4, A[i, c + 3])
+                    end
+                    k += 1
+                end
+                c += 4
+            end
+            while c <= c1
+                k = j0
+                while k + 3 <= j1
+                    b1 = A[k, c]
+                    b2 = A[k + 1, c]
+                    b3 = A[k + 2, c]
+                    b4 = A[k + 3, c]
+                    @simd ivdep for i in ib:ie
+                        acc = A[i, c]
+                        acc = muladd(-A[i, k], b1, acc)
+                        acc = muladd(-A[i, k + 1], b2, acc)
+                        acc = muladd(-A[i, k + 2], b3, acc)
+                        acc = muladd(-A[i, k + 3], b4, acc)
+                        A[i, c] = acc
+                    end
+                    k += 4
+                end
+                while k <= j1
+                    bk = A[k, c]
+                    @simd ivdep for i in ib:ie
+                        A[i, c] = muladd(-A[i, k], bk, A[i, c])
+                    end
+                    k += 1
+                end
+                c += 1
+            end
+            ib = ie + 1
+        end
+    end
+    return nothing
+end
+
+# Pack A[i0:m, j0:j1] column-major into `pack` with column stride ldp.
+@inline function _blocked_lu_pack_panel!(
+        pack::Vector{T}, A::AbstractMatrix{T}, i0::Int, m::Int,
+        j0::Int, j1::Int, ldp::Int
+    ) where {T}
+    @inbounds for k in j0:j1
+        off = (k - j0) * ldp - i0 + 1
+        @simd ivdep for i in i0:m
+            pack[off + i] = A[i, k]
+        end
+    end
+    return nothing
+end
+
+# Same update with the L21 operand packed into a contiguous scratch with a
+# padded stride. Packing matters because power-of-two leading dimensions
+# (N = 512, 1024, ...) put every column on the same L1/L2 cache sets: the
+# in-place kernel loses ~25% at N = 512 while LAPACK is immune because GEMM
+# packs. Packing costs O(rows*jb) copies against O(rows*jb*n2) flops.
+function _blocked_lu_schur_packed!(
+        A::AbstractMatrix{T}, m::Int, j0::Int, j1::Int,
+        c0::Int, c1::Int, rowblock::Int, pack::Vector{T}
+    ) where {T}
+    i0 = j1 + 1
+    rows = m - i0 + 1
+    jb = j1 - j0 + 1
+    ldp = rows % 256 == 0 ? rows + 4 : rows
+    length(pack) < ldp * jb && resize!(pack, ldp * jb)
+    _blocked_lu_pack_panel!(pack, A, i0, m, j0, j1, ldp)
+    @inbounds begin
+        ib = i0
+        while ib <= m
+            ie = min(ib + rowblock - 1, m)
+            c = c0
+            while c + 3 <= c1
+                k = j0
+                while k + 3 <= j1
+                    o1 = (k - j0) * ldp - i0 + 1
+                    o2 = o1 + ldp
+                    o3 = o2 + ldp
+                    o4 = o3 + ldp
+                    b11 = A[k, c]
+                    b21 = A[k + 1, c]
+                    b31 = A[k + 2, c]
+                    b41 = A[k + 3, c]
+                    b12 = A[k, c + 1]
+                    b22 = A[k + 1, c + 1]
+                    b32 = A[k + 2, c + 1]
+                    b42 = A[k + 3, c + 1]
+                    b13 = A[k, c + 2]
+                    b23 = A[k + 1, c + 2]
+                    b33 = A[k + 2, c + 2]
+                    b43 = A[k + 3, c + 2]
+                    b14 = A[k, c + 3]
+                    b24 = A[k + 1, c + 3]
+                    b34 = A[k + 2, c + 3]
+                    b44 = A[k + 3, c + 3]
+                    @simd ivdep for i in ib:ie
+                        a1 = pack[o1 + i]
+                        a2 = pack[o2 + i]
+                        a3 = pack[o3 + i]
+                        a4 = pack[o4 + i]
+                        c1v = A[i, c]
+                        c1v = muladd(-a1, b11, c1v)
+                        c1v = muladd(-a2, b21, c1v)
+                        c1v = muladd(-a3, b31, c1v)
+                        c1v = muladd(-a4, b41, c1v)
+                        A[i, c] = c1v
+                        c2v = A[i, c + 1]
+                        c2v = muladd(-a1, b12, c2v)
+                        c2v = muladd(-a2, b22, c2v)
+                        c2v = muladd(-a3, b32, c2v)
+                        c2v = muladd(-a4, b42, c2v)
+                        A[i, c + 1] = c2v
+                        c3v = A[i, c + 2]
+                        c3v = muladd(-a1, b13, c3v)
+                        c3v = muladd(-a2, b23, c3v)
+                        c3v = muladd(-a3, b33, c3v)
+                        c3v = muladd(-a4, b43, c3v)
+                        A[i, c + 2] = c3v
+                        c4v = A[i, c + 3]
+                        c4v = muladd(-a1, b14, c4v)
+                        c4v = muladd(-a2, b24, c4v)
+                        c4v = muladd(-a3, b34, c4v)
+                        c4v = muladd(-a4, b44, c4v)
+                        A[i, c + 3] = c4v
+                    end
+                    k += 4
+                end
+                while k <= j1
+                    ok = (k - j0) * ldp - i0 + 1
+                    b1 = A[k, c]
+                    b2 = A[k, c + 1]
+                    b3 = A[k, c + 2]
+                    b4 = A[k, c + 3]
+                    @simd ivdep for i in ib:ie
+                        a = pack[ok + i]
+                        A[i, c] = muladd(-a, b1, A[i, c])
+                        A[i, c + 1] = muladd(-a, b2, A[i, c + 1])
+                        A[i, c + 2] = muladd(-a, b3, A[i, c + 2])
+                        A[i, c + 3] = muladd(-a, b4, A[i, c + 3])
+                    end
+                    k += 1
+                end
+                c += 4
+            end
+            while c <= c1
+                k = j0
+                while k + 3 <= j1
+                    o1 = (k - j0) * ldp - i0 + 1
+                    o2 = o1 + ldp
+                    o3 = o2 + ldp
+                    o4 = o3 + ldp
+                    b1 = A[k, c]
+                    b2 = A[k + 1, c]
+                    b3 = A[k + 2, c]
+                    b4 = A[k + 3, c]
+                    @simd ivdep for i in ib:ie
+                        acc = A[i, c]
+                        acc = muladd(-pack[o1 + i], b1, acc)
+                        acc = muladd(-pack[o2 + i], b2, acc)
+                        acc = muladd(-pack[o3 + i], b3, acc)
+                        acc = muladd(-pack[o4 + i], b4, acc)
+                        A[i, c] = acc
+                    end
+                    k += 4
+                end
+                while k <= j1
+                    ok = (k - j0) * ldp - i0 + 1
+                    bk = A[k, c]
+                    @simd ivdep for i in ib:ie
+                        A[i, c] = muladd(-pack[ok + i], bk, A[i, c])
+                    end
+                    k += 1
+                end
+                c += 1
+            end
+            ib = ie + 1
+        end
+    end
+    return nothing
+end
+
+@inline function _blocked_lu_schur!(
+        A::AbstractMatrix{T}, m::Int, j0::Int, j1::Int,
+        c0::Int, c1::Int, rowblock::Int, pack::Vector{T}
+    ) where {T}
+    rows = m - j1
+    n2 = c1 - c0 + 1
+    if rows >= 64 && n2 >= 32
+        _blocked_lu_schur_packed!(A, m, j0, j1, c0, c1, rowblock, pack)
+    else
+        _blocked_lu_schur_unpacked!(A, m, j0, j1, c0, c1, rowblock)
+    end
+    return nothing
+end
+
+function _blocked_lufact!(
+        A::AbstractMatrix{T}, ipiv, m::Int, n::Int, minmn::Int,
+        nb::Int, rowblock::Int
+    ) where {T}
+    pack = T[]
+    info = 0
+    j0 = 1
+    while j0 <= minmn
+        jb = min(nb, minmn - j0 + 1)
+        j1 = j0 + jb - 1
+        info = _blocked_lu_panel!(A, ipiv, m, j0, j1, info)
+        _blocked_lu_swap_rows!(A, ipiv, j0, j1, 1, j0 - 1)
+        if j1 < n
+            _blocked_lu_swap_rows!(A, ipiv, j0, j1, j1 + 1, n)
+            _blocked_lu_trsm_unit_lower!(A, j0, j1, j1 + 1, n)
+            if j1 < m
+                _blocked_lu_schur!(A, m, j0, j1, j1 + 1, n, rowblock, pack)
+            end
+        end
+        j0 += jb
+    end
+    return info
+end
+
+# The `GenericLUFactorization` fast path: real strided float matrices with
+# `RowMaximum` pivoting take the blocked kernel; everything else falls through
+# to the scalar method. Semantics match `generic_lufact!` with a provided
+# `ipiv`: runs to completion with `info` = first zero pivot, `check = true`
+# validates finiteness up front and throws `SingularException` unless
+# `allowsingular`.
+function generic_lufact!(
+        A::StridedMatrix{T}, pivot::RowMaximum,
+        ipiv::AbstractVector{<:Integer};
+        check::Bool = true, allowsingular::Bool = false
+    ) where {T <: Union{Float32, Float64}}
+    Base.require_one_based_indexing(A, ipiv)
+    if check && !all(isfinite, A)
+        throw(ArgumentError("matrix contains Infs or NaNs"))
+    end
+    m, n = size(A)
+    minmn = min(m, n)
+    length(ipiv) >= minmn ||
+        throw(ArgumentError("ipiv has length $(length(ipiv)), needs at least $minmn"))
+    info = if minmn <= _BLOCKED_LU_UNBLOCKED_CUTOFF
+        _blocked_lu_unblocked!(A, ipiv, m, n)
+    else
+        _blocked_lufact!(
+            A, ipiv, m, n, minmn, _blocked_lu_default_panel(minmn),
+            _BLOCKED_LU_ROWBLOCK
+        )
+    end
+    check && !allowsingular && info > 0 &&
+        throw(LinearAlgebra.SingularException(info))
+    return LinearAlgebra.LU{T, typeof(A), typeof(ipiv)}(
+        A, ipiv, convert(LinearAlgebra.BlasInt, info)
+    )
+end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -247,8 +247,15 @@ LUFactorization(pivot) = LUFactorization(; pivot = RowMaximum())
 `GenericLUFactorization(pivot=LinearAlgebra.RowMaximum())`
 
 Julia's built in generic LU factorization. Equivalent to calling LinearAlgebra.generic_lufact!.
-Supports arbitrary number types but does not achieve as good scaling as BLAS-based LU implementations.
-Has low overhead and is good for small matrices.
+Supports arbitrary number types. Has low overhead and is good for small matrices.
+
+For `StridedMatrix{Float64}`/`StridedMatrix{Float32}` with `RowMaximum` pivoting the
+factorization runs a blocked pure-Julia kernel (panel factorization + packed Schur
+update, the LAPACK `getrf` structure written with `@simd ivdep` loops) instead of the
+scalar textbook loop. That keeps the algorithm dependency-free while scaling far
+beyond the scalar kernel: on machines with a weak or unavailable BLAS it is
+competitive with (or faster than) OpenBLAS/MKL `getrf` up to a few hundred unknowns.
+Other element types and pivots keep the scalar generic path.
 
 The back-solve is a pure-Julia column-oriented triangular solve (apply `ipiv`, unit-lower
 forward, upper backward) rather than `ldiv!(::LU, ·)` / OpenBLAS `getrs!`. That avoids the

--- a/test/Core/blocked_lufact.jl
+++ b/test/Core/blocked_lufact.jl
@@ -1,0 +1,213 @@
+using LinearSolve, LinearAlgebra, Test, Random
+using LinearAlgebra: BlasInt
+
+Random.seed!(1234)
+
+_ipiv(n) = Vector{BlasInt}(undef, n)
+
+# Backward-stability residual ||P*A - L*U|| / (||L|| ||U|| eps max(m,n)).
+# Normalizing by ||L||*||U|| (not ||A||) keeps the bound valid on high-growth
+# matrices, where element growth is real and shared by LAPACK.
+function scaled_residual(A, F)
+    m, n = size(A)
+    minmn = min(m, n)
+    L = [
+        i > j ? F.factors[i, j] : (i == j ? one(eltype(A)) : zero(eltype(A)))
+            for i in 1:m, j in 1:minmn
+    ]
+    U = [i <= j ? F.factors[i, j] : zero(eltype(A)) for i in 1:minmn, j in 1:n]
+    PA = copy(Matrix(A))
+    for k in 1:minmn
+        p = F.ipiv[k]
+        if p != k
+            PA[k, :], PA[p, :] = PA[p, :], PA[k, :]
+        end
+    end
+    den = opnorm(L, 1) * opnorm(U, 1) * eps(real(eltype(A))) * max(m, n)
+    return opnorm(PA - L * U, 1) / den
+end
+
+@testset "blocked generic_lufact! kernel" begin
+    @testset "dispatch routes float strided matrices to the blocked method" begin
+        m_blocked = which(
+            LinearSolve.generic_lufact!,
+            Tuple{Matrix{Float64}, RowMaximum, Vector{BlasInt}}
+        )
+        @test endswith(String(m_blocked.file), "blocked_lufact.jl")
+        m_generic = which(
+            LinearSolve.generic_lufact!,
+            Tuple{Matrix{BigFloat}, RowMaximum, Vector{BlasInt}}
+        )
+        @test !endswith(String(m_generic.file), "blocked_lufact.jl")
+    end
+
+    @testset "residual, square, default params ($T)" for T in (Float64, Float32)
+        for n in (
+                1, 2, 3, 5, 7, 8, 9, 13, 16, 17, 31, 32, 33, 40, 41, 63, 64, 65,
+                100, 127, 128, 129, 200, 250, 256, 257, 300, 500, 512,
+            )
+            A = randn(T, n, n)
+            F = LinearSolve.generic_lufact!(copy(A), RowMaximum(), _ipiv(n); check = false)
+            @test F.info == 0
+            @test scaled_residual(A, F) < 20
+        end
+    end
+
+    @testset "forced blocked driver, remainder paths" begin
+        # panel/rowblock combinations that exercise the 4-wide remainders in
+        # the trsm and both Schur kernels, and the packed/unpacked switch
+        for n in (11, 41, 67, 70, 97, 130, 190, 257), nb in (4, 5, 8, 13, 16, 32),
+                rb in (7, 64, 384)
+
+            n <= nb && continue
+            A = randn(n, n)
+            W = copy(A)
+            ipiv = _ipiv(n)
+            info = LinearSolve._blocked_lufact!(W, ipiv, n, n, n, nb, rb)
+            F = LU{Float64, Matrix{Float64}, Vector{BlasInt}}(W, ipiv, BlasInt(info))
+            @test scaled_residual(A, F) < 20
+        end
+    end
+
+    @testset "rectangular m x n" begin
+        for (m, n) in (
+                (100, 3), (3, 100), (128, 40), (40, 128), (257, 130),
+                (130, 257), (65, 64), (64, 65), (513, 100), (100, 513),
+            )
+            A = randn(m, n)
+            F = LinearSolve.generic_lufact!(
+                copy(A), RowMaximum(), _ipiv(min(m, n)); check = false
+            )
+            @test scaled_residual(A, F) < 20
+        end
+    end
+
+    @testset "strided views (contiguous and non-unit row stride)" begin
+        for n in (17, 80)
+            P = randn(2n + 3, n + 2)
+            V1 = @view P[2:(n + 1), 2:(n + 1)]
+            A1 = copy(Matrix(V1))
+            F1 = LinearSolve.generic_lufact!(V1, RowMaximum(), _ipiv(n); check = false)
+            @test scaled_residual(A1, F1) < 20
+            V2 = @view P[1:2:(2n - 1), 1:n]
+            A2 = copy(Matrix(V2))
+            F2 = LinearSolve.generic_lufact!(V2, RowMaximum(), _ipiv(n); check = false)
+            @test scaled_residual(A2, F2) < 20
+        end
+    end
+
+    @testset "pivot sequence matches LAPACK when margins are decisive" begin
+        for n in (17, 64, 129, 300), trial in 1:3
+            # rows of widely separated magnitude, then shuffled: every pivot
+            # decision has orders-of-magnitude margin, so blocked-vs-unblocked
+            # rounding differences cannot flip it and ipiv must match getrf
+            mags = shuffle!([2.0^k for k in 1:n])
+            A = Diagonal(mags) * (I + 0.01 .* randn(n, n))
+            A = A[shuffle(1:n), :]
+            Fl = lu(copy(A); check = false)
+            Fs = LinearSolve.generic_lufact!(copy(A), RowMaximum(), _ipiv(n); check = false)
+            @test Fs.ipiv == Fl.ipiv
+            @test scaled_residual(A, Fs) < 20
+        end
+    end
+
+    @testset "permutation matrix input reproduces LAPACK exactly" begin
+        for n in (16, 65, 200)
+            p = shuffle(1:n)
+            A = Matrix{Float64}(I, n, n)[p, :]
+            Fl = lu(copy(A); check = false)
+            Fs = LinearSolve.generic_lufact!(copy(A), RowMaximum(), _ipiv(n); check = false)
+            @test Fs.ipiv == Fl.ipiv
+            @test Fs.factors == Fl.factors
+            @test Fs.info == 0
+        end
+    end
+
+    @testset "growth matrix (Wilkinson 2^(n-1) growth)" begin
+        for n in (24, 53)
+            A = Matrix{Float64}(I, n, n) .- tril(ones(n, n), -1)
+            A[:, n] .= 1.0
+            Fs = LinearSolve.generic_lufact!(copy(A), RowMaximum(), _ipiv(n); check = false)
+            @test all(Fs.ipiv .== 1:n)
+            @test Fs.factors[n, n] == 2.0^(n - 1)
+            @test scaled_residual(A, Fs) < 20
+        end
+    end
+
+    @testset "singularity detection and check semantics" begin
+        for n in (10, 50, 130), zc in (1, 4, n)
+            A = randn(n, n)
+            A[:, zc] .= 0.0
+            Fl = lu(copy(A); check = false)
+            Fs = LinearSolve.generic_lufact!(copy(A), RowMaximum(), _ipiv(n); check = false)
+            @test Fs.info > 0
+            @test !LinearAlgebra.issuccess(Fs)
+            @test Fs.info == Fl.info
+        end
+        Z = zeros(50, 50)
+        Fz = LinearSolve.generic_lufact!(copy(Z), RowMaximum(), _ipiv(50); check = false)
+        @test Fz.info == 1
+        @test_throws SingularException LinearSolve.generic_lufact!(
+            copy(Z), RowMaximum(), _ipiv(50)
+        )
+        Fa = LinearSolve.generic_lufact!(
+            copy(Z), RowMaximum(), _ipiv(50); allowsingular = true
+        )
+        @test Fa.info == 1
+        # chkfinite runs before factorizing when check=true, like the scalar path
+        An = randn(30, 30)
+        An[2, 2] = NaN
+        @test_throws ArgumentError LinearSolve.generic_lufact!(
+            copy(An), RowMaximum(), _ipiv(30)
+        )
+        Fn = LinearSolve.generic_lufact!(copy(An), RowMaximum(), _ipiv(30); check = false)
+        @test any(isnan, Fn.factors)
+    end
+
+    @testset "ipiv too short throws" begin
+        @test_throws ArgumentError LinearSolve.generic_lufact!(
+            randn(5, 5), RowMaximum(), _ipiv(3); check = false
+        )
+    end
+end
+
+@testset "GenericLUFactorization through the blocked kernel" begin
+    @testset "solve correctness across the size cutover ($T)" for T in (Float64, Float32)
+        rtol = 100 * eps(real(one(T)))
+        for n in (2, 4, 8, 9, 16, 51, 100, 257)
+            A = rand(T, n, n) + n * I
+            b = rand(T, n)
+            B = rand(T, n, 4)
+            sol = solve(LinearProblem(copy(A), copy(b)), GenericLUFactorization())
+            @test SciMLBase.successful_retcode(sol)
+            @test sol.u ≈ A \ b rtol = rtol * n
+            solB = solve(LinearProblem(copy(A), copy(B)), GenericLUFactorization())
+            @test SciMLBase.successful_retcode(solB)
+            @test solB.u ≈ A \ B rtol = rtol * n
+        end
+    end
+
+    @testset "repeated refactorization via cache reuse" begin
+        n = 100
+        b = rand(n)
+        cache = init(LinearProblem(rand(n, n) + n * I, b), GenericLUFactorization())
+        Awork = cache.A
+        for _ in 1:3
+            A = rand(n, n) + n * I
+            # the cache factorizes its matrix in place, so hand it a copy
+            copyto!(Awork, A)
+            cache.A = Awork
+            sol = solve!(cache)
+            @test sol.retcode == ReturnCode.Success
+            @test sol.u ≈ A \ b rtol = 1.0e-10
+        end
+    end
+
+    @testset "singular matrix returns Failure retcode" begin
+        for n in (6, 60)
+            A = zeros(n, n)
+            sol = solve(LinearProblem(A, rand(n)), GenericLUFactorization())
+            @test sol.retcode == ReturnCode.Failure
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ else
             @time @safetestset "EigenvalueProblem" include("Core/eigenvalue.jl")
             @time @safetestset "Batched RHS" include("Core/batch.jl")
             @time @safetestset "GenericLU naive back-solve" include("Core/genericlu_naive_ldiv.jl")
+            @time @safetestset "Blocked generic_lufact! kernel" include("Core/blocked_lufact.jl")
             @time @safetestset "GESV Factorization" include("Core/gesv.jl")
             @time @safetestset "LU Refactorization Reuse" include("Core/lu_refactorization.jl")
             @time @safetestset "Direct BLAS Refactorization Reuse" include("Core/direct_blas_refactorization.jl")


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What

Adds a dependency-free blocked LU kernel (`src/blocked_lufact.jl`) — panel factorization + deferred row swaps + unit-lower trsm + register/cache-blocked Schur update, i.e. the LAPACK `getrf` structure — written entirely with `@inbounds` + `@simd ivdep` + `muladd` loops (no LoopVectorization, no CPU-specific code), and dispatches `generic_lufact!` to it for `StridedMatrix{Float32/Float64}` with `RowMaximum` pivoting. `GenericLUFactorization` therefore keeps its exact API and semantics but scales far beyond the scalar textbook loop; every other eltype/pivot/container keeps the scalar path. No default-algorithm heuristics are changed.

This came out of a design study asking whether RecursiveFactorization's blocking ideas survive without the LV stack (for dependency weight and precompilation portability), and whether that would be a good small-N default on machines where BLAS is weak. Data below; study artifacts (prototype, harness, correctness suite, TTFX scripts) are on the benchmark machine.

## End-to-end effect (`solve!` with `GenericLUFactorization`, this PR vs master)

Fresh factorization + solve per iteration through the full LinearSolve path, min over 3 alternating before/after rounds, single BLAS thread, pinned core (AMD EPYC 7502, Zen 2):

| N | 1.10 before | 1.10 after | speedup | 1.12 before | 1.12 after | speedup |
|---|---|---|---|---|---|---|
| 4 | 200 ns | 190 ns | 1.05x | 200 ns | 189 ns | 1.06x |
| 8 | 490 ns | 450 ns | 1.09x | 490 ns | 410 ns | 1.20x |
| 16 | 2.13 us | 1.80 us | 1.18x | 2.08 us | 1.78 us | 1.17x |
| 32 | 11.7 us | 5.5 us | 2.13x | 12.6 us | 5.5 us | 2.30x |
| 64 | 81.6 us | 20.5 us | 3.99x | 84.7 us | 20.7 us | 4.10x |
| 128 | 636 us | 101 us | 6.32x | 649 us | 101 us | 6.44x |
| 256 | 4.83 ms | 633 us | 7.63x | 4.90 ms | 624 us | 7.86x |
| 512 | 37.9 ms | 4.42 ms | 8.57x | 38.3 ms | 4.48 ms | 8.55x |

No size measured got slower, including the N ≤ 10 range where `GenericLUFactorization` is the default-algorithm choice (that range runs the unblocked sub-kernel, which is the same algorithm as the scalar path with hoisted multipliers and `@simd ivdep`).

## Kernel-level benchmarks vs generic / OpenBLAS / MKL / RecursiveFactorization

Interleaved same-process arms, min-of-many batches, 7 rounds spread over hours, single BLAS/MKL/Julia thread, `taskset`-pinned. `generic` is LinearSolve's current vendored `generic_lufact!` (+ its naive back-solve in the factsolve tables); `RF` is RecursiveFactorization.jl v0.2.27 (`lu!` with pivoting, `check=false`); `rf+getrs` is the actual RFLUFactorization vector-solve path. MKL via MKL.jl 0.9.1. Machine: 2× AMD EPYC 7502 (Zen 2, AVX2), Julia 1.10.11 and 1.12.6 (LLVM 15 / 18, znver2).

**Julia 1.10.11 — factorization only** (min over 7 interleaved rounds; ratio = time/blocked)

| N | generic | OpenBLAS | MKL | RF | blocked (this PR) |
|---|---|---|---|---|---|
| 4 | 140 ns (1.03x) | 655 ns (4.83x) | 177 ns (1.31x) | 228 ns (1.68x) | 136 ns |
| 8 | 350 ns (1.10x) | 1.1 us (3.35x) | 540 ns (1.70x) | 375 ns (1.18x) | 318 ns |
| 16 | 1.9 us (1.30x) | 3.2 us (2.24x) | 1.8 us (1.28x) | 1.2 us (0.80x) | 1.4 us |
| 32 | 11.5 us (2.18x) | 12.0 us (2.28x) | 11.4 us (2.16x) | 4.2 us (0.81x) | 5.3 us |
| 64 | 84.0 us (3.79x) | 39.1 us (1.76x) | 40.1 us (1.81x) | 15.0 us (0.68x) | 22.2 us |
| 128 | 672.1 us (5.91x) | 157.7 us (1.39x) | 149.9 us (1.32x) | 90.1 us (0.79x) | 113.8 us |
| 256 | 5.60 ms (8.23x) | 791.3 us (1.16x) | 854.8 us (1.26x) | 474.9 us (0.70x) | 680.4 us |
| 512 | 60.85 ms (11.26x) | 5.16 ms (0.96x) | 5.71 ms (1.06x) | 4.86 ms (0.90x) | 5.40 ms |
| 1000 | 346.80 ms (12.28x) | 25.87 ms (0.92x) | 32.23 ms (1.14x) | 22.15 ms (0.78x) | 28.24 ms |
| 2000 | 3.64 s (12.39x) | 203.40 ms (0.69x) | 218.16 ms (0.74x) | 177.78 ms (0.61x) | 293.38 ms |

**Julia 1.10.11 — factorize + 1-rhs solve** (min over 7 interleaved rounds; ratio = time/blocked)

| N | generic | OpenBLAS | MKL | RF | blocked (this PR) |
|---|---|---|---|---|---|
| 4 | 224 ns (1.12x) | 1.0 us (5.09x) | 291 ns (1.45x) | 599 ns (2.98x) | 201 ns |
| 8 | 506 ns (1.03x) | 1.5 us (3.09x) | 912 ns (1.85x) | 819 ns (1.66x) | 493 ns |
| 16 | 2.2 us (1.11x) | 4.0 us (1.97x) | 3.0 us (1.46x) | 1.9 us (0.94x) | 2.0 us |
| 32 | 12.4 us (1.97x) | 13.3 us (2.11x) | 14.4 us (2.28x) | 5.6 us (0.89x) | 6.3 us |
| 64 | 86.4 us (3.53x) | 41.9 us (1.72x) | 43.2 us (1.77x) | 17.7 us (0.73x) | 24.4 us |
| 128 | 680.8 us (5.66x) | 164.8 us (1.37x) | 158.3 us (1.32x) | 96.7 us (0.80x) | 120.3 us |
| 256 | 6.22 ms (8.56x) | 812.1 us (1.12x) | 897.8 us (1.24x) | 495.4 us (0.68x) | 726.4 us |
| 512 | 59.23 ms (10.69x) | 5.19 ms (0.94x) | 5.71 ms (1.03x) | 4.93 ms (0.89x) | 5.54 ms |
| 1000 | 379.20 ms (12.38x) | 27.61 ms (0.90x) | 31.09 ms (1.02x) | 22.70 ms (0.74x) | 30.62 ms |
| 2000 | 3.81 s (13.63x) | 196.83 ms (0.70x) | 219.74 ms (0.79x) | 175.46 ms (0.63x) | 279.78 ms |

**Julia 1.12.6 — factorization only** (min over 7 interleaved rounds; ratio = time/blocked)

| N | generic | OpenBLAS | MKL | RF | blocked (this PR) |
|---|---|---|---|---|---|
| 4 | 141 ns (1.32x) | 390 ns (3.64x) | 133 ns (1.24x) | 230 ns (2.15x) | 107 ns |
| 8 | 442 ns (1.36x) | 983 ns (3.02x) | 461 ns (1.42x) | 499 ns (1.53x) | 325 ns |
| 16 | 2.1 us (1.57x) | 3.3 us (2.45x) | 1.7 us (1.26x) | 1.5 us (1.12x) | 1.4 us |
| 32 | 11.8 us (2.25x) | 11.6 us (2.23x) | 11.3 us (2.15x) | 4.5 us (0.86x) | 5.2 us |
| 64 | 108.1 us (4.89x) | 52.0 us (2.35x) | 39.8 us (1.80x) | 20.6 us (0.93x) | 22.1 us |
| 128 | 614.9 us (5.43x) | 161.6 us (1.43x) | 149.2 us (1.32x) | 92.5 us (0.82x) | 113.2 us |
| 256 | 5.03 ms (7.40x) | 786.7 us (1.16x) | 845.0 us (1.24x) | 470.7 us (0.69x) | 679.7 us |
| 512 | 48.41 ms (10.17x) | 5.26 ms (1.11x) | 5.28 ms (1.11x) | 4.74 ms (1.00x) | 4.76 ms |
| 1000 | 290.85 ms (10.84x) | 26.75 ms (1.00x) | 27.63 ms (1.03x) | 23.42 ms (0.87x) | 26.84 ms |
| 2000 | 2.69 s (10.80x) | 192.64 ms (0.77x) | 206.29 ms (0.83x) | 181.98 ms (0.73x) | 248.96 ms |

**Julia 1.12.6 — factorize + 1-rhs solve** (min over 7 interleaved rounds; ratio = time/blocked)

| N | generic | OpenBLAS | MKL | RF | blocked (this PR) |
|---|---|---|---|---|---|
| 4 | 220 ns (1.27x) | 632 ns (3.65x) | 225 ns (1.30x) | 456 ns (2.63x) | 173 ns |
| 8 | 519 ns (1.12x) | 1.2 us (2.52x) | 706 ns (1.52x) | 748 ns (1.61x) | 466 ns |
| 16 | 2.2 us (1.22x) | 3.6 us (2.01x) | 2.4 us (1.34x) | 1.8 us (1.02x) | 1.8 us |
| 32 | 12.6 us (2.06x) | 12.8 us (2.09x) | 12.5 us (2.05x) | 5.6 us (0.92x) | 6.1 us |
| 64 | 108.1 us (4.49x) | 48.3 us (2.01x) | 42.9 us (1.78x) | 22.9 us (0.95x) | 24.1 us |
| 128 | 625.3 us (5.22x) | 168.8 us (1.41x) | 157.1 us (1.31x) | 104.7 us (0.87x) | 119.7 us |
| 256 | 5.14 ms (7.25x) | 822.6 us (1.16x) | 873.4 us (1.23x) | 496.7 us (0.70x) | 709.0 us |
| 512 | 47.64 ms (9.49x) | 5.20 ms (1.04x) | 5.28 ms (1.05x) | 5.26 ms (1.05x) | 5.02 ms |
| 1000 | 283.60 ms (10.48x) | 26.98 ms (1.00x) | 27.68 ms (1.02x) | 23.08 ms (0.85x) | 27.05 ms |
| 2000 | 2.74 s (10.88x) | 195.63 ms (0.78x) | 203.62 ms (0.81x) | 185.25 ms (0.74x) | 251.85 ms |
Reading of those tables:

  - vs the current scalar `generic_lufact!`: the blocked kernel is ≥ parity at every measured size on both Julia versions (worst case 1.03x at N=4 on 1.10) and 2–12x faster from N=32 up.
  - vs single-threaded OpenBLAS/MKL `getrf`: faster up to N ≈ 256 (1.2–4.8x), parity at 512–1000, ~30–45% behind at N=2000. On this weak-BLAS AMD machine the dependency-free path is now the fastest non-RF option through a few hundred unknowns.
  - vs RecursiveFactorization: RF stays 20–40% faster in the 64–2000 band (LoopVectorization's register tiling). The blocked kernel is *faster* than RF at N ≤ 8–16, and `blocked fact + naive solve` beats RF's `fact + getrs` vector-solve path at N ≤ 32 on 1.10 / N ≤ 16 on 1.12. This PR does not compete with RFLU where RF is loaded; it upgrades the no-dependency fallback.
  - A study-side experiment with an explicit Base-only 8x4 `NTuple{4,VecElement}`/`llvm.fma` microkernel reached 17–23 GFLOPS vs this kernel's 10–17 at N ≥ 256 (RF ≈ 24 at N=2000), so the remaining RF gap is a codegen-quality gap of the `@simd` kernel, not fundamental to dropping LV — closable later without new dependencies if wanted.

## Why not just recommend RecursiveFactorization

Measured on the same machine (min of 5 fresh-process reps, warm pkgimages): RF + its LV stack is 36–39 transitive packages, `using RecursiveFactorization` costs 0.73–0.78 s on both Julia versions, and a clean-cache precompile of the stack is 56 s (1.10) / 89 s (1.12). The kernel in this PR is one file inside LinearSolve: zero added dependencies, zero added load time, and it rides LinearSolve's existing precompile workload.

## Correctness

`test/Core/blocked_lufact.jl` ports the study's adversarial suite (411 assertions, run on 1.10.11 and 1.12.6):

  - backward-stability residuals `||PA − LU|| / (||L|| ||U|| ε max(m,n)) < 20` across sizes 1–512 (Float64/Float32), including power-of-two sizes, every panel/rowblock remainder combination, and rectangular m×n;
  - pivot-sequence parity with LAPACK `lu` on decisive-margin matrices and exact factor equality on permutation matrices;
  - Wilkinson growth matrix: no spurious swaps, exact `2^(n-1)` growth element;
  - singularity: `info` parity with LAPACK on zero columns, `check=true` → `SingularException`, `allowsingular=true` honored, `chkfinite` `ArgumentError` on NaN with `check=true`, NaN junk-in/junk-out with `check=false`;
  - strided `SubArray` inputs (contiguous and non-unit row stride), `ipiv`-too-short `ArgumentError`, dispatch guard that float strided matrices actually hit the blocked method and `BigFloat` does not;
  - `GenericLUFactorization` solve-level: correctness across the blocked-size cutover, repeated refactorization via cache reuse, singular → `ReturnCode.Failure`.

The study-side standalone suite (421 assertions) additionally passed under `--check-bounds=yes` on 1.12, so the `@inbounds`/`ivdep` annotations hide no out-of-bounds access on the tested paths.

## Verification run locally

  - `GROUP=Core julia +1.12 --project -e 'using Pkg; Pkg.test()'` — pass (tail pasted below).
  - `GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'` — pass (tail pasted below).
  - New test file standalone on 1.10.11 and 1.12.6 — 411/411 both.
  - `julia +1.12 --project=docs docs/make.jl` — build completed (tail pasted below).
  - Runic formatting and `typos` on the diff — clean.

Tails of the local runs:

```
GenericLU naive back-solve |  480    480  41.3s
Blocked generic_lufact! kernel |  411    411  18.1s
     Testing LinearSolve tests passed 
...
JET Tests     |   34       8     42  2m43.9s
Allocation QA |   60     60  1m34.4s
SupernodalLU Allocation QA |    8      8  18.6s
Quality Assurance |   48       1     49  15m11.4s
     Testing LinearSolve tests passed 
...docs...
└ @ Documenter.HTMLWriter ~/.julia/packages/Documenter/AXNMp/src/html/HTMLWriter.jl:2003
[ Info: Automatic `version="5.6.2"` for inventory from ../Project.toml
┌ Warning: Documenter could not auto-detect the building environment. Skipping deployment.
└ @ Documenter ~/.julia/packages/Documenter/AXNMp/src/deployconfig.jl:93
```

## Not verified / limitations — please weigh these in review

  - **One machine.** All numbers are from one dual-socket EPYC 7502 (Zen 2, AVX2, 256-bit SIMD). The ≥ parity-vs-scalar claim should be microarch-robust (blocked+SIMD vs scalar triple loop), but the crossover points vs BLAS will move on AVX-512/Apple/ARM hardware, and the N=4–16 margins are small. Nothing here retunes defaults, so a machine where this kernel underperforms scalar at tiny N would regress only by the measured-noise margin.
  - **Not measured:** complex eltypes (excluded from the fast path by dispatch), Float16, multithreading (kernel is single-threaded by design, like the scalar path), GPU paths, downstream packages, `pre`-version CI.
  - The packed Schur kernel allocates one `O(N·nb)` scratch per factorization (≈6 KB at N=100, 126 KB at N=1000) once N ≳ 72; the end-to-end numbers above include that cost. The N ≤ 8 unblocked path allocates nothing new. Threading the scratch through the cacheval would be a follow-up if allocation-free refactorization at mid N matters.
  - `allowsingular=true` is honored by the new float path on all Julia versions, while the vendored scalar path ignores it on 1.10 (throws anyway); that is a deliberate small divergence toward the ≥1.11 stdlib semantics.
  - LinearSolve's `@compile_workload` (4×4 default solve) covers the unblocked sub-kernel; the first blocked-size (N > 8) `GenericLUFactorization` call in a session pays ~0.5–0.9 s of one-time compile. Adding a blocked-size solve to the workload would shift that into LinearSolve's precompile (~2 s); left out to keep the precompile budget unchanged — say the word and I'll add it.

## Possible follow-ups (not in this PR)

  - Let LinearSolveAutotune consider `GenericLUFactorization` as a candidate up to N ≈ 256–512; on weak-BLAS machines it now beats the BLAS LUs there.
  - Raise the N ≤ 10 small-matrix default override (the blocked kernel is 1.2–2.3x faster than OpenBLAS/MKL through N=256 on this machine, but that is one machine's data).
  - Swap the `@simd` Schur kernel for the Base-only explicit-SIMD microkernel to close most of the remaining RF gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGVN6qeNL2jGCtaYg1386X
