### PR TITLE
Cover the packed Schur kernel for Float32, and correct two overclaiming comments

### DIFF
--- a/src/blocked_lufact.jl
+++ b/src/blocked_lufact.jl
@@ -585,6 +585,8 @@ function _blocked_lu_schur_micro!(
     length(pack) < ldp * jb && resize!(pack, ldp * jb)
     _blocked_lu_pack_panel!(pack, A, i0, m, j0, j1, ldp)
     V = _blocked_lu_vectype(T)
+    # Must equal the tile's row step; a mismatch silently double-applies or
+    # skips rows rather than erroring.
     mr = 3 * (_BLOCKED_LU_VEC_BYTES ÷ sizeof(T))
     ld = stride(A, 2)
     GC.@preserve A pack begin

--- a/test/Core/blocked_lufact.jl
+++ b/test/Core/blocked_lufact.jl
@@ -80,8 +80,10 @@ end
             @test F.info == 0
             @test scaled_residual(A, F) < 20
         end
-        # rowblock cuts landing mid-tile, and rows == 256 exactly, which is the
-        # padded-pack-stride branch
+        # rowblock cuts landing mid-tile. `n = 264`/`nb = 8` and `n = 272`/
+        # `nb = 16` also enter the `rows == 256` padded pack-stride branch,
+        # though no residual can distinguish the padding: the pad cells are
+        # never read.
         for n in (129, 257, 264, 272), nb in (8, 16, 17), rb in (13, 37, 384)
             A = randn(T, n, n)
             W = copy(A)
@@ -127,9 +129,11 @@ end
         end
     end
 
-    @testset "strided views (contiguous and non-unit row stride)" begin
+    # The non-unit row stride case is the only coverage of the scalar packed
+    # kernel for a float eltype, so it runs for both of them.
+    @testset "strided views, contiguous and non-unit row stride ($T)" for T in (Float64, Float32)
         for n in (17, 80)
-            P = randn(2n + 3, n + 2)
+            P = randn(T, 2n + 3, n + 2)
             V1 = @view P[2:(n + 1), 2:(n + 1)]
             A1 = copy(Matrix(V1))
             F1 = LinearSolve.generic_lufact!(V1, RowMaximum(), _ipiv(n); check = false)


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

Follow-up to #1182. An adversarial audit of that diff (exact-integer-operand harness over 108,468 kernel invocations, mutation-tested to confirm it discriminates, run on 1.10/1.11/1.12/1.13-rc1 x86_64 and on **i686** to exercise the non-x86-64 128-bit width branch) found **no correctness defect** — the tile/edge passes partition the update region exactly once, the pack bound `ldp*jb` is tight, and the sign flip was complete and correctly scoped. It did surface three things worth closing, none of which is a bug:

**1. The scalar packed Schur kernel had no Float32 test.** For a float eltype that kernel is reachable only through a non-unit row stride, and the one testset that builds such a matrix was Float64-only — so #1182's sign flip (`pack` now stores `-L21`, `muladd(-a, b, c)` → `muladd(a, b, c)`) landed on a path with no Float32 coverage. That testset now runs for both eltypes. This is coverage, not a fix: the Float64 case already discriminates the sign flip, and the kernel is eltype-generic, so the new cases are cheap insurance rather than a caught defect.

**2. A test comment claimed coverage it cannot have.** `n ∈ (264, 272)` does enter the `rows == 256` padded pack-stride branch, but the padding cells are never read or written, so **no assertion in the suite can distinguish `ldp = rows + 4` from `ldp = rows`** — a mutant forcing the padding unconditionally passes everything. Those sizes are worth keeping for the row/column remainders they hit; the comment now says what they actually cover.

**3. `mr` in the driver is a second spelling of the tile's row step,** and a mismatch is a silent wrong answer rather than an error (a `mr = 2W` mutant produced 80,196 wrong elements with no error, though the shipped tests do catch it). Noted in a comment next to it.

## Verification

```
julia 1.12.6   blocked generic_lufact! kernel | 525 525 23.1s   GenericLUFactorization through the blocked kernel | 72 72 5.9s
julia 1.10.11  blocked generic_lufact! kernel | 525 525 38.0s   GenericLUFactorization through the blocked kernel | 72 72 16.6s
```

597 assertions, up from 593; the +4 are the Float32 strided-view cases. Runic and `typos` clean.

## Not verified

Real aarch64/ppc64le hardware — the audit ran the 128-bit branch on 32-bit i686 and simulated the width on x86_64, both clean, but no ARM/PPC execution. Nothing here changes runtime behaviour, so this PR carries no performance claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
