### PR TITLE
Raise the no-RF GenericLU default band to 256 under OpenBLAS

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -401,11 +401,11 @@ function defaultalg(A, b, assump::OperatorAssumptions{Bool})
                         #elseif A === nothing || A isa Matrix
                         #    alg = FastLUFactorization()
                         # Blocked generic_lufact! beats vendor getrf ≥ 2x through N = 32
-                        # everywhere, and through 128 vs OpenBLAS (badly tuned small-N
+                        # everywhere, and through 256 vs OpenBLAS (badly tuned small-N
                         # threading — same fact the RFLU 500 band above encodes).
                     elseif (
                             matrix_size <= 32 ||
-                                (isopenblas() && matrix_size <= 128)
+                                (isopenblas() && matrix_size <= 256)
                         ) &&
                             (
                             A === nothing ? eltype(b) <: Union{Float32, Float64} :

--- a/test/Core/default_algs.jl
+++ b/test/Core/default_algs.jl
@@ -27,15 +27,30 @@ else
 end
 
 # the raised GenericLU band is Float32/Float64-only; complex stays on BLAS
-if LinearSolve.appleaccelerate_isavailable()
-    @test LinearSolve.defaultalg(nothing, zeros(ComplexF64, 32)).alg ===
+let complex_alg = if LinearSolve.appleaccelerate_isavailable()
         LinearSolve.DefaultAlgorithmChoice.AppleAccelerateLUFactorization
-elseif LinearSolve.usemkl
-    @test LinearSolve.defaultalg(nothing, zeros(ComplexF64, 32)).alg ===
+    elseif LinearSolve.usemkl
         LinearSolve.DefaultAlgorithmChoice.MKLLUFactorization
-else
-    @test LinearSolve.defaultalg(nothing, zeros(ComplexF64, 32)).alg ===
+    else
         LinearSolve.DefaultAlgorithmChoice.LUFactorization
+    end
+    for n in (32, 256)
+        @test LinearSolve.defaultalg(nothing, zeros(ComplexF64, n)).alg === complex_alg
+    end
+end
+
+# RF loaded: the GenericLU band stays shadowed by the RFLU band on every vendor
+let expected = LinearSolve.appleaccelerate_isavailable() ?
+        LinearSolve.DefaultAlgorithmChoice.AppleAccelerateLUFactorization :
+        LinearSolve.DefaultAlgorithmChoice.RFLUFactorization
+    for n in (16, 32, 100)
+        @test LinearSolve.defaultalg(nothing, zeros(n)).alg === expected
+    end
+    if LinearSolve.isopenblas()
+        for n in (128, 256, 500)
+            @test LinearSolve.defaultalg(nothing, zeros(n)).alg === expected
+        end
+    end
 end
 
 if LinearSolve.usemkl

--- a/test/DefaultsLoading/defaults_loading.jl
+++ b/test/DefaultsLoading/defaults_loading.jl
@@ -41,7 +41,7 @@ else
     @test STRUMPACKFactorization() isa STRUMPACKFactorization
 end
 
-# no-RF dense band: blocked GenericLU owns N ≤ 32 everywhere, ≤ 128 under OpenBLAS
+# no-RF dense band: blocked GenericLU owns N ≤ 32 everywhere, ≤ 256 under OpenBLAS
 @test Base.get_extension(LinearSolve, :LinearSolveRecursiveFactorizationExt) === nothing
 if LinearSolve.appleaccelerate_isavailable()
     @test LinearSolve.defaultalg(nothing, zeros(32)).alg ===
@@ -55,7 +55,9 @@ else
     if LinearSolve.isopenblas()
         @test LinearSolve.defaultalg(nothing, zeros(128)).alg ===
             LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
-        @test LinearSolve.defaultalg(nothing, zeros(129)).alg === above_band
+        @test LinearSolve.defaultalg(nothing, zeros(256)).alg ===
+            LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
+        @test LinearSolve.defaultalg(nothing, zeros(257)).alg === above_band
     else
         @test LinearSolve.defaultalg(nothing, zeros(33)).alg === above_band
     end


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

`#1182` added a register-blocked `VecElement`/`fmuladd` microkernel to the blocked `generic_lufact!` Schur update. The `N <= 128`-under-OpenBLAS edge of the `GenericLUFactorization` default band was measured in `#1177`, before that microkernel landed, so it is stale by construction. This raises that one edge to `256`.

One number moves. `matrix_size <= 32` (the non-OpenBLAS limit), the RFLU band, the tiny-matrix `size(b, 1) <= 10` override, the `get_tuned_algorithm` precedence and the Apple Accelerate position are all unchanged.

### Band map, dense square / `can_setindex(b)` / well- or ill-conditioned

Cascade order (unchanged): `size(b,1) <= 10` → autotune → Accelerate → **RFLU band** → **GenericLU band** → MKL → LU.

| vendor | RecursiveFactorization | before | after |
|---|---|---|---|
| OpenBLAS | not loaded | 1–10 Generic, 11–128 Generic, 129+ OpenBLAS | 1–10 Generic, 11–**256** Generic, **257**+ OpenBLAS |
| OpenBLAS | loaded | 1–10 Generic, 11–500 RFLU, 501+ OpenBLAS | unchanged |
| MKL | not loaded | 1–32 Generic, 33+ MKL | unchanged |
| MKL | loaded | 1–10 Generic, 11–200 RFLU, 201+ MKL | unchanged |
| Accelerate | either | 1–10 Generic, 11+ Accelerate | unchanged |

### The GenericLU band is unreachable when RecursiveFactorization is loaded

This is worth stating explicitly because it is easy to misread the cascade. The RFLU band sits *above* the GenericLU band, so with RF loaded the default reaches `GenericLUFactorization` only at `size(b,1) <= 10` — the `#1177` band, and the raise in this PR, are both no-ops in that cascade. Since RF is a weakdep, the band governs the plain `using LinearSolve` path.

Exhaustively verified over **every** `n` in `1:600` on the built package (`LinearSolve.defaultalg(nothing, zeros(T, n)).alg`, OpenBLAS, Julia 1.12.6), not sampled points:

```
RF loaded      Float64/Float32  [1:GenericLU→10] [11:RFLU→500] [501:LU→600]
               ComplexF64       [1:GenericLU→10] [11:LU→600]
               GenericLU reachable above n=10:  false

RF not loaded  Float64/Float32  [1:GenericLU→256] [257:LU→600]     ← this PR moves 128→256
               ComplexF64       [1:GenericLU→10] [11:LU→600]
               GenericLU reachable above n=10:  true
```

**The shadowing is correct, not a defect.** RFLU is genuinely the fastest of the three throughout the shadowed range, so routing 11–500 to RFLU is already the optimal choice. Ratio of the default's chosen algorithm to the best of the three (1.00 = default already optimal):

| N | RF-loaded default picks | 1.12 f64 bt1 | 1.10 f64 bt1 | 1.12 f32 bt1 | 1.10 f32 bt1 | 1.12 f64 mt | 1.12 f32 mt |
|---:|:--|---:|---:|---:|---:|---:|---:|
| 16–384 | RFLU | 1.00 | 1.00 | 1.00–1.04 | 1.00 | 1.00 | 1.00 |
| 512 | LUFactorization | **1.21** | **1.22** | **1.42** | **1.46** | **2.53** | **1.51** |
| 768 | LUFactorization | **1.22** | **1.24** | **1.41** | **1.42** | **2.29** | **1.94** |
| 1000 | LUFactorization | **1.20** | **1.21** | **1.30** | **1.32** | **2.03** | **2.18** |

Un-shadowing GenericLU — i.e. moving the band above the RFLU branch so 11–256 went to `GenericLUFactorization` — would make the RF-loaded default **1.27x–2.13x slower** at every size in that range (worst cases: 2.13x at N=96 Float32, 1.75x at N=96 Float64). So no reordering is proposed here, and the autotune-override → Accelerate → RFLU → vendor order is untouched.

The one place the RF-loaded cascade *does* leave performance on the table is its top edge, `n >= 501`, where it picks OpenBLAS over an RFLU that is 1.20x–2.53x faster. That is the RFLU upper bound, a different band; see below.

## Measurements

2× AMD EPYC 7502 (128 cores), OpenBLAS, no MKL, no Accelerate. End-to-end through `solve!`, not kernel-only: each timed sample restores `A` from a pristine copy, assigns `cache.A` (which sets `isfresh`), and times `solve!` — so every sample is a fresh factorization plus backsolve. Interleaved across the three algorithms, min over 1000/500/200/80/30/15/10 inner reps × 10 rounds by size, `taskset`-pinned, **min over two independent process launches** for every column below, all collected on an otherwise idle box (load average 6–16 on 128 cores). Worst run-to-run spread for N ≥ 96 was 3.6%.

- `bt1` = `BLAS.set_num_threads(1)`, `JULIA_NUM_THREADS=1`, pinned to one core. RFLU's Polyester threading is serial too, so this is an apples-to-apples serial comparison.
- `mt` = default BLAS threads (32 on 1.12), `julia -t 8` so RFLU is genuinely threaded, pinned to `0-63`.

Julia 1.10 `mt` was collected but is **not reported**. Julia 1.10 defaults BLAS to `nproc` (64 here) where 1.12 defaults to `nproc/2` (32), so with 8 Julia threads on the 64 pinned cores it oversubscribes, and `BLAS/GenericLU` jumps from 1.44x at N=96 to 12.5x at N=128 — reproducibly, on an idle box. That is a harness artifact and it would only overstate the case being made here. Julia 1.10 is covered at one BLAS thread instead.

The algorithms are exactly the ones the default cascade constructs: `GenericLUFactorization()`, `RFLUFactorization()` (= `pivot=Val(true), thread=Val(true)`, matching `RFLUFactorization(throwerror=false)`), `LUFactorization()`.

### OpenBLAS / GenericLU — >1 means blocked GenericLU is faster (this is the edge being moved)

| N | 1.12 f64 bt1 | 1.10 f64 bt1 | 1.12 f32 bt1 | 1.10 f32 bt1 | 1.12 f64 mt | 1.12 f32 mt |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 2.22x | 3.60x | 2.34x | 3.44x | 2.22x | 2.33x |
| 8 | 2.24x | 2.77x | 2.10x | 2.57x | 2.14x | 2.22x |
| 16 | 1.71x | 2.26x | 1.83x | 1.89x | 1.73x | 1.73x |
| 24 | 1.98x | 2.32x | 1.45x | 1.57x | 1.95x | 1.36x |
| 32 | 2.09x | 2.36x | 1.42x | 1.50x | 2.09x | 1.33x |
| 48 | 1.71x | 1.85x | 1.29x | 1.33x | 1.71x | 1.24x |
| 64 | 1.74x | 1.90x | 1.26x | 1.28x | 1.73x | 1.21x |
| 96 | 1.39x | 1.48x | 1.14x | 1.14x | 1.41x | 1.11x |
| 128 | 1.40x | 1.50x | 1.15x | 1.13x | 1.40x | 1.12x |
| 192 | 1.19x | 1.25x | 1.10x | 1.11x | 1.68x | 1.08x |
| **256** | **1.20x** | **1.26x** | **1.14x** | **1.15x** | **1.53x** | **1.13x** |
| 384 | 1.14x | 1.15x | 1.16x | 1.18x | 1.35x | 1.28x |
| 512 | 1.21x | 1.22x | 1.12x | 1.13x | 1.22x | **0.88x** |
| 768 | 1.06x | 1.07x | 1.17x | 1.16x | **0.82x** | **0.88x** |
| 1000 | 1.07x | 1.06x | 1.10x | 1.10x | **0.57x** | **0.83x** |

GenericLU wins in all six configurations at every N through 384. At one BLAS thread OpenBLAS never catches up through N = 1000; with threaded BLAS the crossover is between 384 and 512 for Float32 and between 512 and 768 for Float64.

### Why 256 and not 512

Two reasons.

1. **512 is already lost in one measured configuration.** Float32 with threaded BLAS has OpenBLAS ahead at N=512 (`0.88x`) and at 768 and 1000. An edge at 512 would be wrong there on day one, and Float64 threaded turns over immediately after at 768 (`0.82x`).
2. **This box flatters GenericLU.** Its OpenBLAS `dgetrf` reaches ~20 GFLOP/s single-threaded at N=512, roughly 50% of the Zen2 AVX2 FMA peak — under-tuned. A machine with well-tuned OpenBLAS kernels moves the crossover down, possibly a long way. Everything here is one Zen2 box with one OpenBLAS build.

256 is the largest round number that wins in every configuration measured, with the nearest loss at 512 and a worst-case margin of 1.13x at 256 itself. That is also the same relative margin `#1177` used when it chose 128 against a crossover it measured at 384–512.

### RFLU bands: no change, and the N=512 datum does not generalize

RFLU/GenericLU, >1 means GenericLU faster:

| N | 1.12 f64 bt1 | 1.10 f64 bt1 | 1.12 f32 bt1 | 1.10 f32 bt1 | 1.12 f64 mt | 1.12 f32 mt |
|---:|---:|---:|---:|---:|---:|---:|
| 4 | 1.21x | 1.27x | 1.45x | 1.48x | 1.21x | 1.38x |
| 8 | 1.09x | 1.09x | 1.35x | 1.39x | 1.07x | 1.41x |
| 16 | 0.70x | 0.74x | 1.04x | 0.97x | 0.70x | 0.99x |
| 24 | 0.74x | 0.75x | 0.95x | 0.87x | 0.73x | 0.89x |
| 32 | 0.77x | 0.77x | 0.92x | 0.83x | 0.78x | 0.85x |
| 64 | 0.63x | 0.62x | 0.54x | 0.50x | 0.63x | 0.51x |
| 128 | 0.64x | 0.64x | 0.53x | 0.49x | 0.64x | 0.50x |
| 256 | 0.77x | 0.79x | 0.57x | 0.57x | 0.70x | 0.56x |
| 384 | 0.82x | 0.81x | 0.78x | 0.78x | 0.55x | 0.68x |
| 512 | **1.28x** | **1.31x** | 0.79x | 0.77x | 0.48x | 0.59x |
| 768 | 0.87x | 0.87x | 0.83x | 0.81x | 0.36x | 0.46x |
| 1000 | 0.89x | 0.87x | 0.85x | 0.84x | 0.28x | 0.38x |

**RFLU lower edge stays at 10.** GenericLU wins at N = 4 and 8 in all six configurations and never wins again except at N = 512 (see below). Float64 turns over between 8 and 16; Float32 is a wash at 16 (0.97x–1.04x) and turns over by 24. The existing `size(b,1) <= 10` override sits inside that window, and an eltype-specific edge at 16 would buy at most 4% at exactly one size.

**The N=512 GenericLU win is a power-of-two stride-aliasing artifact, not a general result.** Fine sweep, Julia 1.12, f64, 1 BLAS thread (GFLOP/s):

| N | GenericLU | RFLU | OpenBLAS | RFLU/Gen |
|---:|---:|---:|---:|---:|
| 448 | 24.68 | 29.39 | 22.01 | 0.84x |
| 480 | 25.05 | 30.32 | 22.69 | 0.83x |
| 496 | 24.86 | 29.96 | 22.73 | 0.83x |
| 504 | 24.92 | 29.74 | 22.81 | 0.84x |
| **512** | 24.51 | **19.21** | 20.26 | **1.28x** |
| 520 | 24.93 | 30.16 | 22.83 | 0.83x |
| 544 | 25.81 | 30.56 | 23.39 | 0.84x |
| 576 | 26.14 | 31.39 | 23.87 | 0.83x |
| 640 | 26.78 | 31.07 | 24.87 | 0.86x |

RFLU drops from ~30 GFLOP/s to 19.2 at exactly N=512 and recovers at 520; OpenBLAS dips too (22.8 → 20.3); blocked GenericLU is flat straight through. That is a 4096-byte row stride hitting RFLU's recursive blocking, not an algorithmic crossover. Every one of the eight neighbouring sizes has RFLU ahead by 1.19x–1.21x. Nothing here justifies moving the RFLU band.

**RFLU upper edge stays at 500/200/100 in this PR — but it is the bigger miss, and here is the data for a follow-up.** The 500 OpenBLAS cap is where the RF-loaded default actually loses: from `n = 501` it hands off to OpenBLAS while RFLU is still well ahead. Extending the sweep to find the real crossover, Float64, min over 2 launches, idle box:

| N | GenericLU GF | RFLU GF | OpenBLAS GF | BLAS/RFLU | fastest |
|---:|---:|---:|---:|---:|:--|
| *1 BLAS thread* ||||||
| 1000 | 29.3 | 33.1 | 27.5 | 1.20x | RFLU |
| 1500 | 29.7 | 31.7 | 30.1 | 1.05x | RFLU |
| 2000 | 28.2 | 33.8 | 31.7 | 1.07x | RFLU |
| 3000 | 27.0 | 24.0 | 33.3 | **0.72x** | OpenBLAS |
| *default BLAS threads (32), `-t 8`* ||||||
| 1000 | 29.4 | 102.6 | 52.3 | 1.96x | RFLU |
| 1500 | 29.6 | 118.3 | 87.7 | 1.35x | RFLU |
| 2000 | 28.3 | 139.0 | 117.2 | 1.19x | RFLU |
| 3000 | 26.9 | 156.7 | 158.3 | **0.99x** | OpenBLAS |

The RFLU/OpenBLAS crossover is between 2000 and 3000 in both threading regimes, not at 500. On this box the current cap costs 1.05x–1.96x for every `n` in 501–2000, which is a larger and more common loss than the 129–256 window this PR fixes. Note also that `GenericLUFactorization` is never competitive up there (26.9–29.7 GFLOP/s flat), so this is purely an RFLU-vs-vendor question — inserting GenericLU above 500 would not help.

Deliberately not changed here: it is a different band, it affects everyone who loads RF (i.e. all of OrdinaryDiffEq), and a cap that large needs MKL and Accelerate coverage plus more than one microarchitecture before it moves — the 500 edge presumably came from broader autotune data than one machine. Worth its own PR with autotune-grade coverage.

## Verification

Julia 1.12.6 and 1.10.11 on the same box.

Test discriminates — new `defaults_loading.jl` assertion against unmodified `src/default.jl`:

```
ERROR: LoadError: Some tests did not pass: 10 passed, 1 failed, 0 errored, 0 broken.
Defaults Loading Tests: Test Failed at test/DefaultsLoading/defaults_loading.jl:58
  Expression: (LinearSolve.defaultalg(nothing, zeros(256))).alg === LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
   Evaluated: LinearSolve.DefaultAlgorithmChoice.LUFactorization === LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
```

With the change, `GROUP=<g> julia --project -e 'using Pkg; Pkg.test()'`:

| group | Julia 1.12.6 | Julia 1.10.11 |
|---|---|---|
| DefaultsLoading | `Defaults Loading Tests \| 11 11 1m16.7s`, exit 0 | `Defaults Loading Tests \| 11 11 38.1s`, exit 0 |
| Core | `Basic Tests \| 766 766 10m25.3s`, `Default Alg Tests \| 127 127 7m41.3s`, exit 0 | `Basic Tests \| 766 766 6m08.5s`, `Default Alg Tests \| 127 127 3m34.6s`, exit 0 |
| QA | `Quality Assurance \| 49 49 4m30.4s`, exit 0 | **fails, pre-existing and not run by CI** — see below |

Runic 1.7.0 and `typos` are clean on the three touched files.

**Julia 1.10 `GROUP=QA` fails on `main`, not on this branch, and CI never runs it.** `JET.@test_opt solve(prob_sparse, KLUFactorization())` at `test/qa/jet.jl:136` gives `20 passed, 1 failed, 0 errored, 21 broken`. I reverted `src/default.jl`, `test/Core/default_algs.jl` and `test/DefaultsLoading/defaults_loading.jl` to `origin/main` in a scratch copy and got the byte-identical failure, so it is not caused by this PR.

Root-caused separately: it is a Base 1.10 inference limitation (`code_typed(Base.typejoin, (Any, Any))` has a runtime dispatch on 1.10.11 but not on 1.11.9 or 1.12.6), so on 1.10 any code path that emits a log message fails `@test_opt` — here the two `@SciMLMessage` calls in the KLU `solve!`. Pre-existing since #1083 removed the `broken = true` marker. Note `test/test_groups.toml` declares `[QA] versions = ["lts", "1"]` but the shared SciML matrix clamps QA to `["1"]` (`QA_VERSIONS` in `SciML/.github/scripts/compute_affected_sublibraries.jl`), and a real 44-job `Tests.yml` run contains only `QA (julia 1, self-hosted)` — so there is no red CI job, it only bites `GROUP=QA julia +1.10` locally. Tracked in #1190.

The new `default_algs.jl` assertions (the RF-shadow loop and the ComplexF64 loop at 32/256) pass both before and after by design — they pin that the raised band does *not* leak into the RF-loaded cascade or into complex eltypes.

## Not verified

- **MKL and Apple Accelerate end-to-end.** Neither is available on this box (`LinearSolve.usemkl == false`, `appleaccelerate_isavailable() == false`), so the `matrix_size <= 32` universal limit and the Accelerate branch are untouched and unmeasured.
- **GPU.** No GPU group run.
- **Julia 1.10 with default (64) BLAS threads.** Discarded as unusable, see above. Julia 1.10 is covered at one BLAS thread and Julia 1.12 at both.
- **Sizes above 3000.** The main sweep stops at N = 1000 and the RFLU-cap sweep at N = 3000.
- **Other microarchitectures.** Everything here is one Zen2 box with one OpenBLAS build. See "Why 256 and not 512".

## What a reviewer should push back on

- Whether 256 is the right conservatism given the measured crossover is 512–768. The argument for stopping short is cross-machine risk plus the one Float32-threaded loss at 512.
- **Whether the RFLU 500/OpenBLAS cap should move in a follow-up.** On this box the real crossover is 2000–3000, and the current cap costs 1.05x–1.96x for every `n` in 501–2000 in the RF-loaded default. That is a bigger win than this PR. I did not take it because it needs vendor and microarchitecture coverage I do not have here.
- Whether the `matrix_size <= 32` non-OpenBLAS limit should have been touched. I left it alone rather than guess without MKL/Accelerate hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
