### PR TITLE
Tune SupernodalLU panel solve cutoffs

### DIFF
--- a/benchmarks/supernodal_panel_solve.jl
+++ b/benchmarks/supernodal_panel_solve.jl
@@ -1,0 +1,60 @@
+using BenchmarkTools, LinearAlgebra, LinearSolve, Random, RecursiveFactorization
+using TriangularSolve
+
+const SNLU = LinearSolve.SupernodalLU
+
+machine_load() = Sys.islinux() ? first(split(read("/proc/loadavg", String))) : "unavailable"
+
+function panel_matrix(np)
+    W = Matrix{Float64}(I, np, np)
+    scale = inv(sqrt(np))
+    for j in 1:np
+        for i in 1:(j - 1)
+            W[i, j] = scale * randn()
+        end
+        for i in (j + 1):np
+            W[i, j] = scale * randn()
+        end
+    end
+    return W
+end
+
+function lower_times(W, Y0, np)
+    kernel = @belapsed SNLU._unit_lower_solve!($W, Y, $np) setup = (Y = copy($Y0)) evals = 1
+    triangularsolve = @belapsed TriangularSolve.ldiv!(
+        UnitLowerTriangular(view($W, 1:$np, 1:$np)), Y, Val(false)
+    ) setup = (Y = copy($Y0)) evals = 1
+    blas = @belapsed SNLU._panel_unit_lower_trsm!($W, Y, $np) setup = (Y = copy($Y0)) evals = 1
+    return kernel, triangularsolve, blas
+end
+
+function upper_times(W, Y0, np)
+    kernel = @belapsed SNLU._upper_solve!($W, Y, $np) setup = (Y = copy($Y0)) evals = 1
+    triangularsolve = @belapsed TriangularSolve.ldiv!(
+        UpperTriangular(view($W, 1:$np, 1:$np)), Y, Val(false)
+    ) setup = (Y = copy($Y0)) evals = 1
+    blas = @belapsed SNLU._panel_upper_trsm!($W, Y, $np) setup = (Y = copy($Y0)) evals = 1
+    return kernel, triangularsolve, blas
+end
+
+function benchmark_panel_cutoffs(; nps = (8, 16, 32, 64, 128, 256, 512, 768, 1024, 1280, 1536, 1792, 2048), nrhss = (1, 2, 4, 8, 16, 32))
+    BLAS.set_num_threads(1)
+    Random.seed!(1172)
+    BenchmarkTools.DEFAULT_PARAMETERS.seconds = 0.25
+    BenchmarkTools.DEFAULT_PARAMETERS.samples = 100
+    println("Julia $(VERSION), TriangularSolve $(Base.pkgversion(TriangularSolve)), BLAS threads $(BLAS.get_num_threads()), load $(machine_load())")
+    println("np nrhs sweep kernel_ns triangularsolve_ns blas_ns")
+    for np in nps, nrhs in nrhss
+        W = panel_matrix(np)
+        Y0 = randn(np, nrhs)
+        for (sweep, times) in (("lower", lower_times(W, Y0, np)), ("upper", upper_times(W, Y0, np)))
+            kernel, triangularsolve, blas = times
+            println("$np $nrhs $sweep $(round(Int, kernel * 1.0e9)) $(round(Int, triangularsolve * 1.0e9)) $(round(Int, blas * 1.0e9))")
+        end
+    end
+    return nothing
+end
+
+if abspath(PROGRAM_FILE) == abspath(@__FILE__)
+    benchmark_panel_cutoffs()
+end

--- a/ext/LinearSolveRecursiveFactorizationExt.jl
+++ b/ext/LinearSolveRecursiveFactorizationExt.jl
@@ -257,11 +257,9 @@ end
 
 # Solve-phase pivot-block trsms.  With TriangularSolve available it takes the
 # whole middle band: it is the library RecursiveFactorization already uses for
-# its own trsms, and it carries its own small-size cutoffs (`VECTOR_RHS_CUTOFF`
-# and the blocked-kernel thresholds), so there is no need to re-derive here
-# where it stops beating a naive sweep -- it falls back on its own.  Above
-# `PANEL_BLAS_MIN_NP` the blocked BLAS sweep is still expected to win, so the
-# large end stays on `trsm!`.
+# its own trsms.  A one-column matrix RHS retains the in-tree kernels: it
+# cannot amortize TriangularSolve's setup.  Wider panels use the BLAS path
+# above `PANEL_BLAS_MIN_NP`.
 #
 # Both wrappers need TriangularSolve >= 0.2.2, which is where the matrix
 # `ldiv!(::UpperTriangular{T,<:StridedMatrix{T}}, ::StridedMatrix{T}, ::Val)`
@@ -270,13 +268,12 @@ end
 # dispatch and the path that allocates on Julia 1.11.  The `[compat]` floor is
 # set accordingly.
 #
-# The band boundaries are inherited from the dense back-solve work (#1169,
-# #1164) rather than measured on supernode panels; SciML/LinearSolve.jl#1172
-# tracks measuring them here.
 function SNLU._panel_solve_unit_lower!(
         Ws::Matrix{Tv}, Yb::AbstractMatrix{Tv}, np::Int
     ) where {Tv <: SNLUTypes}
-    if np > SNLU.PANEL_BLAS_MIN_NP
+    if size(Yb, 2) == 1
+        SNLU._unit_lower_solve!(Ws, Yb, np)
+    elseif np > SNLU.PANEL_BLAS_MIN_NP
         SNLU._panel_unit_lower_trsm!(Ws, Yb, np)
     else
         TriangularSolve.ldiv!(UnitLowerTriangular(view(Ws, 1:np, 1:np)), Yb, Val(false))
@@ -287,7 +284,9 @@ end
 function SNLU._panel_solve_upper!(
         Ws::Matrix{Tv}, Yb::AbstractMatrix{Tv}, np::Int
     ) where {Tv <: SNLUTypes}
-    if np > SNLU.PANEL_BLAS_MIN_NP
+    if size(Yb, 2) == 1
+        SNLU._upper_solve!(Ws, Yb, np)
+    elseif np > SNLU.PANEL_BLAS_MIN_NP
         SNLU._panel_upper_trsm!(Ws, Yb, np)
     else
         TriangularSolve.ldiv!(UpperTriangular(view(Ws, 1:np, 1:np)), Yb, Val(false))

--- a/src/SupernodalLU/solve.jl
+++ b/src/SupernodalLU/solve.jl
@@ -59,30 +59,16 @@ end
 # side (not for a vector, and not on 1.10 or 1.12), which breaks the
 # allocation-free guarantee for every panel of every sweep.
 #
-#   np <= PANEL_KERNEL_MAX_NP   the in-tree column kernels.  Supernode panels
-#                               are small -- median width 6 for a 2D Poisson
-#                               factorization -- and at that size any library
-#                               call is dominated by its own overhead.
-#   above, up to PANEL_BLAS_MIN_NP
-#                               `TriangularSolve.ldiv!` when it is available,
-#                               i.e. when RecursiveFactorization is loaded; see
-#                               the hooks below.  It is the same library
-#                               RecursiveFactorization uses for its own trsms,
-#                               and it carries its own small-size cutoffs, so
-#                               the extension hands it the whole band rather
-#                               than re-deriving where it stops winning.
-#                               Without it this band falls back to BLAS.
-#   np > PANEL_BLAS_MIN_NP      `BLAS.trsm!`, whose blocked sweep is what wins
-#                               once the triangle no longer fits in cache.
+#   nrhs == 1                   the in-tree column kernels at every panel width.
+#   no TriangularSolve          kernels through `PANEL_KERNEL_MAX_NP`, then BLAS.
+#   TriangularSolve available   TriangularSolve through `PANEL_BLAS_MIN_NP`, then
+#                               BLAS (apart from the one-column case above).
 #
-# The boundaries follow the dense back-solve work rather than a fresh
-# measurement of this kernel: #1169 puts the in-tree-kernel/BLAS crossover at
-# 256, and #1164 confirms 256 for a `Matrix` orientation (512 wrapped) while
-# finding multi-RHS sweeps still ahead through N=1000.  Those were measured on
-# whole LU back-solves, not on supernode panels, so treat both numbers as
-# provisional -- SciML/LinearSolve.jl#1172 tracks measuring them here directly.
+# With RecursiveFactorization loaded, SciML/LinearSolve.jl#1172 measured
+# TriangularSolve through panels of width 1792.  The no-extension fallback
+# stays conservative at 256.
 const PANEL_KERNEL_MAX_NP = 256
-const PANEL_BLAS_MIN_NP = 1024
+const PANEL_BLAS_MIN_NP = 1792
 
 # `trsm!` needs a BLAS element type in a strided array; everything else stays on
 # the kernels, which are generic and beat the stdlib fallback for those types.
@@ -135,7 +121,7 @@ end
 function _panel_solve_unit_lower!(
         Ws::AbstractMatrix{Tv}, Yb::AbstractMatrix{Tv}, np::Int
     ) where {Tv}
-    if np <= PANEL_KERNEL_MAX_NP || !_panel_blas_eligible(Tv)
+    if np <= PANEL_KERNEL_MAX_NP || size(Yb, 2) == 1 || !_panel_blas_eligible(Tv)
         _unit_lower_solve!(Ws, Yb, np)
     else
         _panel_unit_lower_trsm!(Ws, Yb, np)
@@ -146,7 +132,7 @@ end
 function _panel_solve_upper!(
         Ws::AbstractMatrix{Tv}, Yb::AbstractMatrix{Tv}, np::Int
     ) where {Tv}
-    if np <= PANEL_KERNEL_MAX_NP || !_panel_blas_eligible(Tv)
+    if np <= PANEL_KERNEL_MAX_NP || size(Yb, 2) == 1 || !_panel_blas_eligible(Tv)
         _upper_solve!(Ws, Yb, np)
     else
         _panel_upper_trsm!(Ws, Yb, np)

--- a/test/Core/supernodal_lu.jl
+++ b/test/Core/supernodal_lu.jl
@@ -316,3 +316,20 @@ end
     SNLU.solve!(X, F, B)
     @test norm(A * X - B) <= 1.0e-11 * norm(B)
 end
+
+@testset "multi-RHS panel solve tiers" begin
+    for np in (8, SNLU.PANEL_BLAS_MIN_NP, SNLU.PANEL_BLAS_MIN_NP + 256), nrhs in (1, 4)
+        W = Matrix{Float64}(I, np, np)
+        for j in 1:np, i in 1:np
+            i == j && continue
+            W[i, j] = randn() / sqrt(np)
+        end
+        Y0 = randn(np, nrhs)
+        Y = copy(Y0)
+        SNLU._panel_solve_unit_lower!(W, Y, np)
+        @test Y ≈ UnitLowerTriangular(W) \ Y0 rtol = 1.0e-12
+        copyto!(Y, Y0)
+        SNLU._panel_solve_upper!(W, Y, np)
+        @test Y ≈ UpperTriangular(W) \ Y0 rtol = 1.0e-12
+    end
+end


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

Closes https://github.com/SciML/LinearSolve.jl/issues/1172.

## What changed

Adds a reproducible benchmark for forward and backward SupernodalLU multi-RHS panel solves. It refreshes the RHS for every sample, pins BLAS to one thread, and records machine load.

The solve routing now retains the in-tree kernels for one-column RHS at all panel widths and keeps TriangularSolve for wider panels through `np = 1792`; larger panels use BLAS. The no-extension fallback remains conservative at 256.

On the pinned benchmark host (Julia 1.12.6, TriangularSolve 0.2.4, one BLAS thread), at `np = 1280`, `nrhs = 4`, TriangularSolve took 260349 ns versus BLAS at 1008164 ns for the lower sweep and 269298 ns versus 996645 ns for the upper sweep. At `np = 2048`, `nrhs = 8`, BLAS becomes faster (3247412 ns versus 4311808 ns lower; 3039994 ns versus 4408396 ns upper).

## Verification

- `GROUP=Core /home/crackauc/.juliaup/bin/julia +1.12 --project -e 'using Pkg; Pkg.test()'`\n  - Passed: `Testing LinearSolve tests passed`.\n- `GROUP=QA /home/crackauc/.juliaup/bin/julia +1.12 --project -e 'using Pkg; Pkg.test()'`\n  - Passed: Quality Assurance 48 pass, 1 expected broken.\n- `Runic --check --diff` on the four changed files, `typos` on those files, and `git diff --check` all passed.\n- Ran the new benchmark smoke test with `np = 8`, `nrhs = 1`; all three routes completed.\n\n## Not verified\n\nThe docs build is not applicable: this does not change public API or documentation. I did not run the Everything, downstream, or GPU groups.