### PR TITLE
QA: retire the tracked ExplicitImports and JET broken markers

### DIFF
--- a/lib/LinearSolveAutotune/src/LinearSolveAutotune.jl
+++ b/lib/LinearSolveAutotune/src/LinearSolveAutotune.jl
@@ -1,9 +1,9 @@
 module LinearSolveAutotune
 
 # Ensure MKL is available for benchmarking by setting the preference before loading LinearSolve
-using Preferences
-using MKL_jll
-using OpenBLAS_jll
+using Preferences: Preferences
+using MKL_jll: MKL_jll
+using OpenBLAS_jll: OpenBLAS_jll
 
 # Set MKL preference to true for benchmarking if MKL is available
 # We need to use UUID instead of the module since LinearSolve isn't loaded yet
@@ -18,32 +18,36 @@ if MKL_jll.is_available()
     end
 end
 
-using LinearSolve
-using BenchmarkTools
-using DataFrames
-using PrettyTables
-using Statistics
-using Random
-using LinearAlgebra
-using Printf
-using Dates
-using Base64
-using ProgressMeter
-using CPUSummary
+using LinearSolve: LinearSolve, AppleAccelerateLUFactorization,
+    CudaOffloadLUFactorization, FastLUFactorization, GenericLUFactorization,
+    LUFactorization, LinearAliasSpecifier, LinearProblem, MKLLUFactorization,
+    MetalLUFactorization, OpenBLASLUFactorization, RFLUFactorization,
+    SimpleLUFactorization, solve
+using BenchmarkTools: BenchmarkTools, @benchmarkable
+using DataFrames: DataFrames, DataFrame, combine, groupby, nrow
+using PrettyTables: PrettyTables, pretty_table
+using Statistics: Statistics, std
+using Random: Random, MersenneTwister
+using LinearAlgebra: LinearAlgebra, norm
+using Printf: Printf, @sprintf
+using Dates: Dates
+using Base64: Base64, base64encode
+using ProgressMeter: ProgressMeter, Progress
+using CPUSummary: CPUSummary
+using Pkg: Pkg
 
 # Hard dependency to ensure RFLUFactorization others solvers are available
-using RecursiveFactorization
-using blis_jll
-using LAPACK_jll
-using cuSOLVER
-using Metal
-using FastLapackInterface
-
+using RecursiveFactorization: RecursiveFactorization
+using blis_jll: blis_jll
+using LAPACK_jll: LAPACK_jll
+using cuSOLVER: cuSOLVER
+using Metal: Metal
+using FastLapackInterface: FastLapackInterface
 
 # Optional dependencies for telemetry and plotting
-using GitHub
-using gh_cli_jll
-using Plots
+using GitHub: GitHub
+using gh_cli_jll: gh_cli_jll
+using Plots: Plots, plot, plot!, savefig
 
 export autotune_setup, share_results, AutotuneResults, plot
 

--- a/lib/LinearSolveAutotune/src/gpu_detection.jl
+++ b/lib/LinearSolveAutotune/src/gpu_detection.jl
@@ -644,20 +644,21 @@ function get_detailed_system_info()
         system_data["libm"] = "unknown"
     end
 
-    # libdl_name may not exist in all Julia versions
-    try
-        system_data["libdl"] = Base.libdl_name
-    catch
-        system_data["libdl"] = "unknown"
-    end
+    # libdl_name may not exist in all Julia versions; look it up dynamically so
+    # the reference stays valid (and JET-clean) on versions without the binding.
+    system_data["libdl"] = isdefined(Base, :libdl_name) ?
+        string(getglobal(Base, :libdl_name)) : "unknown"
 
     # Memory information (if available)
     try
         if Sys.islinux()
             meminfo = read(`cat /proc/meminfo`, String)
             mem_match = match(r"MemTotal:\s*(\d+)\s*kB", meminfo)
-            if mem_match !== nothing
-                system_data["total_memory_gb"] = round(parse(Int, mem_match.captures[1]) / 1024 / 1024, digits = 2)
+            # The capture is typed `Union{Nothing, SubString}`; bind it to a
+            # local so the guard narrows it.
+            mem_kb = mem_match === nothing ? nothing : mem_match.captures[1]
+            if mem_kb !== nothing
+                system_data["total_memory_gb"] = round(parse(Int, mem_kb) / 1024 / 1024, digits = 2)
             else
                 system_data["total_memory_gb"] = "unknown"
             end

--- a/lib/LinearSolveAutotune/src/telemetry.jl
+++ b/lib/LinearSolveAutotune/src/telemetry.jl
@@ -328,8 +328,11 @@ function format_categories_markdown(categories::Dict{String, String})
         return sorted_pairs
     end
 
-    # Format each element type
-    for (eltype, ranges) in sort(eltype_categories)
+    # Format each element type in sorted order. `sort` has no `Dict` method, so
+    # sort the keys; the old `sort(eltype_categories)` was a guaranteed
+    # MethodError on this path.
+    for eltype in sort!(collect(keys(eltype_categories)))
+        ranges = eltype_categories[eltype]
         push!(lines, "#### Recommendations for $eltype")
         push!(lines, "")
         push!(lines, "| Size Range | Best Algorithm |")
@@ -473,10 +476,12 @@ function upload_to_github(
 
     @info "📤 Preparing to upload benchmark results..."
 
-    return try
-        target_repo = "SciML/LinearSolve.jl"
-        issue_number = 725  # The existing issue for collecting autotune results
+    # Assigned outside the `try` so the `catch` block's messages can always
+    # reference them.
+    target_repo = "SciML/LinearSolve.jl"
+    issue_number = 725  # The existing issue for collecting autotune results
 
+    return try
         # Construct comment body - use cpu_model if available for more specific info
         cpu_display = get(system_info, "cpu_model", get(system_info, "cpu_name", "unknown"))
         os_name = get(system_info, "os", "unknown")
@@ -561,23 +566,24 @@ function upload_plots_to_gist(plot_files::Union{Nothing, Tuple, Dict}, auth, elt
         return nothing, Dict{String, String}()
     end
 
+    # Handle different plot_files formats. Computed outside the `try` so the
+    # `catch` block's fallback call always has `existing_files` defined.
+    files_to_upload = if isa(plot_files, Tuple)
+        # Legacy format: (png_file, pdf_file)
+        Dict("benchmark_plot.png" => plot_files[1], "benchmark_plot.pdf" => plot_files[2])
+    elseif isa(plot_files, Dict)
+        plot_files
+    else
+        return nothing, Dict{String, String}()
+    end
+
+    # Filter existing files
+    existing_files = Dict(k => v for (k, v) in files_to_upload if isfile(v))
+    if isempty(existing_files)
+        return nothing, Dict{String, String}()
+    end
+
     try
-        # Handle different plot_files formats
-        files_to_upload = if isa(plot_files, Tuple)
-            # Legacy format: (png_file, pdf_file)
-            Dict("benchmark_plot.png" => plot_files[1], "benchmark_plot.pdf" => plot_files[2])
-        elseif isa(plot_files, Dict)
-            plot_files
-        else
-            return nothing, Dict{String, String}()
-        end
-
-        # Filter existing files
-        existing_files = Dict(k => v for (k, v) in files_to_upload if isfile(v))
-        if isempty(existing_files)
-            return nothing, Dict{String, String}()
-        end
-
         # Create README content
         readme_content = """
         # LinearSolve.jl Benchmark Plots
@@ -615,9 +621,12 @@ function upload_plots_to_gist(plot_files::Union{Nothing, Tuple, Dict}, auth, elt
             "files" => gist_files
         )
 
-        # Create the gist
+        # Create the gist. GitHub.jl types `html_url` as a `Union` with
+        # `Nothing`, so guard before deriving the id and username from it.
         gist = GitHub.create_gist(; params = params, auth = auth)
-        gist_url = gist.html_url
+        html_url = gist.html_url
+        html_url === nothing && error("GitHub gist creation returned no html_url")
+        gist_url = string(html_url)
         gist_id = split(gist_url, "/")[end]
         username = split(gist_url, "/")[end - 1]
 

--- a/lib/LinearSolveAutotune/test/qa/qa.jl
+++ b/lib/LinearSolveAutotune/test/qa/qa.jl
@@ -6,6 +6,9 @@ docs_src = normpath(joinpath(pkgdir(LinearSolveAutotune), "..", "..", "docs", "s
 run_qa(
     LinearSolveAutotune;
     explicit_imports = true,
+    # `plot` is deliberately re-exported from Plots: the package extends it with
+    # AutotuneResults methods and exports it as the plotting entry point.
+    reexports_allow = (:plot,),
     api_docs_kwargs = (; rendered = true, docs_src),
     jet_kwargs = (; target_defined_modules = true),
     ei_kwargs = (;
@@ -25,17 +28,4 @@ run_qa(
             ),
         ),
     ),
-    # Heavy `using LinearAlgebra, Statistics, Random, Printf, Base64, Plots, ...`
-    # brings ~55 names implicitly; making them explicit is a source refactor tracked
-    # in https://github.com/SciML/LinearSolve.jl/issues/1058
-    ei_broken = (:no_implicit_imports,),
-    # JET reports 8 pre-existing latent issues in the telemetry/GPU-detection
-    # source (parse/split union splits and try/catch variable-scope leaks in
-    # telemetry.jl + gpu_detection.jl). These predate this QA conversion: the
-    # prior `JET.test_package(LinearSolveAutotune; target_defined_modules=true)`
-    # call surfaced the identical 8 reports, and #1033 (which added this QA group)
-    # merged with the same QA(julia 1) lane red. Fixing them is a telemetry-source
-    # task tracked in https://github.com/SciML/LinearSolve.jl/issues/1058; mark the
-    # JET check known-broken so it auto-flags once those source bugs are fixed.
-    jet_broken = true,
 )

--- a/lib/LinearSolvePyAMG/src/LinearSolvePyAMG.jl
+++ b/lib/LinearSolvePyAMG/src/LinearSolvePyAMG.jl
@@ -27,14 +27,12 @@ sol = solve(prob, PyAMG(accel = "gmres"))
 """
 module LinearSolvePyAMG
 
-using LinearSolve
-using LinearAlgebra
-using SparseArrays
-using PythonCall
-using CondaPkg
+using LinearSolve: LinearSolve, LinearCache, LinearVerbosity, OperatorAssumptions
+using LinearAlgebra: norm
+using SparseArrays: SparseMatrixCSC, sparse
+using PythonCall: Py, pyimport, pyconvert
+using CondaPkg: CondaPkg
 using SciMLBase: SciMLBase, ReturnCode
-
-import LinearSolve: LinearCache, LinearVerbosity, OperatorAssumptions
 
 # ---------------------------------------------------------------------------
 # Algorithm types

--- a/lib/LinearSolvePyAMG/test/qa/qa.jl
+++ b/lib/LinearSolvePyAMG/test/qa/qa.jl
@@ -21,8 +21,4 @@ run_qa(
         # LinearCache is not declared public in LinearSolve.
         all_explicit_imports_are_public = (; ignore = (:LinearCache,)),
     ),
-    # `using LinearAlgebra, SparseArrays, PythonCall, CondaPkg` brings several names
-    # in implicitly; making them explicit is a source refactor tracked in
-    # https://github.com/SciML/LinearSolve.jl/issues/1058
-    ei_broken = (:no_implicit_imports,),
 )

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -117,6 +117,75 @@ linearsolve_internal_imports = (
     :defaultalg, :do_factorization, :get_blas_operation_info, :init_cacheval,
 )
 
+# LinearSolve's own non-public names reached as `LinearSolve.x` (or
+# `LinearSolve.SupernodalLU.x`) from its extension modules. Same class as
+# `linearsolve_internal_imports` above: an extension is its own module root, so
+# ExplicitImports counts these as external accesses. Promoting them is a separate
+# public-API decision (https://github.com/SciML/LinearSolve.jl/issues/1058); this
+# inventory keeps the strict check on so any new non-public access is caught.
+linearsolve_internal_accesses = (
+    Symbol("@get_cacheval"), :ALREADY_WARNED_CUDSS, :AbstractFactorization,
+    :AbstractKrylovSubspaceMethod, :DefaultAlgorithmChoice, :DefaultLinearSolver,
+    :DefaultLinearSolverInit, :GPUArraysCore, :LinearCache,
+    :NONPERSISTENT_ZERO_FRACTION, :PERSISTENT_ZERO_FRACTION_THRESHOLD,
+    :PrecompileTools, :SciMLLinearSolveAlgorithm, :SupernodalLU,
+    :_SPARSE_LU_FALLBACK_ALGORITHMS, :_SPARSE_ONLY_ALGORITHMS,
+    :__is_extension_loaded, :__nonstructural_zeros, :_adjoint_factorization_solve,
+    :_adjoint_krylov_solve, :_can_reuse_cache_factorization,
+    :_custom_adjoint_factorization_solve, :_custom_cache_factorization,
+    :_custom_can_reuse_adjoint_factorization, Symbol("_direct_lu_factorize!"),
+    Symbol("_direct_lu_solve!"), Symbol("_fast_sym_givens!"), :_init_cacheval,
+    :_isidentity_struct, Symbol("_ldiv!"), :_select_eigenpairs, :_sym_givens,
+    :cudss_loaded, :default_alias_A, :default_num_eigenpairs, :default_tol,
+    :defaultalg, :defaultalg_adjoint_eval, :do_factorization, :error_no_cudss_lu,
+    :handle_sparsematrixcsc_lu, :init_cacheval, :init_sparse_reduction, :is_cusparse,
+    :is_cusparse_csc, :is_cusparse_csr, :is_underdetermined, :issparsematrix,
+    :issparsematrixcsc, :make_SparseMatrixCSC, :makeempty_SparseMatrixCSC,
+    :pattern_changed, Symbol("reduce_operand!"), :sparse_colpivqr_factorize,
+    Symbol("update_tolerances_internal!"), :use_klulike_sparse_structure, :useblis,
+    :usecuda, :usemetal, :userecursivefactorization,
+    # LinearSolve.SupernodalLU
+    :SupernodalLUFactor, :_costabs, Symbol("_panel_ldiv!"), Symbol("_panel_rdiv!"),
+    :nperturbed, :snlu, Symbol("snlu!"), Symbol("solve!"),
+)
+
+# Non-public names of stdlib / backend packages accessed with a qualified path,
+# where the owner exposes no public spelling for what the solver bindings need.
+# Grouped by owner; a name listed once is ignored for every owner (the check's
+# `ignore` is name-based).
+external_internal_accesses = (
+    # Base / Base.Experimental
+    Symbol("@_inline_meta"), :Experimental, :RefValue, :USE_BLAS64, :USE_GPL_LIBS,
+    :return_types, :structdiff, :typename, Symbol("@max_methods"),
+    # LinearAlgebra (+ .BLAS / .LAPACK)
+    :AdjointFactorization, :BlasFloat, :BlasInt, :PivotingStrategy, :QRCompactWY,
+    :QRIteration, :TransposeFactorization, :_check_lu_success, Symbol("_ipiv_rows!"),
+    :checknonsingular, :generic_lufact!, :lupivottype, :lutype, :get_config,
+    :get_num_threads, :set_num_threads, :chkfinite, :chklapackerror, :chktrans,
+    Symbol("geqp3!"), Symbol("geqrt!"), Symbol("getrf!"),
+    # SparseArrays (+ .SPQR)
+    :AbstractSparseMatrixCSC, :CHOLMOD, :SPQR, :UMFPACK, :getcolptr, :QRSparse,
+    # AMDGPU (+ .rocBLAS / .rocSOLVER)
+    :rocBLAS, :rocSOLVER, Symbol("trsv!"), Symbol("geqrf!"), Symbol("getrs!"),
+    Symbol("ormqr!"),
+    # CUDSS / cuSOLVER
+    :cuSPARSE, :CUDACore,
+    # EnzymeCore (+ .EnzymeRules)
+    :EnzymeRules, :augmented_primal, :forward, :inactive_type, :reverse,
+    # ForwardDiff
+    :Dual, :npartials, :partials, :valtype, :value,
+    # IterativeSolvers
+    :GMRESIterable, :IDRSIterable, :MINRESIterable, :Residual,
+    Symbol("gmres_iterable!"), Symbol("idrs_iterable!"), Symbol("init!"),
+    Symbol("init_residual!"), Symbol("minres_iterable!"),
+    # Krylov / Mooncake / EnumX / PureKLU / MKL_jll / OpenBLAS_jll
+    Symbol("warm_start!"), Symbol("increment_and_get_rdata!"), Symbol("rrule!!"),
+    :symbol_map, :KLU_OK, :is_available,
+    # RecursiveFactorization / TriangularSolve
+    Symbol("lu!"), Symbol("🦋mul!"), Symbol("🦋workspace"), Symbol("ldiv!"),
+    Symbol("rdiv!"),
+)
+
 docs_src = normpath(joinpath(@__DIR__, "..", "..", "docs", "src"))
 scimlbase_reexports = Tuple(names(LinearSolve.SciMLBase; all = false, imported = false))
 
@@ -183,12 +252,16 @@ run_qa(
                 backend_internal_imports..., linearsolve_internal_imports...,
             ),
         ),
+        # Inventory of today's non-public qualified accesses (see the two constants
+        # above). Replaces the blanket `ei_broken` marker from
+        # https://github.com/SciML/LinearSolve.jl/issues/1058: the strict check now
+        # runs, so a qualified access of any name not listed here fails QA.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                linearsolve_internal_accesses..., external_internal_accesses...,
+            ),
+        ),
     ),
-    # ~90 qualified accesses of non-public names (LinearSolve's own internals reached
-    # via LinearSolve.x from extensions, plus stdlib/SciMLBase/LinearAlgebra internals).
-    # Making them public is a large cross-package effort tracked in
-    # https://github.com/SciML/LinearSolve.jl/issues/1058
-    ei_broken = (:all_qualified_accesses_are_public,),
 )
 
 if klu_mod !== nothing


### PR DESCRIPTION
Fixes #1058.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- Root QA: replaces the all_qualified_accesses_are_public ei_broken marker with an explicit ignore inventory, split into LinearSolve-owned and external names grouped by owner. The strict check now runs, so any new non-public qualified access fails QA. Promoting names to public stays a separate API decision, matching the existing linearsolve_internal_imports stance.
- LinearSolvePyAMG: converted to explicit imports and dropped its no_implicit_imports marker. QA 21 of 21.
- LinearSolveAutotune: converted all using lines to explicit imports (53 names, generated with ExplicitImports itself) and dropped both markers.
- Fixed the 8 pre-existing JET reports behind jet_broken: hoisted target_repo, issue_number and existing_files out of try blocks so catch blocks cannot hit undefined variables, guarded gist.html_url against nothing, guarded the meminfo regex capture, and replaced the Base.libdl_name reference with a dynamic isdefined lookup.
- Fixed a real latent bug JET then exposed: format_categories_markdown called sort on a Dict, a guaranteed MethodError whenever share_results formatted non-empty categories. Now sorts the keys; verified by direct call.
- Added reexports_allow for plot, which LinearSolveAutotune deliberately extends and exports.
- Verified: root qa.jl 20 of 20 with zero broken, PyAMG 21 of 21, Autotune 20 of 21 where the single failure is Aqua persistent-tasks, which reproduces identically on pristine main on this Windows host. Runic clean.

AI Disclosure: Used Fable 5