### PR TITLE
Register-blocked VecElement/fmuladd microkernel for the blocked LU Schur update

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -638,6 +638,12 @@ PrecompileTools.@compile_workload begin
     sol = solve(prob)
     sol = solve(prob, LUFactorization())
     sol = solve(prob, KrylovJL_GMRES())
+    # 80 x 80 is past both `GenericLUFactorization` size switches: the blocked
+    # driver (panel, trsm, row swaps) and the register-blocked Schur kernel,
+    # neither of which the 4 x 4 problem above reaches.
+    Ablocked = rand(80, 80) + 80I
+    bblocked = rand(80)
+    sol = solve(LinearProblem(Ablocked, bblocked), GenericLUFactorization())
 end
 
 ALREADY_WARNED_CUDSS = Ref{Bool}(false)

--- a/src/blocked_lufact.jl
+++ b/src/blocked_lufact.jl
@@ -1,9 +1,9 @@
 # Blocked, partially pivoted LU for real strided float matrices, in plain
-# Julia (`@inbounds` + `@simd ivdep` + `muladd` only — no LoopVectorization,
-# no CPU-specific code). Same blocked/panel structure as LAPACK getrf
-# (getf2 + laswp + trsm + gemm), which keeps the trailing matrix in cache and
-# gives LLVM's auto-vectorizer long contiguous inner loops. Dispatch-selected
-# specialization of `generic_lufact!`, so `GenericLUFactorization` uses it for
+# Julia: no LoopVectorization, no SIMD.jl, no CPU feature detection, the only
+# non-scalar primitives being Base's `VecElement` tuples and LLVM's `fmuladd`.
+# Same blocked/panel structure as LAPACK getrf (getf2 + laswp + trsm + gemm),
+# which keeps the trailing matrix in cache. Dispatch-selected specialization of
+# `generic_lufact!`, so `GenericLUFactorization` uses it for
 # `StridedMatrix{Float64/Float32}` with `RowMaximum` pivoting; every other
 # eltype/pivot/container keeps the scalar `generic_lufact!` path.
 
@@ -276,7 +276,9 @@ function _blocked_lu_schur_unpacked!(
     return nothing
 end
 
-# Pack A[i0:m, j0:j1] column-major into `pack` with column stride ldp.
+# Pack -A[i0:m, j0:j1] column-major into `pack` with column stride ldp. The
+# negation happens here, O(rows*jb) times, so the O(rows*jb*n2) update loops
+# below are plain fused multiply-adds.
 @inline function _blocked_lu_pack_panel!(
         pack::Vector{T}, A::AbstractMatrix{T}, i0::Int, m::Int,
         j0::Int, j1::Int, ldp::Int
@@ -284,7 +286,7 @@ end
     @inbounds for k in j0:j1
         off = (k - j0) * ldp - i0 + 1
         @simd ivdep for i in i0:m
-            pack[off + i] = A[i, k]
+            pack[off + i] = -A[i, k]
         end
     end
     return nothing
@@ -339,28 +341,28 @@ function _blocked_lu_schur_packed!(
                         a3 = pack[o3 + i]
                         a4 = pack[o4 + i]
                         c1v = A[i, c]
-                        c1v = muladd(-a1, b11, c1v)
-                        c1v = muladd(-a2, b21, c1v)
-                        c1v = muladd(-a3, b31, c1v)
-                        c1v = muladd(-a4, b41, c1v)
+                        c1v = muladd(a1, b11, c1v)
+                        c1v = muladd(a2, b21, c1v)
+                        c1v = muladd(a3, b31, c1v)
+                        c1v = muladd(a4, b41, c1v)
                         A[i, c] = c1v
                         c2v = A[i, c + 1]
-                        c2v = muladd(-a1, b12, c2v)
-                        c2v = muladd(-a2, b22, c2v)
-                        c2v = muladd(-a3, b32, c2v)
-                        c2v = muladd(-a4, b42, c2v)
+                        c2v = muladd(a1, b12, c2v)
+                        c2v = muladd(a2, b22, c2v)
+                        c2v = muladd(a3, b32, c2v)
+                        c2v = muladd(a4, b42, c2v)
                         A[i, c + 1] = c2v
                         c3v = A[i, c + 2]
-                        c3v = muladd(-a1, b13, c3v)
-                        c3v = muladd(-a2, b23, c3v)
-                        c3v = muladd(-a3, b33, c3v)
-                        c3v = muladd(-a4, b43, c3v)
+                        c3v = muladd(a1, b13, c3v)
+                        c3v = muladd(a2, b23, c3v)
+                        c3v = muladd(a3, b33, c3v)
+                        c3v = muladd(a4, b43, c3v)
                         A[i, c + 2] = c3v
                         c4v = A[i, c + 3]
-                        c4v = muladd(-a1, b14, c4v)
-                        c4v = muladd(-a2, b24, c4v)
-                        c4v = muladd(-a3, b34, c4v)
-                        c4v = muladd(-a4, b44, c4v)
+                        c4v = muladd(a1, b14, c4v)
+                        c4v = muladd(a2, b24, c4v)
+                        c4v = muladd(a3, b34, c4v)
+                        c4v = muladd(a4, b44, c4v)
                         A[i, c + 3] = c4v
                     end
                     k += 4
@@ -373,10 +375,10 @@ function _blocked_lu_schur_packed!(
                     b4 = A[k, c + 3]
                     @simd ivdep for i in ib:ie
                         a = pack[ok + i]
-                        A[i, c] = muladd(-a, b1, A[i, c])
-                        A[i, c + 1] = muladd(-a, b2, A[i, c + 1])
-                        A[i, c + 2] = muladd(-a, b3, A[i, c + 2])
-                        A[i, c + 3] = muladd(-a, b4, A[i, c + 3])
+                        A[i, c] = muladd(a, b1, A[i, c])
+                        A[i, c + 1] = muladd(a, b2, A[i, c + 1])
+                        A[i, c + 2] = muladd(a, b3, A[i, c + 2])
+                        A[i, c + 3] = muladd(a, b4, A[i, c + 3])
                     end
                     k += 1
                 end
@@ -395,10 +397,10 @@ function _blocked_lu_schur_packed!(
                     b4 = A[k + 3, c]
                     @simd ivdep for i in ib:ie
                         acc = A[i, c]
-                        acc = muladd(-pack[o1 + i], b1, acc)
-                        acc = muladd(-pack[o2 + i], b2, acc)
-                        acc = muladd(-pack[o3 + i], b3, acc)
-                        acc = muladd(-pack[o4 + i], b4, acc)
+                        acc = muladd(pack[o1 + i], b1, acc)
+                        acc = muladd(pack[o2 + i], b2, acc)
+                        acc = muladd(pack[o3 + i], b3, acc)
+                        acc = muladd(pack[o4 + i], b4, acc)
                         A[i, c] = acc
                     end
                     k += 4
@@ -407,7 +409,7 @@ function _blocked_lu_schur_packed!(
                     ok = (k - j0) * ldp - i0 + 1
                     bk = A[k, c]
                     @simd ivdep for i in ib:ie
-                        A[i, c] = muladd(-pack[ok + i], bk, A[i, c])
+                        A[i, c] = muladd(pack[ok + i], bk, A[i, c])
                     end
                     k += 1
                 end
@@ -419,6 +421,210 @@ function _blocked_lu_schur_packed!(
     return nothing
 end
 
+# `@simd ivdep` gives LLVM one accumulator per C column, so every fused
+# multiply-add pays for a load and a store of C. The microkernel below holds a
+# `3W x 4` tile of C in vector registers across the whole k loop instead: 12
+# accumulators, 3 panel vectors and one broadcast, exactly the 16 vector
+# registers x86-64 has. Still dependency-free — `VecElement` tuples are Base's
+# portable vector type and `llvm.fmuladd` is reachable through `ccall(...,
+# llvmcall, ...)`. `fmuladd` rather than `fma` contracts to a hardware fma
+# where the target has one and degrades to mul + add where it does not, never
+# to a libm call.
+
+# 256-bit tiles on x86-64 (AVX and up), 128-bit elsewhere; both are legal LLVM
+# vector types on every target, which a narrower machine splits.
+const _BLOCKED_LU_VEC_BYTES = Sys.ARCH === :x86_64 ? 32 : 16
+
+for (T, sfx) in ((Float64, "f64"), (Float32, "f32")), W in (2, 4, 8, 16)
+    V = NTuple{W, VecElement{T}}
+    @eval @inline _blocked_lu_fma(a::$V, b::$V, c::$V) = ccall(
+        $("llvm.fmuladd.v$(W)$(sfx)"), llvmcall, $V, ($V, $V, $V), a, b, c
+    )
+end
+
+@inline _blocked_lu_vectype(::Type{T}) where {T} =
+    NTuple{_BLOCKED_LU_VEC_BYTES ÷ sizeof(T), VecElement{T}}
+@inline _blocked_lu_vload(::Type{V}, p::Ptr) where {V} = unsafe_load(Ptr{V}(p))
+@inline _blocked_lu_vstore!(p::Ptr, v::V) where {V} = unsafe_store!(Ptr{V}(p), v)
+@inline _blocked_lu_bcast(::Type{NTuple{W, VecElement{T}}}, x::T) where {W, T} =
+    ntuple(_ -> VecElement(x), Val(W))
+
+# Everything the tile below cannot cover — row and column remainders, and
+# regions too small for a whole tile — one column and one row vector at a time.
+@inline function _blocked_lu_micro_edge!(
+        ::Type{V}, pA::Ptr{T}, ld::Int, pP::Ptr{T}, ldp::Int,
+        i0::Int, ib::Int, ie::Int, j0::Int, j1::Int, c0::Int, c1::Int
+    ) where {W, T, V <: NTuple{W, VecElement{T}}}
+    ib > ie && return nothing
+    sz = sizeof(T)
+    lds = ld * sz
+    ldps = ldp * sz
+    for c in c0:c1
+        pcol = pA + (c - 1) * lds
+        pb0 = pcol + (j0 - 1) * sz
+        i = ib
+        while i + W - 1 <= ie
+            q = pcol + (i - 1) * sz
+            acc = _blocked_lu_vload(V, q)
+            pk = pP + (i - i0) * sz
+            pb = pb0
+            for _ in j0:j1
+                acc = _blocked_lu_fma(
+                    _blocked_lu_vload(V, pk), _blocked_lu_bcast(V, unsafe_load(pb)), acc
+                )
+                pk += ldps
+                pb += sz
+            end
+            _blocked_lu_vstore!(q, acc)
+            i += W
+        end
+        while i <= ie
+            q = pcol + (i - 1) * sz
+            s = unsafe_load(q)
+            pk = pP + (i - i0) * sz
+            pb = pb0
+            for _ in j0:j1
+                s = muladd(unsafe_load(pk), unsafe_load(pb), s)
+                pk += ldps
+                pb += sz
+            end
+            unsafe_store!(q, s)
+            i += 1
+        end
+    end
+    return nothing
+end
+
+# C[ib:ie, c0:c1] += P * B over whole `3W x 4` tiles, P the packed (negated)
+# L21 panel and B = A[j0:j1, c0:c1]. Returns the first column no tile covered.
+@inline function _blocked_lu_micro_tile!(
+        ::Type{V}, pA::Ptr{T}, ld::Int, pP::Ptr{T}, ldp::Int,
+        i0::Int, ib::Int, ie::Int, j0::Int, j1::Int, c0::Int, c1::Int
+    ) where {W, T, V <: NTuple{W, VecElement{T}}}
+    sz = sizeof(T)
+    lds = ld * sz
+    ldps = ldp * sz
+    vb = W * sz
+    c = c0
+    while c + 3 <= c1
+        pcol = pA + (c - 1) * lds
+        pb0 = pcol + (j0 - 1) * sz
+        i = ib
+        while i + 3W - 1 <= ie
+            q1 = pcol + (i - 1) * sz
+            q2 = q1 + lds
+            q3 = q2 + lds
+            q4 = q3 + lds
+            t11 = _blocked_lu_vload(V, q1)
+            t21 = _blocked_lu_vload(V, q1 + vb)
+            t31 = _blocked_lu_vload(V, q1 + 2vb)
+            t12 = _blocked_lu_vload(V, q2)
+            t22 = _blocked_lu_vload(V, q2 + vb)
+            t32 = _blocked_lu_vload(V, q2 + 2vb)
+            t13 = _blocked_lu_vload(V, q3)
+            t23 = _blocked_lu_vload(V, q3 + vb)
+            t33 = _blocked_lu_vload(V, q3 + 2vb)
+            t14 = _blocked_lu_vload(V, q4)
+            t24 = _blocked_lu_vload(V, q4 + vb)
+            t34 = _blocked_lu_vload(V, q4 + 2vb)
+            pk = pP + (i - i0) * sz
+            pb = pb0
+            for _ in j0:j1
+                p1 = _blocked_lu_vload(V, pk)
+                p2 = _blocked_lu_vload(V, pk + vb)
+                p3 = _blocked_lu_vload(V, pk + 2vb)
+                b = _blocked_lu_bcast(V, unsafe_load(pb))
+                t11 = _blocked_lu_fma(p1, b, t11)
+                t21 = _blocked_lu_fma(p2, b, t21)
+                t31 = _blocked_lu_fma(p3, b, t31)
+                b = _blocked_lu_bcast(V, unsafe_load(pb + lds))
+                t12 = _blocked_lu_fma(p1, b, t12)
+                t22 = _blocked_lu_fma(p2, b, t22)
+                t32 = _blocked_lu_fma(p3, b, t32)
+                b = _blocked_lu_bcast(V, unsafe_load(pb + 2lds))
+                t13 = _blocked_lu_fma(p1, b, t13)
+                t23 = _blocked_lu_fma(p2, b, t23)
+                t33 = _blocked_lu_fma(p3, b, t33)
+                b = _blocked_lu_bcast(V, unsafe_load(pb + 3lds))
+                t14 = _blocked_lu_fma(p1, b, t14)
+                t24 = _blocked_lu_fma(p2, b, t24)
+                t34 = _blocked_lu_fma(p3, b, t34)
+                pk += ldps
+                pb += sz
+            end
+            _blocked_lu_vstore!(q1, t11)
+            _blocked_lu_vstore!(q1 + vb, t21)
+            _blocked_lu_vstore!(q1 + 2vb, t31)
+            _blocked_lu_vstore!(q2, t12)
+            _blocked_lu_vstore!(q2 + vb, t22)
+            _blocked_lu_vstore!(q2 + 2vb, t32)
+            _blocked_lu_vstore!(q3, t13)
+            _blocked_lu_vstore!(q3 + vb, t23)
+            _blocked_lu_vstore!(q3 + 2vb, t33)
+            _blocked_lu_vstore!(q4, t14)
+            _blocked_lu_vstore!(q4 + vb, t24)
+            _blocked_lu_vstore!(q4 + 2vb, t34)
+            i += 3W
+        end
+        c += 4
+    end
+    return c
+end
+
+# Same update as `_blocked_lu_schur_packed!` through the microkernel. Rows stay
+# cut into `rowblock` chunks so the packed panel the tiles stream over each
+# column group stays cache-resident.
+function _blocked_lu_schur_micro!(
+        A::AbstractMatrix{T}, m::Int, j0::Int, j1::Int,
+        c0::Int, c1::Int, rowblock::Int, pack::Vector{T}
+    ) where {T}
+    i0 = j1 + 1
+    rows = m - i0 + 1
+    jb = j1 - j0 + 1
+    ldp = rows % 256 == 0 ? rows + 4 : rows
+    length(pack) < ldp * jb && resize!(pack, ldp * jb)
+    _blocked_lu_pack_panel!(pack, A, i0, m, j0, j1, ldp)
+    V = _blocked_lu_vectype(T)
+    mr = 3 * (_BLOCKED_LU_VEC_BYTES ÷ sizeof(T))
+    ld = stride(A, 2)
+    GC.@preserve A pack begin
+        pA = pointer(A)
+        pP = pointer(pack)
+        ib = i0
+        while ib <= m
+            ie = min(ib + rowblock - 1, m)
+            rfull = ib + ((ie - ib + 1) ÷ mr) * mr - 1
+            ct = _blocked_lu_micro_tile!(V, pA, ld, pP, ldp, i0, ib, rfull, j0, j1, c0, c1)
+            _blocked_lu_micro_edge!(V, pA, ld, pP, ldp, i0, rfull + 1, ie, j0, j1, c0, c1)
+            _blocked_lu_micro_edge!(V, pA, ld, pP, ldp, i0, ib, rfull, j0, j1, ct, c1)
+            ib = ie + 1
+        end
+    end
+    return nothing
+end
+
+# The microkernel addresses A through a raw pointer, so it needs the
+# `StridedArray` pointer/stride contract and a unit row stride.
+@inline function _blocked_lu_schur_wide!(
+        A::AbstractMatrix{T}, m::Int, j0::Int, j1::Int,
+        c0::Int, c1::Int, rowblock::Int, pack::Vector{T}
+    ) where {T}
+    _blocked_lu_schur_packed!(A, m, j0, j1, c0, c1, rowblock, pack)
+    return nothing
+end
+
+@inline function _blocked_lu_schur_wide!(
+        A::StridedMatrix{T}, m::Int, j0::Int, j1::Int,
+        c0::Int, c1::Int, rowblock::Int, pack::Vector{T}
+    ) where {T <: Union{Float32, Float64}}
+    if stride(A, 1) == 1
+        _blocked_lu_schur_micro!(A, m, j0, j1, c0, c1, rowblock, pack)
+    else
+        _blocked_lu_schur_packed!(A, m, j0, j1, c0, c1, rowblock, pack)
+    end
+    return nothing
+end
+
 @inline function _blocked_lu_schur!(
         A::AbstractMatrix{T}, m::Int, j0::Int, j1::Int,
         c0::Int, c1::Int, rowblock::Int, pack::Vector{T}
@@ -426,7 +632,7 @@ end
     rows = m - j1
     n2 = c1 - c0 + 1
     if rows >= 64 && n2 >= 32
-        _blocked_lu_schur_packed!(A, m, j0, j1, c0, c1, rowblock, pack)
+        _blocked_lu_schur_wide!(A, m, j0, j1, c0, c1, rowblock, pack)
     else
         _blocked_lu_schur_unpacked!(A, m, j0, j1, c0, c1, rowblock)
     end

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -266,11 +266,13 @@ Supports arbitrary number types. Has low overhead and is good for small matrices
 
 For `StridedMatrix{Float64}`/`StridedMatrix{Float32}` with `RowMaximum` pivoting the
 factorization runs a blocked pure-Julia kernel (panel factorization + packed Schur
-update, the LAPACK `getrf` structure written with `@simd ivdep` loops) instead of the
-scalar textbook loop. That keeps the algorithm dependency-free while scaling far
-beyond the scalar kernel: on machines with a weak or unavailable BLAS it is
-competitive with (or faster than) OpenBLAS/MKL `getrf` up to a few hundred unknowns.
-Other element types and pivots keep the scalar generic path.
+update, the LAPACK `getrf` structure) instead of the scalar textbook loop. The Schur
+update is a register-blocked microkernel written on Base's `VecElement` tuples and
+LLVM's `fmuladd` intrinsic, so the algorithm stays dependency-free — no
+LoopVectorization, no SIMD.jl, no CPU feature detection — while scaling far beyond the
+scalar kernel: on machines with a weak or unavailable BLAS it is competitive with (or
+faster than) OpenBLAS/MKL `getrf` up to a few hundred unknowns. Other element types and
+pivots keep the scalar generic path.
 
 The back-solve is a pure-Julia column-oriented triangular solve (apply `ipiv`, unit-lower
 forward, upper backward) rather than `ldiv!(::LU, ·)` / OpenBLAS `getrs!`. That avoids the

--- a/test/Core/blocked_lufact.jl
+++ b/test/Core/blocked_lufact.jl
@@ -69,6 +69,51 @@ end
         end
     end
 
+    @testset "microkernel tiles and remainders ($T)" for T in (Float64, Float32)
+        # The register-blocked kernel takes the update at >= 64 trailing rows
+        # and >= 32 trailing columns, in tiles of 3W rows by 4 columns
+        # (W = 4 for Float64, 8 for Float32). This range straddles every row
+        # and column remainder of both tile shapes in both directions.
+        for n in 72:97
+            A = randn(T, n, n)
+            F = LinearSolve.generic_lufact!(copy(A), RowMaximum(), _ipiv(n); check = false)
+            @test F.info == 0
+            @test scaled_residual(A, F) < 20
+        end
+        # rowblock cuts landing mid-tile, and rows == 256 exactly, which is the
+        # padded-pack-stride branch
+        for n in (129, 257, 264, 272), nb in (8, 16, 17), rb in (13, 37, 384)
+            A = randn(T, n, n)
+            W = copy(A)
+            ipiv = _ipiv(n)
+            info = LinearSolve._blocked_lufact!(W, ipiv, n, n, n, nb, rb)
+            F = LU{T, Matrix{T}, Vector{BlasInt}}(W, ipiv, BlasInt(info))
+            @test scaled_residual(A, F) < 20
+        end
+        # unit row stride with a leading dimension wider than the matrix: the
+        # kernel addresses columns through `stride(A, 2)`, not `size(A, 1)`
+        for n in (80, 130)
+            P = randn(T, n + 9, n + 4)
+            V = @view P[1:n, 1:n]
+            A = copy(Matrix(V))
+            F = LinearSolve.generic_lufact!(V, RowMaximum(), _ipiv(n); check = false)
+            @test scaled_residual(A, F) < 20
+        end
+    end
+
+    @testset "eltypes outside the microkernel keep the scalar kernel" begin
+        # 80 x 80 puts the update past the >= 64 rows / >= 32 columns switch,
+        # so this is the packed scalar kernel, not the unpacked one
+        n = 80
+        A = big.(randn(n, n))
+        W = copy(A)
+        ipiv = _ipiv(n)
+        info = LinearSolve._blocked_lufact!(W, ipiv, n, n, n, 8, 384)
+        F = LU{BigFloat, Matrix{BigFloat}, Vector{BlasInt}}(W, ipiv, BlasInt(info))
+        @test info == 0
+        @test scaled_residual(A, F) < 20
+    end
+
     @testset "rectangular m x n" begin
         for (m, n) in (
                 (100, 3), (3, 100), (128, 40), (40, 128), (257, 130),


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

Two independent commits:

1. **Register-blocked microkernel for the blocked LU Schur update.** The `@simd ivdep` Schur kernel gives LLVM one accumulator per C column, so every fused multiply-add pays for a load and a store of C. For pointer-addressable `Float32`/`Float64` matrices with unit row stride the update now runs a microkernel that keeps a `3W x 4` tile of C in vector registers across the whole k loop. Zero new dependencies: `NTuple{W, VecElement{T}}` (Base) plus `llvm.fmuladd` through `ccall(..., llvmcall, ...)`. Worth **1.10–1.27x** on the factorization at N ≥ 256 and closes **30–45%** of the remaining gap to RecursiveFactorization at N = 2000.
2. **A blocked-size `GenericLUFactorization` solve in `@compile_workload`.** First blocked solve in a fresh session: **180 ms → 1.3 ms**, with no measurable precompile-time cost. Kept separate so it can be dropped independently.

## Design

`fmuladd` rather than `fma` is the portability-critical choice: `llvm.fma` lowers to a **libm call** on a target without an FMA unit, while `llvm.fmuladd` contracts to a hardware fma where one exists and degrades to mul + add where it does not. Tiles are 256-bit on x86-64 and 128-bit elsewhere; both are legal LLVM vector types on every target (a narrower machine splits them), so there is no CPU feature query anywhere.

Tile shape was measured, not assumed (kernel-only harness, min over 25 interleaved rounds, GFLOPS, `N/nb/rowblock`):

| config (acc regs) | F64 512/16/384 | F64 1000/32/384 | F64 2000/32/384 | F32 1000/32/384 | F32 2000/32/384 |
|---|---:|---:|---:|---:|---:|
| `@simd ivdep` (shipped) | 18.56 | 24.72 | 23.99 | 42.60 | 42.83 |
| 2W x 4 (8) | 20.74 | 24.15 | 24.02 | 41.39 | 40.73 |
| 2W x 6 (12) | 22.15 | 27.61 | **27.84** | 47.36 | **53.97** |
| **3W x 4 (12)** | **22.48** | **27.68** | 26.74 | **47.85** | 50.73 |

`3W x 4` and `2W x 6` are within noise of each other (3W x 4 wins 8 of 14 measured cells); both use 12 accumulators. Shapes needing 16+ accumulators (`4W x 4`, `3W x 6`) spill — visible directly in `code_native` as `ymm`/`rsp` traffic — and were slower. The shipped kernel compiles to 16 `vfmadd*` and **zero** vector stack spills for both `Float64` and `Float32` on znver2.

Everything else is untouched: panel/trsm/swap structure, the `nb`/`rowblock`/cutoff parameters, and the `rows >= 64 && cols >= 32` switch that already selected the packed kernel. Non-unit row strides, other eltypes and every smaller shape keep the `@simd ivdep` kernels — which now consume an already-negated packed panel, so both paths drop one negation from their inner loop (exact in floating point: a sign flip).

## Benchmarks

AMD EPYC 7502 (znver2), 1 BLAS thread, `taskset`-pinned, machine shared with other jobs. Both arms are the *same process*: the before-file and the after-file are loaded into two bare modules and run interleaved, min-of-many, alongside RecursiveFactorization 0.2.27 and OpenBLAS `getrf!`. **"A/A control"** is a third module holding a second copy of the *before* file — same source, different module — so it measures the module-layout noise floor for that cell.

**julia 1.12.6 — Float64 — factorization only**

| N | before | after | after/before | A/A control | RF | OpenBLAS | GF before | GF after | GF RF |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 4 | 114 ns | 113 ns | **1.01x** | 0.97x | 172 ns | 325 ns | 0.4 | 0.4 | 0.2 |
| 8 | 473 ns | 474 ns | **1.00x** | 1.00x | 583 ns | 1.2 us | 0.7 | 0.7 | 0.6 |
| 16 | 1.9 us | 1.8 us | **1.03x** | 0.99x | 1.6 us | 4.2 us | 1.4 | 1.5 | 1.8 |
| 32 | 6.9 us | 6.2 us | **1.13x** | 0.98x | 5.1 us | 16.3 us | 3.1 | 3.5 | 4.3 |
| 64 | 29.7 us | 27.4 us | **1.09x** | 0.99x | 17.2 us | 53.8 us | 5.9 | 6.4 | 10.2 |
| 128 | 106.0 us | 95.1 us | **1.11x** | 0.97x | 60.8 us | 147.7 us | 13.2 | 14.7 | 23.0 |
| 256 | 932.6 us | 793.5 us | **1.18x** | 0.97x | 560.2 us | 1.0 ms | 12.0 | 14.1 | 20.0 |
| 512 | 4.6 ms | 3.6 ms | **1.27x** | 1.00x | 4.6 ms | 4.6 ms | 19.4 | 24.7 | 19.3 |
| 1000 | 25.7 ms | 22.5 ms | **1.14x** | 0.99x | 19.3 ms | 24.2 ms | 25.9 | 29.6 | 34.5 |
| 1500 | 90.9 ms | 78.6 ms | **1.16x** | 0.95x | 69.0 ms | 76.7 ms | 24.8 | 28.6 | 32.6 |
| 2000 | 268.5 ms | 221.6 ms | **1.21x** | 0.97x | 183.2 ms | 194.9 ms | 19.9 | 24.1 | 29.1 |

**julia 1.10.11 — Float64 — factorization only**

| N | before | after | after/before | A/A control | RF | OpenBLAS | GF before | GF after | GF RF |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 4 | 206 ns | 209 ns | **0.99x** | 1.01x | 279 ns | 748 ns | 0.2 | 0.2 | 0.2 |
| 8 | 409 ns | 436 ns | **0.94x** | 0.80x | 475 ns | 1.4 us | 0.8 | 0.8 | 0.7 |
| 16 | 1.6 us | 1.5 us | **1.06x** | 0.89x | 1.3 us | 3.7 us | 1.7 | 1.8 | 2.1 |
| 32 | 5.9 us | 6.4 us | **0.92x** | 0.86x | 5.3 us | 14.5 us | 3.7 | 3.4 | 4.1 |
| 64 | 27.4 us | 26.9 us | **1.02x** | 0.99x | 16.6 us | 55.0 us | 6.4 | 6.5 | 10.5 |
| 128 | 150.7 us | 132.5 us | **1.14x** | 1.08x | 83.8 us | 227.2 us | 9.3 | 10.6 | 16.7 |
| 256 | 924.6 us | 786.2 us | **1.18x** | 0.99x | 559.4 us | 1.0 ms | 12.1 | 14.2 | 20.0 |
| 512 | 4.6 ms | 3.7 ms | **1.24x** | 0.97x | 4.5 ms | 4.8 ms | 19.6 | 24.2 | 19.8 |
| 1000 | 35.7 ms | 31.7 ms | **1.13x** | 1.34x | 24.8 ms | 25.5 ms | 18.7 | 21.0 | 26.8 |
| 1500 | 92.2 ms | 94.3 ms | **0.98x** | 0.89x | 69.0 ms | 75.3 ms | 24.4 | 23.9 | 32.6 |
| 2000 | 221.8 ms | 191.9 ms | **1.16x** | 1.00x | 153.3 ms | 170.2 ms | 24.0 | 27.8 | 34.8 |

The 1.10 N=1500 cell is the one large-N cell that goes the wrong way (0.98x); its A/A control is 0.89x, i.e. that cell was noisy in this run. The same size on 1.12 is 1.16x and the 1.10 factorize+solve run gives 1.13x at N=1500.

**Fraction of the RF gap closed at N = 2000** (factorization only): 1.12/F64 45% (19.9 → 24.1 of 29.1 GF), 1.10/F64 35% (24.0 → 27.8 of 34.8), 1.12/F32 37% (48.5 → 56.3 of 69.7), 1.10/F32 30% (46.4 → 53.3 of 69.5). As a share of RF throughput the zero-dependency path goes from ~69% to ~77–83%. At N = 512 it beats both RF and OpenBLAS (24.7 vs 19.3 vs 19.6 GF) — RF and the in-place kernels lose to cache-set aliasing at power-of-two leading dimensions, which the packing here avoids.

<details><summary>Float32 and factorize+solve tables, both Julia versions</summary>

**julia 1.12.6 — Float32 — factorization only**

| N | before | after | after/before | A/A control | RF | GF before | GF after | GF RF |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 4 | 215 ns | 212 ns | 1.02x | 0.99x | 353 ns | 0.2 | 0.2 | 0.1 |
| 8 | 379 ns | 433 ns | 0.88x | 0.97x | 622 ns | 0.9 | 0.8 | 0.5 |
| 16 | 1.8 us | 1.8 us | 0.98x | 0.96x | 2.1 us | 1.5 | 1.5 | 1.3 |
| 32 | 7.2 us | 7.4 us | 0.97x | 0.95x | 7.0 us | 3.1 | 3.0 | 3.1 |
| 64 | 25.5 us | 27.0 us | 0.94x | 0.82x | 13.5 us | 6.9 | 6.5 | 13.0 |
| 128 | 112.8 us | 112.5 us | 1.00x | 0.92x | 53.3 us | 12.4 | 12.4 | 26.2 |
| 256 | 380.0 us | 371.5 us | 1.02x | 0.93x | 211.8 us | 29.4 | 30.1 | 52.8 |
| 512 | 2.5 ms | 2.2 ms | 1.12x | 0.96x | 1.5 ms | 35.8 | 40.1 | 60.9 |
| 1000 | 14.4 ms | 13.3 ms | 1.08x | 0.97x | 10.0 ms | 46.4 | 50.2 | 66.6 |
| 1500 | 47.8 ms | 46.1 ms | 1.04x | 0.98x | 35.5 ms | 47.1 | 48.8 | 63.4 |
| 2000 | 110.1 ms | 94.7 ms | 1.16x | 1.00x | 76.5 ms | 48.5 | 56.3 | 69.7 |

**julia 1.10.11 — Float32 — factorization only**

| N | before | after | after/before | A/A control | RF | GF before | GF after | GF RF |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 16 | 1.2 us | 1.2 us | 0.96x | 1.02x | 1.3 us | 2.3 | 2.2 | 2.1 |
| 32 | 4.5 us | 4.7 us | 0.96x | 1.02x | 4.3 us | 4.9 | 4.7 | 5.1 |
| 64 | 26.1 us | 26.0 us | 1.00x | 1.01x | 13.8 us | 6.7 | 6.7 | 12.6 |
| 128 | 74.2 us | 77.4 us | 0.96x | 0.98x | 37.1 us | 18.8 | 18.1 | 37.7 |
| 256 | 376.3 us | 366.7 us | 1.03x | 0.98x | 208.5 us | 29.7 | 30.5 | 53.6 |
| 512 | 2.5 ms | 2.2 ms | 1.14x | 1.00x | 1.5 ms | 36.1 | 41.1 | 61.6 |
| 1000 | 14.4 ms | 13.3 ms | 1.09x | 1.00x | 10.0 ms | 46.3 | 50.3 | 66.5 |
| 1500 | 48.0 ms | 46.4 ms | 1.03x | 1.00x | 35.6 ms | 46.9 | 48.5 | 63.2 |
| 2000 | 114.9 ms | 100.1 ms | 1.15x | 1.00x | 76.8 ms | 46.4 | 53.3 | 69.5 |

**julia 1.12.6 — Float64 — factorize + 1 rhs** (same `ldiv!` back-solve on every arm, so the delta is the factorization)

| N | before | after | after/before | A/A control | RF | GF before | GF after | GF RF |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 4 | 454 ns | 412 ns | 1.10x | 0.99x | 492 ns | 0.1 | 0.1 | 0.1 |
| 16 | 2.6 us | 2.6 us | 1.02x | 0.99x | 2.3 us | 1.0 | 1.1 | 1.2 |
| 32 | 7.5 us | 7.2 us | 1.05x | 0.95x | 6.4 us | 2.9 | 3.1 | 3.4 |
| 64 | 32.9 us | 31.7 us | 1.04x | 0.97x | 21.2 us | 5.3 | 5.5 | 8.2 |
| 128 | 158.5 us | 149.3 us | 1.06x | 0.97x | 96.8 us | 8.8 | 9.4 | 14.4 |
| 256 | 646.8 us | 572.2 us | 1.13x | 0.96x | 407.9 us | 17.3 | 19.5 | 27.4 |
| 512 | 4.6 ms | 3.7 ms | 1.25x | 0.99x | 4.8 ms | 19.2 | 24.1 | 18.7 |
| 1000 | 27.1 ms | 23.1 ms | 1.17x | 1.02x | 19.7 ms | 24.6 | 28.8 | 33.8 |
| 2000 | 303.6 ms | 253.6 ms | 1.20x | 1.01x | 208.0 ms | 17.6 | 21.0 | 25.6 |

**julia 1.10.11 — Float64 — factorize + 1 rhs**

| N | before | after | after/before | A/A control | RF | GF before | GF after | GF RF |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 16 | 3.2 us | 2.8 us | 1.16x | 1.09x | 2.3 us | 0.8 | 1.0 | 1.2 |
| 32 | 8.9 us | 8.2 us | 1.08x | 1.02x | 6.8 us | 2.5 | 2.7 | 3.2 |
| 64 | 31.0 us | 30.4 us | 1.02x | 0.92x | 19.8 us | 5.6 | 5.8 | 8.8 |
| 128 | 149.5 us | 147.5 us | 1.01x | 0.92x | 93.8 us | 9.3 | 9.5 | 14.9 |
| 256 | 659.2 us | 576.7 us | 1.14x | 0.99x | 415.9 us | 17.0 | 19.4 | 26.9 |
| 512 | 4.7 ms | 3.7 ms | 1.25x | 1.01x | 4.6 ms | 19.0 | 23.9 | 19.2 |
| 1000 | 26.3 ms | 23.2 ms | 1.14x | 0.98x | 19.7 ms | 25.3 | 28.8 | 33.8 |
| 2000 | 227.5 ms | 206.7 ms | 1.10x | 0.97x | 162.7 ms | 23.4 | 25.8 | 32.8 |

</details>

## Small N: nothing changed, and the measurements say so

The microkernel is reached only from the existing `rows >= 64 && cols >= 32` branch. With the default panel of 8 that is N >= 72, so **below that the executed code is the same functions it was before** and no regression is possible by construction.

Package-level check anyway, on three installed builds (`generic_lufact!` through the real package, batch-of-K, min over 6 interleaved rounds, ns/call), the whole thing run twice end to end:

| N | main | +microkernel | +microkernel +workload | mk/main | mk+wl/main |
|---:|---:|---:|---:|---:|---:|
| 4 | 71 / 71 | 69 / 69 | 71 / 72 | 1.03x | 0.98-1.00x |
| 8 | 241 / 243 | 223 / 220 | 240 / 237 | 1.08-1.10x | 1.01-1.02x |
| 16 | 1163 / 1160 | 1105 / 1115 | 1080 / 1080 | 1.04-1.05x | 1.07-1.08x |
| 32 | 4575 / 4596 | 4161 / 4186 | 4148 / 4166 | 1.10x | 1.10x |
| 64 | 19755 / 19604 | 18129 / 18082 | 17897 / 17909 | 1.08-1.09x | 1.10x |
| 128 | 101094 / 101410 | 90514 / 91262 | 90915 / 90837 | 1.11x | 1.11-1.12x |
| 256 | 630697 / 638037 | 558912 / 553268 | 537658 / 539502 | 1.13-1.15x | 1.17-1.18x |
| 512 | 4486590 / 4437450 | 3584943 / 3597534 | 3591934 / 3593234 | 1.25x | 1.24-1.25x |

No cell regresses. Do **not** read the 1.04-1.10x at N = 16-64 as a win from this PR, though: at those sizes all three builds execute identical code (`code_native` for `_blocked_lu_unblocked!` is the same 394 lines with the same instruction mix in all three), so that is loop alignment moving under the edit. The same sensitivity shows up in the in-process A/B as the A/A control, which lands at 0.82-1.01x on 1.12 and 1.01-1.15x on 1.10 - the same size as the A/B spread at those N, with opposite sign on the two versions. Small-N `GenericLUFactorization` timings move by ~10% on any edit to this package; that is pre-existing and neither introduced nor removed here.

## Precompile / TTFX (commit 2, separable)

First blocked `GenericLUFactorization` solve in a fresh process (N = 200, min of 3):

| main | +microkernel | +microkernel +workload |
|---:|---:|---:|
| 180 ms | 178 ms | **1.3 ms** |

Precompile cost is below this machine's noise. Two interleaved runs of `Pkg.precompile("LinearSolve")` (min of 6 rounds each, source content changed every round to force a rebuild) give main 15.25 s / 16.14 s against the workload build 16.60 s / 15.20 s - the ordering flips between the two runs, and single-round times spread 15-36 s under load. So: no precompile-time cost measurable here, upper bound ~1 s.

The workload build costs nothing at small N either (table above). It is still a separate commit so it can be dropped independently.

## Correctness

`test/Core/blocked_lufact.jl` grows from 411 to 593 assertions. New coverage, both eltypes: every size in 72:97 (straddles every row remainder of the `3W x 4` tile — W = 4 for `Float64`, 8 for `Float32` — and every column remainder, in both directions); forced `nb`/`rowblock` grids including `rowblock` cuts that land mid-tile and `rows == 256` exactly (the padded pack-stride branch); unit row stride with a leading dimension wider than the matrix (the kernel addresses columns through `stride(A, 2)`); and an 80 x 80 `BigFloat` factorization past the same size switch, which exercises the scalar packed fallback the microkernel does not cover.

Full file, 593/593 passing in all four configurations:

```
julia 1.10.11                    521 + 72 assertions
julia 1.12.6                     521 + 72 assertions
julia 1.10.11 --check-bounds=yes 521 + 72 assertions
julia 1.12.6  --check-bounds=yes 521 + 72 assertions
```

The pre-existing adversarial cases (LAPACK pivot-sequence parity on decisive-margin and permutation matrices, Wilkinson 2^(n-1) growth, singular `info` parity, `check=false`, rectangular, strided views, cache reuse) all still pass — the pivot sequence and `info` are unchanged because only the Schur arithmetic moved.

`GROUP=Core` on julia 1.12.6: `Testing LinearSolve tests passed`, with `Blocked generic_lufact! kernel | 593 593 30.2s` inside it. `julia --project=docs docs/make.jl` exits 0. Runic and `typos` are clean on the changed files. `GROUP=Core` on 1.10 was still running when this was written; I will post its tail as a comment.

`GROUP=QA` on 1.12.6 is **red, and red on main too** - `all_qualified_accesses_are_public` errors on seven `LinearSolve.SupernodalLU` names imported by `LinearSolveRecursiveFactorizationExt` (`PANEL_BLAS_MIN_NP`, `_panel_solve_unit_lower!`, `_panel_solve_upper!`, `_panel_unit_lower_trsm!`, `_panel_upper_trsm!`, `_unit_lower_solve!`, `_upper_solve!`), all from #1171, none touched here. Everything else in QA passes (48 passed, 1 errored). That failure is being bisected and fixed separately; it is not this PR's.

## Not verified

- **Non-x86 targets.** No aarch64/ppc machine here. The code is arch-independent by construction (`VecElement` tuples + `fmuladd`, 128-bit tiles off x86-64, no feature query), but the codegen and the tile-shape tuning were only checked on znver2.
- **AVX-512.** znver2 has none. 256-bit tiles are deliberate — a 512-bit tile would need its own tuning, and `3W x 4` at 512 bits would be a 24-row tile.
- **Pre-AVX x86-64.** On a machine without AVX the 256-bit tile legalizes to pairs of SSE registers and the 12 accumulators would spill. Correctness is unaffected (`fmuladd` degrades to mul + add, never to libm) but the microkernel could be slower than the `@simd` path there. Any x86-64 CPU since Sandy Bridge has AVX, and package code is compiled for the host, so I did not add a guard.
- **macOS/Windows**, GPU groups, and downstream packages.

## Judgment calls a reviewer should push back on

- **`3W x 4` over `2W x 6`.** They are statistically tied (see the tuning table); I picked the one that won more cells. `2W x 6` leaves one spare vector register, which might matter on a target where the pointer bookkeeping needs one.
- **The panel width was left alone.** With the microkernel, `nb = 32` beats the current `nb = 16` at N = 2000 by ~7% (25.8 vs 24.6 GF; `nb` sweep at rowblock 384: N=128 favors 8, N=256/512 favor 16, N=1000 is flat 16–32, N=2000 favors 32). Retuning `_blocked_lu_default_panel` is a separate change that also moves the `@simd` path, so it is not in this PR — it would have confounded every A/B above.
- **The negated pack changes the scalar packed kernel too.** Sign flips are exact in floating point, so results are unchanged, but it does touch a kernel the microkernel does not use.
- **Raw pointers.** The microkernel uses `unsafe_load`/`unsafe_store!` on `Ptr{NTuple{W,VecElement{T}}}` (alignment 1, so unaligned columns are fine) guarded by dispatch on `StridedMatrix{Float32/Float64}` plus a `stride(A, 1) == 1` check, with `GC.@preserve` around the pointer lifetime. Anything else — non-unit row stride, other eltypes — dispatches to the scalar packed kernel, and that fallback is covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
