### PR TITLE
Assert the LU back-solve branch directly instead of by bitwise inequality

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -454,6 +454,22 @@ end
 _naive_ldiv_cutoff(::AbstractMatrix) = 256
 _naive_ldiv_cutoff(::_AdjTransStridedFactors) = 512
 
+# Branch predicate of `_smart_lu_ldiv!` below. Split out so the selection is
+# observable directly: the naive kernel and `getrs!` agree to within an ulp, so
+# comparing their outputs bitwise is not a reliable way to tell which one ran.
+_use_naive_lu_ldiv(x, F, b) = false
+
+function _use_naive_lu_ldiv(
+        x::StridedVector{T},
+        F::LU{T, <:Union{StridedMatrix{T}, _AdjTransStridedFactors}},
+        b::StridedVector{T}
+    ) where {T <: BLASELTYPES}
+    return !(
+        x isa GPUArraysCore.AnyGPUArray || b isa GPUArraysCore.AnyGPUArray ||
+            F.factors isa GPUArraysCore.AnyGPUArray
+    ) && length(x) <= _naive_ldiv_cutoff(F.factors)
+end
+
 # Size-aware back-solve for `ldiv!`-baseline algorithms (`LUFactorization` and
 # the defaults routed to it): single vectors at or below the crossover take the
 # naive kernel; everything else (larger vectors, multi-RHS, non-BLAS/GPU) keeps
@@ -465,11 +481,7 @@ function _smart_lu_ldiv!(
         F::LU{T, <:Union{StridedMatrix{T}, _AdjTransStridedFactors}},
         b::StridedVector{T}
     ) where {T <: BLASELTYPES}
-    if x isa GPUArraysCore.AnyGPUArray || b isa GPUArraysCore.AnyGPUArray ||
-            F.factors isa GPUArraysCore.AnyGPUArray ||
-            length(x) > _naive_ldiv_cutoff(F.factors)
-        return _ldiv!(x, F, b)
-    end
+    _use_naive_lu_ldiv(x, F, b) || return _ldiv!(x, F, b)
     x !== b && copyto!(x, b)
     return _naive_lu_ldiv!(F.factors, F.ipiv, x)
 end

--- a/test/Core/genericlu_naive_ldiv.jl
+++ b/test/Core/genericlu_naive_ldiv.jl
@@ -103,25 +103,30 @@ end
 end
 
 @testset "LUFactorization back-solve is size-aware (naive below cutoff, getrs! above)" begin
-    for n in (64, 256)
+    # The branch is read off `_use_naive_lu_ldiv`, not inferred from
+    # `sol.u != ldiv!(...)`: the two agree to within an ulp and on a given draw
+    # can agree exactly (0.13% of draws at N = 64 on an EPYC 7502 / OpenBLAS
+    # 0.3.29 build), which is how the single-draw form of this check failed.
+    cutoff = LinearSolve._naive_ldiv_cutoff(zeros(0, 0))
+    for n in (cutoff ÷ 4, cutoff, cutoff + 1, 2 * cutoff)
+        naive_expected = n <= cutoff
         A = rand(n, n) + n * I
         b = rand(n)
         cache = init(LinearProblem(copy(A), copy(b)), LUFactorization())
-        sol = solve!(cache)
+        u = copy(solve!(cache).u)
         F = cache.cacheval
-        xldiv = ldiv!(similar(b), F, copy(b))
-        @test sol.u != xldiv
-        @test sol.u ≈ A \ b rtol = 1.0e-10 * n
-    end
-    for n in (257, 600)
-        A = rand(n, n) + n * I
-        b = rand(n)
-        cache = init(LinearProblem(copy(A), copy(b)), LUFactorization())
-        sol = solve!(cache)
-        F = cache.cacheval
-        xldiv = ldiv!(similar(b), F, copy(b))
-        @test sol.u == xldiv
-        @test sol.u ≈ A \ b rtol = 1.0e-10 * n
+        @test LinearSolve._use_naive_lu_ldiv(u, F, b) == naive_expected
+        @test u ≈ A \ b rtol = 1.0e-10 * n
+        if naive_expected
+            # A fallback to `ldiv!` would reproduce its bits on *every* draw.
+            @test any(1:32) do _
+                bk = rand(n)
+                cache.b = bk
+                solve!(cache).u != ldiv!(similar(bk), F, copy(bk))
+            end
+        else
+            @test u == ldiv!(similar(b), F, copy(b))
+        end
     end
     # Matrix right-hand sides keep the BLAS-3 path at every size
     n = 100
@@ -130,8 +135,8 @@ end
     cacheB = init(LinearProblem(copy(A), copy(B)), LUFactorization())
     solB = solve!(cacheB)
     FB = cacheB.cacheval
-    Xldiv = ldiv!(similar(B), FB, copy(B))
-    @test solB.u == Xldiv
+    @test !LinearSolve._use_naive_lu_ldiv(solB.u, FB, B)
+    @test solB.u == ldiv!(similar(B), FB, copy(B))
     @test solB.u ≈ A \ B rtol = 1.0e-8
 end
 


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

`test/Core/genericlu_naive_ldiv.jl:113` has been failing intermittently on `main` across every Julia version. The assertion is `@test sol.u != xldiv`: it infers *which* back-solve ran by requiring the pure-Julia naive kernel to produce **bitwise different** bits from LAPACK `getrs!`. Those two implementations differ by at most one ulp, and on some right-hand sides they agree exactly — so the check is a coin flip on the RNG draw, not a statement about routing.

This splits the branch condition of `_smart_lu_ldiv!` out into `_use_naive_lu_ldiv` and asserts that predicate directly, and replaces the single-draw bitwise inequality with an end-to-end check over 32 right-hand sides that a fallback to `ldiv!` cannot satisfy. The deterministic assertions (`==` against `getrs!` above the cutoff, and for matrix right-hand sides) are kept as-is — asserting *equality* with `getrs!` on the `getrs!` path is exact by construction and never flaked.

Origin: the testset was added in #1164.

## This is a fragile assertion, not a routing regression

Two independent lines of evidence.

**1. N = 64 and N = 256 take the identical branch.** Both are `<= _naive_ldiv_cutoff(::AbstractMatrix) == 256`, same method, same predicate. A routing bug would have failed both. Every observed failure is a single failure at N = 64.

**2. The measured coincidence rate is nonzero and size-dependent.** Rate at which the `LUFactorization` solve is bitwise equal to `ldiv!(similar(b), F, copy(b))` over independent random draws (EPYC 7502, OpenBLAS 0.3.29, Julia 1.12.6):

| N | draws | bitwise equal | rate |
|---|---|---|---|
| 2 | 200 | 146 | 73% |
| 3 | 200 | 98 | 49% |
| 8 | 200 | 21 | 10.5% |
| 16 | 20000 | 112 | 0.56% |
| 32 | 20000 | 60 | 0.30% |
| 48 | 20000 | 65 | 0.325% |
| **64** | **20000** | **26** | **0.13%** |
| 96 | 4000 | 0 | 0% |
| 256 | 4000 | 0 | 0% |

The two results are never far apart — on the exact inputs from the first failing CI job, `maximum(abs, sol.u .- xldiv)` is `1.73e-18` at N = 64 (1 ulp) and `5.64e-18` at N = 256, and `sol.u` is bitwise equal to the naive kernel's own output. Routing is correct; the discriminator is not.

Failing jobs, all the same line and testset, `498 passed, 1 failed`:

- `tests / Core (julia 1)` on main@5fb25b3b — https://github.com/SciML/LinearSolve.jl/actions/runs/31293459740/job/93194888553
- `Downgrade / Downgrade Tests - Core` (Julia 1.10.11) — https://github.com/SciML/LinearSolve.jl/actions/runs/31298849837/job/93208249304
- `tests / Core (julia lts)` on main@8dd6e7a5 — https://github.com/SciML/LinearSolve.jl/actions/runs/31299476053/job/93211000897
- `Core (julia pre)` on #1182

## Failing before

7 of the first 4000 `Random.seed!` values reproduce it at N = 64. On an unmodified checkout of main, `Random.seed!(480)`:

```
main: LUFactorization back-solve is size-aware: Test Failed at .../before.jl:14
  Expression: sol.u != xldiv
   Evaluated: [0.004046602699651987, 0.0017868602796672927, -0.001064694946134331, ...]
           != [0.004046602699651987, 0.0017868602796672927, -0.001064694946134331, ...]

Test Summary:                                  | Pass  Fail  Total  Time
main: LUFactorization back-solve is size-aware |    1     1      2  5.1s
ERROR: LoadError: Some tests did not pass: 1 passed, 1 failed, 0 errored, 0 broken.
```

Same draw with this branch applied:

```
Test Summary:                                   | Pass  Total  Time
fixed: LUFactorization back-solve is size-aware |   12     12  2.1s
```

## The new check still fails when routing breaks

Four separate regressions injected into `src/factorization.jl`, each run against the shipped test file:

**(a) Off-by-one at the cutoff** — `length(x) <= cutoff` → `length(x) < cutoff`:

```
  Test Failed at test/Core/genericlu_naive_ldiv.jl:120
  Expression: LinearSolve._use_naive_lu_ldiv(u, F, b) == naive_expected
   Evaluated: false == true
  Test Failed at test/Core/genericlu_naive_ldiv.jl:122
  Expression: any(1:32) do _
  ... | 13 passed, 2 failed
```

**(b) Helper ignores the predicate** — body of the specialized `_smart_lu_ldiv!` replaced by `return _ldiv!(x, F, b)`. The predicate assertion still passes; only the end-to-end check catches it:

```
  Test Failed at test/Core/genericlu_naive_ldiv.jl:122
  Expression: any(1:32) do _   (twice, N = 64 and N = 256)
  ... | 13 passed, 2 failed
```

**(c) Solve call site bypasses the helper** — `y = _smart_lu_ldiv!(cache.u, F, cache.b)` → `y = _ldiv!(cache.u, F, cache.b)` at `src/factorization.jl:601`. Predicate untouched, caught end-to-end:

```
  Test Failed at test/Core/genericlu_naive_ldiv.jl:122
  Expression: any(1:32) do _   (twice)
  ... | 13 passed, 2 failed
```

**(d) Multi-RHS rerouted onto the naive kernel** — `_smart_lu_ldiv!(x, F, b) = F isa LU ? _generic_lu_ldiv!(x, F, b) : _ldiv!(x, F, b)`. Predicate untouched, caught by the matrix-RHS assertion:

```
  Test Failed at test/Core/genericlu_naive_ldiv.jl:139
  Expression: solB.u == ldiv!(similar(B), FB, copy(B))
  ... | 14 passed, 1 failed
```

## Verification

`GROUP=Core`, Julia 1.12.6, on this branch rebased onto main@8dd6e7a5:

```
GenericLU naive back-solve |  504    504  39.0s
...
     Testing LinearSolve tests passed
```
0 `Test Failed` / `Error During Test` lines in the 852-line log. (Also run pre-rebase on main@5fb25b3b: same, 0 failures.)

`GROUP=QA`, Julia 1.12.6:

```
Test Summary:     | Pass  Total     Time
Quality Assurance |   49     49  4m44.3s
     Testing LinearSolve tests passed
```

The test file standalone on Julia 1.10.11 (the version of the red `Downgrade` and `lts` jobs):

```
LUFactorization back-solve is size-aware (naive below cutoff, getrs! above) |   15     15  8.8s
```

`Runic --check` clean on both changed files; `typos` clean.

## Not verified

- No GPU hardware here, so the `AnyGPUArray` arm of `_use_naive_lu_ldiv` is exercised only by the fact that it is the same expression as before, moved verbatim.
- Downstream packages, and the allowed-to-fail `julia pre` lane, were not run locally.
- Only `Core` and `QA` were run; other groups are unchanged by this diff (the only src change is behavior-preserving).

## For a reviewer to push back on

- **The 32-draw end-to-end check is statistical.** It requires that *at least one* of 32 draws differ from `getrs!`; a fallback to `ldiv!` matches on all 32. With the measured 0.13% per-draw coincidence at N = 64 the false-failure probability is ~1e-92. It would fail permanently only against a BLAS whose `getrs!` is bit-identical to the naive kernel for every input (reference netlib `dtrsm` with the same contraction would be), which is why the predicate assertion, not this one, is the primary check.
- **Test sizes are now derived from `_naive_ldiv_cutoff` rather than hardcoded.** That means the testset follows a retuned cutoff instead of failing on it — deliberate, since the policy under test is "at or below the cutoff → naive", not the constant 256. Say the word if you would rather pin the number.
- **`_naive_ldiv_cutoff(::_AdjTransStridedFactors) = 512` looks unreachable** and I left it alone (out of scope). `_smart_lu_ldiv!` has one call site, and `init_cacheval(::LUFactorization, ::Union{Adjoint,Transpose}, ...)` returns an `lu(A)` whose `.factors` is a plain `Matrix`; also `Adjoint{Float64,Matrix{Float64}} <: StridedMatrix{Float64}` is `false`, so wrapped factors would not reach the specialized method anyway. Worth a follow-up before anyone writes a test asserting `getrs!` above the wrapped cutoff.
- **No release needed.** `_use_naive_lu_ldiv` is internal (underscore, not exported, not `public`), so there is no public-API or docs surface and nothing to backport; this rides the next patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
