### PR TITLE
QA: mark the KLU JET assertion broken on the LTS, where Base logging is not inference-clean

### DIFF
--- a/test/qa/jet.jl
+++ b/test/qa/jet.jl
@@ -133,7 +133,16 @@ end
     JET.@test_opt solve(prob_sparse, UMFPACKFactorization()) broken = true
     # Passes since the 5.0 lightweight solution: with the cache no longer
     # captured in the returned LinearSolution, the KLU solve is dispatch-clean.
-    JET.@test_opt solve(prob_sparse, KLUFactorization())
+    #
+    # Except on the LTS. `@SciMLMessage` in the failure branches expands to
+    # `Logging.@logmsg`, and on 1.10 the `Base.CoreLogging` path it enters
+    # reaches `Base.typejoin`, which is itself a runtime dispatch there. That
+    # makes *any* solve able to emit a log fail `@test_opt` on 1.10, regardless
+    # of anything LinearSolve does; 1.11 carries the Base fix. Measured on this
+    # assertion: 2 reports on 1.10.11, 0 on 1.12.6, and the 1.10 reports name
+    # only `typejoin`/`CoreLogging`/`_emit_log`, none of the KLU internals that
+    # #1148 and #1163 dealt with. See SciML/LinearSolve.jl#1190.
+    JET.@test_opt solve(prob_sparse, KLUFactorization()) broken = VERSION < v"1.11"
     JET.@test_opt solve(prob_sparse_spd, CHOLMODFactorization()) broken = true
 
     # SparspakFactorization requires Sparspak to be loaded


### PR DESCRIPTION
Fixes #1190.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- One line of test annotation, no source change. The KLU assertion at `test/qa/jet.jl:136` becomes `broken = VERSION < v"1.11"`.
- Cause is in Base, not here. `@SciMLMessage` in the failure branches expands to `Logging.@logmsg`, and on 1.10 the `Base.CoreLogging` path it enters reaches `Base.typejoin`, which is itself a runtime dispatch on that version. Any solve that can emit a log therefore fails `@test_opt` on 1.10 no matter what LinearSolve does, and 1.11 carries the Base fix.
- Reproduced independently before changing anything: `report_opt` on this solve gives 2 reports on 1.10.11 and 0 on 1.12.6.
- The 1.10 reports name only `typejoin`, `CoreLogging`, `_emit_log` and `SciMLLogging`. None of them name `getproperty` or `_extract!`, which is what separates this from the KLU internals that #1148 and #1163 fixed. This is not a regression of that work.
- `broken` rather than a skip, so it registers an unexpected pass and gets removed if the assertion ever starts holding on the LTS.
- Verified both directions rather than assuming the marker behaves: the assertion registers Pass on 1.12.6 and Broken on 1.10.11. That check matters because a marker that swallowed a real pass on 1.12 would quietly undo what #1163 established.
- Full `test/qa/jet.jl` on 1.12.6 is green with zero failures, and the sparse testset reads 1 pass and 2 broken as expected. Runic is clean.
- Note this is not currently a red CI check: the reusable workflow pins QA to `QA_VERSIONS = ["1"]`, which overrides the `["lts", "1"]` in `test/test_groups.toml`. It bites `GROUP=QA` runs on the LTS locally, and would become a CI failure if that list ever widened.

AI Disclosure: Used Opus 5