### PR TITLE
Move default-path precompile coverage into the extensions that invalidate it

### DIFF
--- a/ext/LinearSolveRecursiveFactorizationExt.jl
+++ b/ext/LinearSolveRecursiveFactorizationExt.jl
@@ -6,7 +6,7 @@ using ArrayInterface: ArrayInterface
 using LinearAlgebra: LinearAlgebra, UnitLowerTriangular, UpperTriangular, ldiv!, mul!
 using RecursiveFactorization: RecursiveFactorization
 using TriangularSolve: TriangularSolve
-using SciMLBase: SciMLBase, ReturnCode
+using SciMLBase: SciMLBase, LinearProblem, ReturnCode, solve
 using SciMLLogging: @SciMLMessage
 
 LinearSolve.userecursivefactorization(A::Union{Nothing, AbstractMatrix}) = true
@@ -327,6 +327,17 @@ function SNLU._panel_solve_upper!(
         TriangularSolve.ldiv!(UpperTriangular(view(Ws, 1:np, 1:np)), Yb, Val(false))
     end
     return nothing
+end
+
+# The `@generated` `solve!(::LinearCache, ::DefaultLinearSolver)` body reaches both
+# `userecursivefactorization` and the `RFLUFactorization` `solve!` above, so loading
+# this extension invalidates every default-path specialization LinearSolve cached.
+LinearSolve.PrecompileTools.@compile_workload begin
+    A = rand(4, 4)
+    b = rand(4)
+    prob = LinearProblem(A, b)
+    sol = solve(prob)
+    sol = solve(prob, RFLUFactorization())
 end
 
 end

--- a/ext/LinearSolveSparseArraysExt.jl
+++ b/ext/LinearSolveSparseArraysExt.jl
@@ -1271,6 +1271,13 @@ function LinearSolve.init_cacheval(
 end
 
 LinearSolve.PrecompileTools.@compile_workload begin
+    # Krylov, a hard LinearSolve dependency, pulls in SparseArrays, so this
+    # extension always loads and always invalidates the dense default path.
+    for T in (Float64, Float32)
+        denseprob = LinearProblem(rand(T, 4, 4), rand(T, 4))
+        sol = solve(denseprob)
+    end
+
     A = sprand(4, 4, 0.3) + I
     b = rand(4)
     prob = LinearProblem(A, b)

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -631,21 +631,6 @@ useblis(x) = false
 usecuda(x) = false
 usemetal(x) = false
 
-PrecompileTools.@compile_workload begin
-    A = rand(4, 4)
-    b = rand(4)
-    prob = LinearProblem(A, b)
-    sol = solve(prob)
-    sol = solve(prob, LUFactorization())
-    sol = solve(prob, KrylovJL_GMRES())
-    # 80 x 80 is past both `GenericLUFactorization` size switches: the blocked
-    # driver (panel, trsm, row swaps) and the register-blocked Schur kernel,
-    # neither of which the 4 x 4 problem above reaches.
-    Ablocked = rand(80, 80) + 80I
-    bblocked = rand(80)
-    sol = solve(LinearProblem(Ablocked, bblocked), GenericLUFactorization())
-end
-
 ALREADY_WARNED_CUDSS = Ref{Bool}(false)
 error_no_cudss_lu(A) = nothing
 cudss_loaded(A) = false
@@ -714,5 +699,21 @@ export LinearVerbosity
 export AbstractEigenvalueAlgorithm,
     DenseEigen, ArpackJL, ArnoldiMethod, ArnoldiMethodJL,
     KrylovKitEigen, JacobiDavidsonJL
+
+PrecompileTools.@compile_workload begin
+    # Element type is a coverage axis, size is not: inference is whole-body, so the
+    # blocked `GenericLUFactorization` kernels are cached from these 4 x 4 calls.
+    for T in (Float64, Float32)
+        A = rand(T, 4, 4)
+        b = rand(T, 4)
+        prob = LinearProblem(A, b)
+        sol = solve(prob, LUFactorization())
+        sol = solve(prob, GenericLUFactorization())
+        sol = solve(prob, KrylovJL_GMRES())
+    end
+    # Per-element-type default coverage lives in the extension workloads instead:
+    # they invalidate whatever the default path caches here.
+    sol = solve(LinearProblem(rand(4, 4), rand(4)))
+end
 
 end


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

`using LinearSolve` always loads `LinearSolveSparseArraysExt` — Krylov is a hard
dependency and pulls in SparseArrays — and loading `LinearSolveRecursiveFactorizationExt`
adds the `RFLUFactorization` `solve!` that the `@generated`
`solve!(::LinearCache, ::DefaultLinearSolver)` body calls. Both invalidate the
default-path specializations the root `@compile_workload` caches, so the root
workload's `solve(prob)` was thrown away before any user reached it: the first
default solve cost **6.63 s** with RecursiveFactorization loaded and 0.22 s without.

Each extension now re-caches the default path it invalidates, and the root workload
covers Float32 as well as Float64 for the explicitly-selected factorizations. Problem
size is dropped as a workload axis — inference is whole-body, so the blocked
`GenericLUFactorization` driver and its register-blocked Schur kernel are cached from
a 4 x 4 call (measured below).

## Coverage: before → after

TTFX = min over 5 fresh processes of the in-process `@elapsed` of the *first* call.
`~1e-4 s` means cached; `>0.1 s` is a real gap. "LS alone" = `using LinearSolve`;
"+RF" = `using LinearSolve, RecursiveFactorization, TriangularSolve`.

| entry point | LS alone before → after | +RF before → after |
| --- | --- | --- |
| **Gaps closed** | | |
| `solve(prob)` 4x4 Float64 | 0.22 s → **0.08 ms** | 6.63 s → **0.03 s** |
| `solve(prob)` 64x64 Float64 | 0.16 s → **0.15 ms** | 5.89 s → **0.03 s** |
| `solve(prob)` 600x600 Float64 | 0.14 s → **0.04 s** | 6.16 s → **0.28 s** |
| `solve(prob)` 4x4 Float32 | 7.31 s → **0.16 ms** | 17.71 s → 11.04 s |
| `solve(prob)` 64x64 Float32 | 6.65 s → **0.23 ms** | 18.98 s → 9.71 s |
| `init(prob)` + `solve!(cache)` | 0.17 s → **0.04 s** | 5.62 s → **0.04 s** |
| non-square default (least squares) | 1.28 s → 1.03 s | 6.33 s → **0.03 s** |
| integer-eltype default (#1156) | 0.21 s → 0.11 s | 6.00 s → **0.42 s** |
| `LUFactorization` Float32 | 0.84 s → **0.21 ms** | 0.95 s → **0.17 ms** |
| `GenericLUFactorization` Float32, n=8 | 1.23 s → **0.08 ms** | 1.51 s → **0.08 ms** |
| `GenericLUFactorization` Float32, n=80 | 1.23 s → **0.14 ms** | 1.58 s → **0.12 ms** |
| `KrylovJL_GMRES` Float32 | 2.74 s → **0.14 ms** | 2.89 s → **0.15 ms** |
| `RFLUFactorization` Float64 | — | 4.09 s → **0.15 ms** |
| `RFLUFactorization` `pivot=Val(false)` | — | 3.97 s → **0.59 s** |
| `RFLUFactorization` matrix RHS | — | 5.76 s → 2.98 s |
| `ButterflyFactorization` | — | 7.88 s → 5.47 s |
| `QRFactorization` Float64 | 0.63 s → 0.60 s | 0.94 s → **0.19 s** |
| `SVDFactorization` Float64 | 1.13 s → 0.86 s | 1.05 s → **0.18 s** |
| **Already covered (unchanged)** | | |
| `solve(prob, LUFactorization())` Float64 | 0.15 ms → 0.16 ms | 0.14 ms → 0.18 ms |
| `solve(prob, KrylovJL_GMRES())` Float64 | 0.16 ms → 0.14 ms | 0.13 ms → 0.15 ms |
| `GenericLUFactorization` Float64, n=4 | 0.08 ms → 0.06 ms | 0.06 ms → 0.08 ms |
| `GenericLUFactorization` Float64, n=80 | 0.14 ms → 0.16 ms | 0.11 ms → 0.14 ms |
| **Left uncovered on purpose (see below)** | | |
| `solve(prob)` Adjoint operator | 7.56 s → 7.50 s | 8.07 s → 7.21 s |
| `solve(prob)` Transpose operator | 8.58 s → 7.49 s | 7.93 s → 7.85 s |
| `solve(prob)` matrix (multi-RHS) | 4.86 s → 4.83 s | 9.76 s → 6.69 s |
| `solve(prob)` ComplexF64 | 6.62 s → 6.96 s | 11.85 s → 11.15 s |

The n=4 vs n=80 `GenericLUFactorization` rows are the ablation for #1182's 80 x 80 entry:
with that entry deleted, *both* the 4 x 4 and the 80 x 80 first call cost 0.179 s and
0.174 s; with a 4 x 4 `solve(prob, GenericLUFactorization())` in its place, both return
to ~1e-4 s. The coverage came from naming the algorithm, not from the size, so the
workload now uses 4 x 4.

## Precompile cost

Paired measurement: BASE (unmodified `main`) and NEW alternate rep-by-rep against two
`Pkg.develop`ed checkouts, so machine load hits both arms equally. A random comment
line is appended to `src/LinearSolve.jl` each rep because Julia ≥ 1.11 content-hashes
sources and `touch` no longer invalidates.

```
/usr/bin/time -f "TIME %U %S %e" env JULIA_NUM_PRECOMPILE_TASKS=1 \
  julia +1.12 --startup-file=no --project=<env> -e 'using Pkg; Pkg.precompile()'
```

Min over 4 paired reps:

| metric | before | after | delta |
| --- | --- | --- | --- |
| CPU time, user+sys incl. children | 42.9 s | 69.1 s | +26.2 s |
| wall | 30.4 s | 41.3 s | +11.0 s |
| `LinearSolve` (Pkg's own line) | 16648 ms | 18937 ms | +2.3 s |
| `→ LinearSolveSparseArraysExt` | 7578 ms | 10180 ms | +2.6 s |
| `→ LinearSolveRecursiveFactorizationExt` | 2751 ms | 8004 ms | +5.3 s |

CPU time is the headline metric, not wall: the host ran at load average ~270 on 128
cores throughout, which moved unpaired wall-clock numbers by 2x between runs. CPU time
varied by <10% across reps within an arm.

Precompile time is paid once per install; **load time is paid once per process**, so
that is measured too — min over 6 fresh processes per arm, same paired alternation:

| metric | before | after | delta |
| --- | --- | --- | --- |
| `@elapsed using LinearSolve` | 1.304 s | 1.331 s | +27 ms (+2.1%) |
| ... plus RecursiveFactorization, TriangularSolve | 1.865 s | 1.910 s | +45 ms (+2.4%) |
| loaded pkgimage total (3 modules) | 9.87 MB | 17.02 MB | +7.15 MB |

The pkgimage grows 72% but costs 27-45 ms of load, against 4-18 s of first-call
compilation removed.

## Dropped as not paying for themselves

Each of these was implemented, measured, and then reverted:

- **Float32 in the RecursiveFactorization extension workload** — `+43.4 s` CPU
  precompile (measured as 68.5 s vs 25.1 s deltas for the two configs). It would take
  `solve(prob)` 4x4 Float32 from 17.71 s to ~0 s, but only for users who use Float32
  *and* load RecursiveFactorization, and it is the single most expensive line
  available. Everyone would pay it. The Float32 default remains covered for plain
  `using LinearSolve` (7.31 s → 0.16 ms), which costs `+4.6 s` CPU and does pay.
- **Adjoint / Transpose / matrix-RHS default entries** — `+26.9 s` CPU precompile
  together, for ~14 s of TTFX confined to adjoint-sensitivity and batched-solve users.
  These are the four rows still red in the table above; they are real gaps, just not
  ones worth doubling precompile time for. Same reasoning for ComplexF64.

## Verification

```
$ GROUP=Core julia +1.12 --project -e 'using Pkg; Pkg.test()'
... (37 test sets, all green; e.g. "Adjoint Sensitivity | 107 107", "ForwardDiff Overloads | 147 147", "Algorithm Interface | 136 136", "Butterfly Factorization | 44 44")
     Testing LinearSolve tests passed

$ GROUP=QA julia +1.12 --project -e 'using Pkg; Pkg.test()'
Quality Assurance |   49     49  3m60.0s   (Aqua + ExplicitImports + api/docs)
JET Tests         |   34   8 broken   42  1m06.8s   (pre-existing broken markers)
Allocation QA     |   60     60  1m23.5s
SupernodalLU Allocation QA |    8      8  16.5s
     Testing LinearSolve tests passed

$ julia +1.12 -e 'using Runic; exit(Runic.main(["--check", "--diff", <changed files>]))'
(exit 0, no diff)

$ git diff | typos -
(exit 0)
```

## Unrelated observation, no change made here

With RecursiveFactorization loaded under OpenBLAS, `defaultalg` returns
`RFLUFactorization` for **every** size in 11..500, Float32 and Float64 alike:

```
Float64 n=4   -> GenericLUFactorization      Float64 n=128 -> RFLUFactorization
Float64 n=12  -> RFLUFactorization           Float64 n=500 -> RFLUFactorization
Float64 n=32  -> RFLUFactorization           Float64 n=600 -> LUFactorization
```

so the GenericLU band that #1177 raised to 32 (128 under OpenBLAS) is shadowed by the
RFLU branch above it — the default reaches `GenericLUFactorization` only at
`size(b, 1) <= 10`. Surfacing it because it changes who benefits from #1173/#1177/#1182;
this PR touches precompile coverage only and leaves the ordering alone.

## Not verified

- Julia 1.12.6, x86_64 Linux, OpenBLAS only. Not run on the 1.10 LTS, on macOS /
  AppleAccelerate, under MKL, or with any GPU extension loaded — all three of those
  branches sit in the same `defaultalg` chain and could have different coverage.
- Only the `Core` and `QA` groups were run. `Trim`, `DefaultsLoading`, `AD`, the GPU
  groups, and downstream packages were not.
- Docs were not built: no docstring, `docs/`, or public-API surface is touched.
- Precompile numbers come from a shared, heavily loaded host; the paired protocol
  controls for that but does not eliminate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
