### PR TITLE
QA: cover the SupernodalLU panel-solve names added after the inventory

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -145,8 +145,12 @@ linearsolve_internal_accesses = (
     Symbol("update_tolerances_internal!"), :use_klulike_sparse_structure, :useblis,
     :usecuda, :usemetal, :userecursivefactorization,
     # LinearSolve.SupernodalLU
-    :SupernodalLUFactor, :_costabs, Symbol("_panel_ldiv!"), Symbol("_panel_rdiv!"),
-    :nperturbed, :snlu, Symbol("snlu!"), Symbol("solve!"),
+    :PANEL_BLAS_MIN_NP, :SupernodalLUFactor, :_costabs, Symbol("_panel_ldiv!"),
+    Symbol("_panel_rdiv!"), Symbol("_panel_solve_unit_lower!"),
+    Symbol("_panel_solve_upper!"), Symbol("_panel_unit_lower_trsm!"),
+    Symbol("_panel_upper_trsm!"), Symbol("_unit_lower_solve!"),
+    Symbol("_upper_solve!"), :nperturbed, :snlu, Symbol("snlu!"),
+    Symbol("solve!"),
 )
 
 # Non-public names of stdlib / backend packages accessed with a qualified path,


### PR DESCRIPTION
Fixes the red `QA (julia 1)` job on main.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- #1058 replaced the blanket `ei_broken` marker on `all_qualified_accesses_are_public` with an explicit ignore inventory, which makes the check strict: any qualified access to a name not on the list fails QA.
- That inventory was built before #1174 and the follow-up SupernodalLU panel work merged. Those added seven new `LinearSolve.SupernodalLU` names reached from `LinearSolveRecursiveFactorizationExt`, so QA went red on main as soon as #1058 merged.
- The names are `PANEL_BLAS_MIN_NP`, `_panel_solve_unit_lower!`, `_panel_solve_upper!`, `_panel_unit_lower_trsm!`, `_panel_upper_trsm!`, `_unit_lower_solve!` and `_upper_solve!`. This adds them to the same SupernodalLU group in the inventory, no behaviour change.
- Rather than fixing the reported names one at a time, I re-ran the full enumeration on current main and compared it against the inventory. The only group that moved is SupernodalLU, from 8 names to 15; every other owner group is unchanged, and the total goes from 145 to 152.
- Verified: `test/qa/qa.jl` on this branch is 20 of 20 with zero broken. It fails on unmodified main with the two most recent names, which is the regression this fixes.
- Worth flagging for future PRs: this is the maintenance cost of the strict check. Anything that reaches for a new internal from an extension now needs a line here, and the failure message names exactly which one.

AI Disclosure: Used Opus 5