### PR TITLE
QA: cover the SupernodalLU panel-solve hooks in the non-public access inventory

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -145,8 +145,11 @@ linearsolve_internal_accesses = (
     Symbol("update_tolerances_internal!"), :use_klulike_sparse_structure, :useblis,
     :usecuda, :usemetal, :userecursivefactorization,
     # LinearSolve.SupernodalLU
-    :SupernodalLUFactor, :_costabs, Symbol("_panel_ldiv!"), Symbol("_panel_rdiv!"),
-    :nperturbed, :snlu, Symbol("snlu!"), Symbol("solve!"),
+    :PANEL_BLAS_MIN_NP, :SupernodalLUFactor, :_costabs, Symbol("_panel_ldiv!"),
+    Symbol("_panel_rdiv!"), Symbol("_panel_solve_unit_lower!"),
+    Symbol("_panel_solve_upper!"), Symbol("_panel_unit_lower_trsm!"),
+    Symbol("_panel_upper_trsm!"), Symbol("_unit_lower_solve!"),
+    Symbol("_upper_solve!"), :nperturbed, :snlu, Symbol("snlu!"), Symbol("solve!"),
 )
 
 # Non-public names of stdlib / backend packages accessed with a qualified path,


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

`GROUP=QA` errors on `main` (5fb25b3b): `all_qualified_accesses_are_public` flags seven `LinearSolve.SupernodalLU` names that `LinearSolveRecursiveFactorizationExt` reaches when it overrides the panel-solve hooks. This adds those seven to `linearsolve_internal_accesses` in `test/qa/qa.jl`, alongside `_panel_ldiv!`/`_panel_rdiv!` — the factorization-phase hooks of the exact same kind, which are already listed.

This is a merge-order gap, not a design change. #1176 retired the blanket `ei_broken` marker and turned the strict check on with an inventory enumerating the accesses present at the time it was written; #1174 and #1178 had added the panel-solve hooks in the meantime, so the inventory shipped incomplete.

Ignore-list (not promote-to-public) is the right side of that fork here: `src/SupernodalLU/SupernodalLU.jl` states "Internal to LinearSolve: the public surface is `SupernodalLUFactorization`", the module exports nothing, and `src/SupernodalLU/solve.jl` describes these specifically as "Overridable hooks for the solve-phase pivot-block trsms, the same arrangement the factorization phase uses for `_panel_rdiv!`/`_panel_ldiv!`". The general question of promoting LinearSolve's internal-but-cross-module names stays with SciML/LinearSolve.jl#1058.

## Bisect

First failing commit is c4ec4ea4 (#1176) — confirmed by running the suite at that commit and its parent, not inferred from the diff.

| commit | result |
| --- | --- |
| 00f8b3a3 (#1164) — parent | `Quality Assurance \| 48 passed, 1 broken, 49 total` — exit 0 |
| c4ec4ea4 (#1176) | `Quality Assurance \| 48 passed, 1 errored, 49 total` — exit 1, same seven names |

The 1 broken at the parent is the `ei_broken = (:all_qualified_accesses_are_public,)` marker that #1176 removed.

## Verification

All runs are `GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'` on Julia 1.12.6, in a fresh clone.

**Failing before, on clean `origin/main` @ 5fb25b3b:**

```
all_qualified_accesses_are_public: Error During Test at SciMLTesting/src/SciMLTesting.jl:925
  Test threw exception
  Expression: check(pkg; _explicit_imports_kwargs(pkg, name, ei_kwargs)...) === nothing
  NonPublicQualifiedAccessException
  Module `LinearSolveRecursiveFactorizationExt` has explicit imports of names from modules
  in which they are not public (i.e. exported or declared public in Julia 1.11+):
  - `PANEL_BLAS_MIN_NP` is not public in `LinearSolve.SupernodalLU` ... ext/LinearSolveRecursiveFactorizationExt.jl:311:22
  - `_panel_solve_unit_lower!` is not public in `LinearSolve.SupernodalLU` ... :306:15
  - `_panel_solve_upper!` is not public in `LinearSolve.SupernodalLU` ... :319:15
  - `_panel_unit_lower_trsm!` is not public in `LinearSolve.SupernodalLU` ... :312:14
  - `_panel_upper_trsm!` is not public in `LinearSolve.SupernodalLU` ... :325:14
  - `_unit_lower_solve!` is not public in `LinearSolve.SupernodalLU` ... :310:14
  - `_upper_solve!` is not public in `LinearSolve.SupernodalLU` ... :323:14

Test Summary:                                  | Pass  Error  Total     Time
Quality Assurance                              |   48      1     49  4m16.9s
  Extensions loaded                            |   26            26     0.3s
  Quality Assurance                            |   20      1     21  2m58.1s
    ExplicitImports                            |    5      1      6    53.9s
      no_implicit_imports                      |    1             1    28.1s
      no_stale_explicit_imports                |    1             1     6.4s
      all_explicit_imports_via_owners          |    1             1     3.1s
      all_qualified_accesses_via_owners        |    1             1     7.8s
      all_qualified_accesses_are_public        |           1      1     5.0s
      all_explicit_imports_are_public          |    1             1     3.4s
ERROR: Package LinearSolve errored during testing
```

**Passing after, same clone with this commit applied:**

```
Test Summary: | Pass  Broken  Total     Time
JET Tests     |   34       8     42  1m19.6s
Test Summary: | Pass  Total     Time
Allocation QA |   60     60  1m33.7s
Test Summary:              | Pass  Total   Time
SupernodalLU Allocation QA |    8      8  21.7s
Test Summary:     | Pass  Total     Time
Quality Assurance |   49     49  4m17.6s
     Testing LinearSolve tests passed
```

The errored check flips to passing and the total goes 48+1 → 49 passed. (The 8 broken under `JET Tests` are pre-existing on `main` and untouched here.)

**Also run:** Runic on the changed file (`Runic.main(["--check", "--diff", "test/qa/qa.jl"])` → exit 0) and `typos test/qa/qa.jl` → clean.

## Not verified

- Only `GROUP=QA` was run. Other groups are unaffected — this touches nothing outside `test/qa/qa.jl` — but I did not run them.
- Nothing GPU, downstream, or credential-gated.

## For a reviewer to push back on

The one judgment call is ignore-list vs. promote-to-public. I read the module header and the `solve.jl` hook comment as settling it (these are deliberately internal override points), but making the panel-solve hooks a documented extension seam is a defensible alternative and would be a public-API decision rather than a QA fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
