### PR TITLE
Raise the default GenericLUFactorization band to 32 (128 under OpenBLAS)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.6.2"
+version = "5.6.3"
 authors = ["SciML"]
 
 [deps]

--- a/src/default.jl
+++ b/src/default.jl
@@ -400,6 +400,18 @@ function defaultalg(A, b, assump::OperatorAssumptions{Bool})
                         DefaultAlgorithmChoice.RFLUFactorization
                         #elseif A === nothing || A isa Matrix
                         #    alg = FastLUFactorization()
+                        # Blocked generic_lufact! beats vendor getrf ≥ 2x through N = 32
+                        # everywhere, and through 128 vs OpenBLAS (badly tuned small-N
+                        # threading — same fact the RFLU 500 band above encodes).
+                    elseif (
+                            matrix_size <= 32 ||
+                                (isopenblas() && matrix_size <= 128)
+                        ) &&
+                            (
+                            A === nothing ? eltype(b) <: Union{Float32, Float64} :
+                                eltype(A) <: Union{Float32, Float64}
+                        )
+                        DefaultAlgorithmChoice.GenericLUFactorization
                     elseif usemkl &&
                             b isa DenseArray && !(b isa GPUArraysCore.AnyGPUArray) &&
                             eltype(b) <: Union{Float32, Float64, ComplexF32, ComplexF64}

--- a/test/Core/default_algs.jl
+++ b/test/Core/default_algs.jl
@@ -15,6 +15,29 @@ end
 prob = LinearProblem(rand(50, 50), rand(50))
 solve(prob)
 
+# RF loaded: unconditional GenericLU ends at 10, RFLU (Accelerate on Apple) from 11
+@test LinearSolve.defaultalg(nothing, zeros(10)).alg ===
+    LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
+if LinearSolve.appleaccelerate_isavailable()
+    @test LinearSolve.defaultalg(nothing, zeros(11)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.AppleAccelerateLUFactorization
+else
+    @test LinearSolve.defaultalg(nothing, zeros(11)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.RFLUFactorization
+end
+
+# the raised GenericLU band is Float32/Float64-only; complex stays on BLAS
+if LinearSolve.appleaccelerate_isavailable()
+    @test LinearSolve.defaultalg(nothing, zeros(ComplexF64, 32)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.AppleAccelerateLUFactorization
+elseif LinearSolve.usemkl
+    @test LinearSolve.defaultalg(nothing, zeros(ComplexF64, 32)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.MKLLUFactorization
+else
+    @test LinearSolve.defaultalg(nothing, zeros(ComplexF64, 32)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.LUFactorization
+end
+
 if LinearSolve.usemkl
     @test LinearSolve.defaultalg(nothing, zeros(600)).alg ===
         LinearSolve.DefaultAlgorithmChoice.MKLLUFactorization

--- a/test/DefaultsLoading/defaults_loading.jl
+++ b/test/DefaultsLoading/defaults_loading.jl
@@ -1,4 +1,5 @@
 using SparseArrays
+using LinearAlgebra
 using LinearSolve
 using Test
 
@@ -38,6 +39,30 @@ if STRUMPACKExt === nothing || !STRUMPACKExt.strumpack_isavailable()
     @test_throws ["STRUMPACKFactorization", "STRUMPACK_jll"] STRUMPACKFactorization()
 else
     @test STRUMPACKFactorization() isa STRUMPACKFactorization
+end
+
+# no-RF dense band: blocked GenericLU owns N ≤ 32 everywhere, ≤ 128 under OpenBLAS
+@test Base.get_extension(LinearSolve, :LinearSolveRecursiveFactorizationExt) === nothing
+if LinearSolve.appleaccelerate_isavailable()
+    @test LinearSolve.defaultalg(nothing, zeros(32)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.AppleAccelerateLUFactorization
+else
+    above_band = LinearSolve.usemkl ?
+        LinearSolve.DefaultAlgorithmChoice.MKLLUFactorization :
+        LinearSolve.DefaultAlgorithmChoice.LUFactorization
+    @test LinearSolve.defaultalg(nothing, zeros(32)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
+    if LinearSolve.isopenblas()
+        @test LinearSolve.defaultalg(nothing, zeros(128)).alg ===
+            LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
+        @test LinearSolve.defaultalg(nothing, zeros(129)).alg === above_band
+    else
+        @test LinearSolve.defaultalg(nothing, zeros(33)).alg === above_band
+    end
+    let A = rand(32, 32) + 32I, b = rand(32)
+        sol = solve(LinearProblem(A, b))
+        @test norm(A * sol.u - b) < 1.0e-8
+    end
 end
 
 using Sparspak


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What

Raises the default-algorithm cutoff at which dense square Float32/Float64 problems switch from `GenericLUFactorization` to vendor BLAS, justified by the blocked `generic_lufact!` kernel merged in https://github.com/SciML/LinearSolve.jl/pull/1173: a new band `N ≤ 32 || (isopenblas() && N ≤ 128)` slots in between the RFLU branch and the MKL/LU branches in `defaultalg`, mirroring the vendor-conditional style of the existing RFLU band. One new `elseif` in `src/default.jl`; nothing else in the selection logic moves.

## Band map (dense square, BLAS eltypes, well/ill-conditioned, no autotune prefs, non-GPU)

Before (order of precedence):

| band | choice |
|---|---|
| N ≤ 10 (all four BLAS eltypes) | GenericLUFactorization |
| N > 10, tuned autotune preference set | tuned algorithm |
| N > 10, Apple Accelerate available | AppleAccelerateLUFactorization |
| Float32/64, RF loaded: N ≤ 100, or ≤ 500 (`isopenblas()`), or ≤ 200 (`usemkl`) | RFLUFactorization |
| otherwise | MKLLUFactorization if `usemkl`, else LUFactorization |

After — identical except one new band between RFLU and MKL/LU:

| band | choice |
|---|---|
| **Float32/64: N ≤ 32, or N ≤ 128 (`isopenblas()`)** | **GenericLUFactorization** |

Consequences:

- **RF loaded: nothing changes.** The RFLU band (100/500/200) fully shadows the new band on every vendor, so the RFLU lower edge stays at 10 and its upper edges are untouched.
- **Autotune preferences still override**: the new band sits after the `get_tuned_algorithm` check, and the pre-preference unconditional GenericLU band stays at N ≤ 10 (the Preferences tests pin size-15 tuned choices being honored).
- **Apple unaffected**: the Accelerate branch sits above the new band; macOS behavior is unchanged for N > 10 (no Apple measurements exist for the blocked kernel).
- **Complex unaffected**: the new band is Float32/Float64-only (the blocked kernel dispatches on real strided floats; complex would fall back to the scalar generic path, which loses to BLAS at these sizes).

## Measurements (this machine)

2× AMD EPYC 7502 (Zen 2, 64 physical cores / 128 CPUs, 2 NUMA nodes), Julia 1.10.11 and 1.12.6, LBT → OpenBLAS (`libopenblas64_`). Run against the #1173 branch head, whose `src/blocked_lufact.jl`/`src/generic_lufact.jl` are byte-identical to what merged into `main`. `LinearSolve.usemkl == false` here — LinearSolve's `LoadMKL_JLL` preference defaults off on EPYC — so there is no MKL arm; on this machine class OpenBLAS through `LUFactorization` is exactly what runs above the band. Full `solve!` path per sample: `cache.A = A` (marks `isfresh`) then `solve!(cache)`, i.e. fresh factorization + solve through LinearSolve, cache-reuse style. Interleaved same-process arms, arm order rotated per round, min over 7 rounds × (50–1000 samples/round). `RFLU` is the real `RFLUFactorization` path with RecursiveFactorization loaded (1 Julia thread). Ratios are time/GenericLU-blocked (> 1 = blocked faster).

**Default-threaded BLAS (the headline): `BLAS.get_num_threads() == 64`, machine as-is, unpinned.** Note the generosity direction: 64 idle physical cores is as flattering a setup as threaded OpenBLAS ever gets — on smaller machines the BLAS side only gets worse, so a crossover measured here is an upper bound biased toward BLAS.

Julia 1.12.6, default threads:

| N | GenericLU (blocked) | OpenBLAS LU | RFLU |
|---|---|---|---|
| 8 | 529 ns | 1.17 us (2.21x) | 699 ns (1.32x) |
| 16 | 1.67 us | 3.4 us (2.04x) | 1.78 us (1.07x) |
| 24 | 3.35 us | 7.1 us (2.12x) | 3.31 us (0.99x) |
| 32 | 5.72 us | 12.27 us (2.15x) | 5.49 us (0.96x) |
| 48 | 12.77 us | 21.87 us (1.71x) | 9.76 us (0.76x) |
| 64 | 23.26 us | 38.86 us (1.67x) | 17.21 us (0.74x) |
| 96 | 60.22 us | 78.27 us (1.3x) | 40.5 us (0.67x) |
| 128 | 116.61 us | 149.33 us (1.28x) | 96.05 us (0.82x) |
| 192 | 326.59 us | 517.63 us (1.58x) | 238.65 us (0.73x) |
| 256 | 706.89 us | 796.47 us (1.13x) | 479.44 us (0.68x) |
| 384 | 1.9 ms | 2.1 ms (1.11x) | 1.35 ms (0.71x) |
| 512 | 5.02 ms | 4.44 ms (0.88x) | 4.62 ms (0.92x) |

Julia 1.10.11, default threads — 1.10's older OpenBLAS fans out its thread pool from N ≈ 128 and collapses:

| N | GenericLU (blocked) | OpenBLAS LU | RFLU |
|---|---|---|---|
| 8 | 519 ns | 1.6 us (3.08x) | 859 ns (1.66x) |
| 16 | 1.83 us | 4.19 us (2.29x) | 1.89 us (1.03x) |
| 24 | 3.46 us | 7.98 us (2.31x) | 3.32 us (0.96x) |
| 32 | 5.94 us | 13.54 us (2.28x) | 5.76 us (0.97x) |
| 48 | 12.96 us | 22.96 us (1.77x) | 9.69 us (0.75x) |
| 64 | 23.1 us | 41.57 us (1.8x) | 17.77 us (0.77x) |
| 96 | 60.1 us | 82.54 us (1.37x) | 40.6 us (0.68x) |
| 128 | 116.75 us | 1.22 ms (10.44x) | 95.41 us (0.82x) |
| 192 | 315.09 us | 2.48 ms (7.87x) | 240.83 us (0.76x) |
| 256 | 696.85 us | 3.59 ms (5.16x) | 482.79 us (0.69x) |
| 384 | 1.9 ms | 6.44 ms (3.39x) | 1.37 ms (0.72x) |
| 512 | 4.97 ms | 9.59 ms (1.93x) | 4.88 ms (0.98x) |

**Reference: `BLAS.set_num_threads(1)`, pinned to one core (`taskset -c 2`, `OMP_NUM_THREADS=1`).**

Julia 1.12.6, 1 BLAS thread:

| N | GenericLU (blocked) | OpenBLAS LU | RFLU |
|---|---|---|---|
| 8 | 529 ns | 1.18 us (2.23x) | 690 ns (1.3x) |
| 16 | 1.67 us | 3.41 us (2.04x) | 1.75 us (1.05x) |
| 24 | 3.35 us | 7.06 us (2.11x) | 3.3 us (0.99x) |
| 32 | 5.81 us | 12.32 us (2.12x) | 5.58 us (0.96x) |
| 48 | 12.71 us | 21.84 us (1.72x) | 9.74 us (0.77x) |
| 64 | 23.26 us | 38.66 us (1.66x) | 17.61 us (0.76x) |
| 96 | 60.19 us | 78.0 us (1.3x) | 40.42 us (0.67x) |
| 128 | 117.21 us | 148.87 us (1.27x) | 94.23 us (0.8x) |
| 192 | 327.26 us | 353.99 us (1.08x) | 238.39 us (0.73x) |
| 256 | 708.47 us | 753.68 us (1.06x) | 477.69 us (0.67x) |
| 384 | 1.9 ms | 1.92 ms (1.01x) | 1.36 ms (0.72x) |
| 512 | 4.95 ms | 4.74 ms (0.96x) | 4.79 ms (0.97x) |

Julia 1.10.11, 1 BLAS thread:

| N | GenericLU (blocked) | OpenBLAS LU | RFLU |
|---|---|---|---|
| 8 | 519 ns | 1.37 us (2.64x) | 739 ns (1.42x) |
| 16 | 1.83 us | 3.89 us (2.13x) | 1.76 us (0.96x) |
| 24 | 3.49 us | 7.65 us (2.19x) | 3.23 us (0.93x) |
| 32 | 5.93 us | 13.3 us (2.24x) | 5.61 us (0.95x) |
| 48 | 13.12 us | 23.12 us (1.76x) | 9.57 us (0.73x) |
| 64 | 23.06 us | 41.26 us (1.79x) | 17.51 us (0.76x) |
| 96 | 60.2 us | 80.48 us (1.34x) | 40.59 us (0.67x) |
| 128 | 116.94 us | 159.9 us (1.37x) | 96.71 us (0.83x) |
| 192 | 312.06 us | 357.3 us (1.14x) | 239.27 us (0.77x) |
| 256 | 694.96 us | 785.57 us (1.13x) | 479.9 us (0.69x) |
| 384 | 1.88 ms | 1.99 ms (1.06x) | 1.36 ms (0.73x) |
| 512 | 4.95 ms | 4.88 ms (0.99x) | 4.76 ms (0.96x) |

## Why 32 and 128

- **32 universal**: blocked wins ≥ 2.0x at N ≤ 32 in all four configurations above, and #1173's single-threaded kernel benchmarks on this machine additionally show ≥ 2.15x vs MKL getrf at 32. Small-N getrf overhead (LAPACK call + pivot bookkeeping + threading heuristics) is a vendor-universal property, so 32 is the "safe everywhere" bound.
- **128 under `isopenblas()`**: the largest size where blocked wins in *all four* configurations with real margin — 1.27–1.37x single-threaded, 1.28x (1.12) and 10.4x (1.10) default-threaded. Beyond 128 the win persists here (1.01–1.14x single-threaded through 384; default-threaded crossover is 384–512 on 1.12 and past 512 on 1.10) but the single-threaded margins are inside cross-machine variance, so the band edge stays at 128 rather than chasing 256+. The conditional mirrors the RFLU band's `isopenblas() && N ≤ 500`, which encodes the same fact about OpenBLAS's poorly tuned small-N threading.
- **No `usemkl` extension beyond 32**: `usemkl == false` on this EPYC box (LinearSolve's own `LoadMKL_JLL` preference), so there is no end-to-end MKL measurement here; extending past 32 against MKL on #1173's kernel-level single-thread data alone felt too thin. Machines where the extension band applies while `usemkl` is true (LBT still OpenBLAS) route N > 128 to MKL exactly as before.
- **RFLU lower edge stays at 10**: at solve! level RFLU already matches/beats blocked at N = 16 on 1.10 (0.96x) and from N = 24 on 1.12 (0.99x); blocked's only clear win is N = 8 (1.3–1.66x). That fails the "supported on both 1.10 and 1.12" bar, so the RF-loaded band logic is untouched.

Per-machine tuning beyond these conservative edges is LinearSolveAutotune territory — it measures the actual machine and its preferences override this heuristic entirely (which is why the band sits below the `get_tuned_algorithm` check).

## Tests

- `test/Core/default_algs.jl` (+): RF-loaded edges — N = 10 → GenericLU, N = 11 → RFLU (Accelerate on Apple); ComplexF64 N = 32 stays on BLAS.
- `test/DefaultsLoading/defaults_loading.jl` (+): no-RF band — asserts the RF extension is absent, N = 32 → GenericLU, and under `isopenblas()` N = 128 → GenericLU / N = 129 → MKL-or-LU (N = 33 → MKL-or-LU otherwise), plus an in-band default `solve` correctness check. Apple-conditional like the neighboring tests.

## Verification run locally

Test files run standalone in scratch envs that `Pkg.develop` this branch; the defaults tests were run once on the pre-merge #1173 stack and re-run on the exact rebased tree being pushed.

- `test/Core/default_algs.jl` — Julia 1.12.6 and 1.10.11 (RF loaded): exit 0, every testset passes (tail: `Sparse ComplexF32 with Int32 indices | 5 5`); re-run after rebase onto `main`: exit 0.
- `test/DefaultsLoading/defaults_loading.jl` — Julia 1.12.6 and 1.10.11 in envs **without** RecursiveFactorization (the file asserts the RF extension is absent): exit 0 (top-level `@test`s, any failure is a nonzero exit); re-run after rebase: exit 0.
- `test/Core/basictests.jl` — Julia 1.12.6: `LinearSolve | 642 642` plus trailing testsets, exit 0.
- `GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'` — `Testing LinearSolve tests passed`, exit 0.
- Runic v1 `--check --diff` on the changed files — clean. `typos` on the diff — clean.
- Behavior smoke on this machine: no-RF gives GenericLU through N = 128 and LUFactorization from 129; with RF loaded 11–500 stays RFLU; ComplexF64 N = 32 stays LUFactorization.

## Not verified

- **Other machines — the main caveat.** All numbers are one dual-EPYC-7502 Zen 2 box. The 128 OpenBLAS edge is believed conservative (this box is as favorable to threaded BLAS as it gets, and 1-thread margins at 128 are 1.27x+), but AVX-512 Intel, Apple silicon, and aarch64 were not measured. Autotune preferences override the band on machines where it is wrong.
- No MKL end-to-end arm (see above), no Apple Accelerate measurements (branch order leaves macOS behavior unchanged), GPU paths untouched, docs build not run (no docs files touched; the one prose mention of the ≤ 10 override in `docs/src/advanced/internal_api.md` remains true).
- Allowed-to-fail CI lanes (julia pre, GPU, downstream) were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
