### PR TITLE
Pin the Trim CI group to a versioned GitHub-hosted runner label

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -107,10 +107,15 @@ num_threads = 2
 [LinearSolvePureUMFPACK]
 versions = ["lts", "1", "pre"]
 
-# Trim ran on GitHub-hosted ubuntu-latest (self-hosted was false for this
-# group); keep it on the default ubuntu-latest runner.
+# juliac links the trimmed executable with gcc/clang, so Trim is the one group
+# that needs a runner with a C compiler. `ubuntu-latest` does not give that:
+# SciML's self-hosted pool advertises the same label, so the job is routed by
+# whichever pool has capacity, and a persistent runner without gcc fails the
+# link ("could not find a compiler, looked for gcc and clang" -- #977). Pin a
+# versioned GitHub-hosted label, which the self-hosted pool does not advertise.
 [Trim]
 versions = ["1"]
+runner = "ubuntu-24.04"
 
 # GPU folds the former bespoke GPU.yml: a dep-adding CUDA group on a
 # self-hosted GPU runner.


### PR DESCRIPTION
Fixes #977.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- Trim is the one group that links a binary, so juliac needs gcc or clang on the runner. The group set no runner, so it inherited the matrix script default of ubuntu-latest.
- SciML self-hosted runners advertise the ubuntu-latest label too, so the job goes to whichever pool has capacity. A persistent runner without a compiler fails the link with "could not find a compiler, looked for gcc and clang".
- Fix is one line: runner = "ubuntu-24.04". A versioned GitHub-hosted label is not advertised by the self-hosted pool, so routing is deterministic.
- The comment above the group claimed ubuntu-latest meant GitHub-hosted, which is the assumption that caused this. It now records the compiler requirement and the routing hazard instead.
- Honest status: the failure reported in #977 no longer reproduces. It was filed on 2026-05-11 against runner deepsea3-39, and the pool has since migrated. Across the last 120 Tests runs every Trim job passed, landing on either real GitHub-hosted runners or ephemeral self-hosted-4vcpu-16gb runners that do have gcc. No deepsea3 runner serves this repo now. This PR is hardening against recurrence, not a fix for a currently red job.
- No test surface applies to a CI matrix declaration. Verified instead by running SciML/.github scripts/compute_affected_sublibraries.jl --root-matrix against the repo before and after: the matrix stays at 43 cells and the only difference is the Trim cell moving from ubuntu-latest to ubuntu-24.04, with the other 42 cells identical. TOML parse checked.
- Option 2 from the issue, installing gcc on the self-hosted runners, stays available and is complementary. This is the package-side half.

AI Disclosure: Used Opus 5