### PR TITLE
Give the RecursiveFactorization extension a compile workload for the default solve path

### DIFF
--- a/ext/LinearSolveRecursiveFactorizationExt.jl
+++ b/ext/LinearSolveRecursiveFactorizationExt.jl
@@ -7,7 +7,7 @@ using ArrayInterface: ArrayInterface
 using LinearAlgebra: LinearAlgebra, UnitLowerTriangular, UpperTriangular, ldiv!, mul!
 using RecursiveFactorization: RecursiveFactorization
 using TriangularSolve: TriangularSolve
-using SciMLBase: SciMLBase, ReturnCode
+using SciMLBase: SciMLBase, LinearProblem, ReturnCode, solve
 using SciMLLogging: @SciMLMessage
 
 LinearSolve.userecursivefactorization(A::Union{Nothing, AbstractMatrix}) = true
@@ -278,6 +278,16 @@ function supernodal_panel_solve_backend!(
         throw(ArgumentError("unknown supernodal panel operation: $operation"))
     end
     return B
+end
+
+# Re-caches the default solve path, which this extension invalidates via
+# `userecursivefactorization`. Size is not a coverage axis: inference is whole-body.
+LinearSolve.PrecompileTools.@compile_workload begin
+    A = rand(4, 4)
+    b = rand(4)
+    prob = LinearProblem(A, b)
+    sol = solve(prob)
+    sol = solve(prob, RFLUFactorization())
 end
 
 end


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

`ext/LinearSolveRecursiveFactorizationExt.jl` redefines `LinearSolve.userecursivefactorization`, which `defaultalg` calls. That invalidates the default-path specializations the root `@compile_workload` caches, and the extension had no workload of its own to re-cache them. Result on current `main`: with RecursiveFactorization loaded, the first default `solve` costs ~2.2 s at every problem size, while the same solve without it costs ~0.1 ms.

This adds an eight-line `@compile_workload` to the extension covering the default `solve(prob)` path plus explicit `RFLUFactorization()`. It is the RecursiveFactorization half of the precompile work; the SparseArrays half was subsumed by the fold in #1191, which moved that extension into `src/` so the root workload's coverage survives.

## Verification

Julia 1.12.6, x86-64 Linux, OpenBLAS, 64 BLAS threads, 1 Julia thread. Each number is a fresh process running only `using ...` then one `solve(LinearProblem(rand(n,n) + n*I, rand(n)))`; median of 5.

**Time to first solve, ms**

| n | no RF, before | no RF, after | with RF, before | with RF, after |
|---:|---:|---:|---:|---:|
| 4 | 0.073 | 0.077 | **2215.7** | **0.075** |
| 20 | 0.085 | 0.083 | **2180.8** | **0.170** |
| 64 | 0.130 | 0.144 | **2235.1** | **0.212** |
| 200 | 0.778 | 0.890 | **2197.6** | **0.681** |

The no-RF column is the control: unchanged, as expected — this workload only runs when the extension loads.

**Version dependence.** The default-path recovery is Julia 1.12+ only. n = 64, one fresh process per cell, ms:

| julia | explicit `RFLUFactorization()` | default `solve(prob)` |
|---|---:|---:|
| 1.10.11 | 192 → 44 | 5960 → 6040 |
| 1.11.9 | 174 → 49 | 4028 → 4466 |
| 1.12.6 | 442 → 0.26 | 2047 → 0.13 |

On 1.10/1.11 the explicit-algorithm coverage lands but the default path does not re-cache. I measured this; I did not root-cause it in Julia's precompile machinery, so I am not going to claim a mechanism. A 20×20 workload (which *executes* the RFLU branch rather than only inferring it) does not rescue those versions either — 6572 ms / 4693 ms — so this is not a matter of picking a different problem.

**Test suites**, on the rebased branch:

```
GROUP=Core julia +1.12 --project -e 'using Pkg; Pkg.test()'
     Testing LinearSolve tests passed          (31 test summaries, 0 failures)

GROUP=QA   julia +1.12 --project -e 'using Pkg; Pkg.test()'
JET Tests                  |   34       8      42   1m12.3s
Allocation QA              |   60              60   1m31.0s
SupernodalLU Allocation QA |    8               8     16.6s
Quality Assurance          |   48              48   4m13.6s
     Testing LinearSolve tests passed
```

(The 8 broken JET markers are pre-existing.) `typos` clean; Runic clean.

## Cost

Paired, alternating between the HEAD and working-tree versions of the extension file and re-running `Pkg.precompile()` — only the extension recompiles, the root module is untouched. 4 reps, medians:

| | without workload | with workload | Δ |
|---|---:|---:|---:|
| precompile wall | 5.93 s | 8.91 s | **+2.98 s** |
| precompile CPU (user+sys) | 12.96 s | 17.04 s | **+4.08 s** |
| extension cache on disk | 103.6 KB | 1265.5 KB | **+1.16 MB** |

`@elapsed using LinearSolve, RecursiveFactorization`: 2009.8 ms → 2024.2 ms (median of 11), i.e. **+14 ms**. That is inside the run-to-run noise — an earlier 7-rep pair on the same build gave 1986.0 → 2047.4 ms (+61 ms). Treat the load-time cost as "under ~60 ms", not as a precise figure.

Net for a user who loads RecursiveFactorization on 1.12: load + first solve goes from ~1986 + 2216 = ~4.2 s to ~2024 + 0.1 = ~2.0 s.

## Why there is no size sweep

Matrix size is not a coverage axis here. `typeof(init(prob))` is identical at n = 4, 20 and 200 — the same `LinearCache{Matrix{Float64}, …, DefaultLinearSolver, DefaultLinearSolverInit{…}}` — and inference is whole-body, so a single 4×4 problem re-caches the entire default cascade, including the RFLU band a 4×4 never reaches at runtime (it takes the `size(b,1) <= 10` GenericLU override). The table above is the check: the 4×4 workload takes n = 200, which does run RFLU, from 2197.6 ms to 0.681 ms. Measured directly against a 20×20 variant on 1.12: default solve 0.13 ms vs 0.14 ms — no difference, so the larger size buys nothing and costs more workload runtime.

## What I dropped, with the numbers

**Float32.** Default-path TTFX with `Float32` inputs is ~5.7–5.9 s *whether or not RecursiveFactorization is loaded* (n=4: 5729 ms no-RF vs 5766 ms RF; n=64: 5830 vs 5904). It is a pre-existing gap in the root workload, which is Float64-only, not something this extension invalidates. Adding a Float32 pair here costs +4 s wall / +9 s CPU of extension precompile and fixes only the RF-loaded half (down to 0.24–0.35 ms) while leaving the no-RF half at ~6.0–6.3 s. Wrong place; dropped. If Float32 is worth covering it belongs in the root workload, where it would fix both halves.

**Matrix / multi-RHS.** `LinearProblem(rand(64,64)+64I, rand(64,3))` costs 4182 ms without RF and 4053 ms with RF. Same story — independent of this extension. Dropped.

**`ButterflyFactorization` and `RF32MixedLUFactorization`.** Also defined in this extension, but they are opt-in algorithms that nothing in the default cascade reaches, so they do not participate in the invalidation this PR is fixing. Covering them is a separate cost/benefit question.

## What I did not verify

- Anything off x86-64 Linux / OpenBLAS. The MKL and AppleAccelerate branches of the default cascade were never taken on this machine.
- GPU jobs, downstream jobs, and the `julia pre` job — not run locally.
- No new test. The repo has no timing- or precompile-coverage test anywhere in `test/`, and the only way to make a test that fails before this change and passes after is a wall-clock assertion, which would additionally have to be version-gated to 1.12+ given the table above. I would rather say that plainly than add a test that passes either way.
- The 1.10/1.11 shortfall is measured, not explained.

## Note on #1188

https://github.com/SciML/LinearSolve.jl/pull/1188 covered both the SparseArrays and RecursiveFactorization extensions and was closed unmerged. Its SparseArrays half is obsolete after #1191. This is a fresh, single-purpose PR for the still-missing RecursiveFactorization half — not a revival of that branch — and every number above is measured on current `main`, not carried over from it.

## Possible follow-up (not here)

The reason this workload is needed at all is that the extension invalidates by *redefining a method*. Two neighbours in the same cascade — `isopenblas()` and `appleaccelerate_isavailable()` — are `Ref{Bool}` flags instead, which do not invalidate. Converting `userecursivefactorization` to that pattern would let the root workload's coverage survive on every Julia version and drop the +1.16 MB duplicate cache, but it changes a trait function that `RFLUFactorization`'s constructor calls, so it belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
