### PR TITLE
IterativeSolvers: fix MINRES residual field and IDRS keyword forwarding

### DIFF
--- a/ext/LinearSolveIterativeSolversExt.jl
+++ b/ext/LinearSolveIterativeSolversExt.jl
@@ -106,7 +106,18 @@ function LinearSolve.init_cacheval(
         history = IterativeSolvers.ConvergenceHistory(partial = true)
         history[:abstol] = abstol
         history[:reltol] = reltol
-        filter_kwargs(; idrs_s = 0, kwargs...) = kwargs
+        # `idrs_iterable!` takes the tolerances and the iteration cap
+        # positionally and accepts only `smoothing`/`verbose` as keywords, so
+        # every name passed positionally below has to be dropped here. Filtering
+        # `idrs_s` alone meant `IterativeSolversJL_IDRS(abstol = ...)` forwarded
+        # `abstol` as a keyword too and failed with a `MethodError`
+        # (SciML/LinearSolve.jl#24).
+        function filter_kwargs(;
+                idrs_s = 0, abstol = nothing, reltol = nothing,
+                maxiter = nothing, kwargs...
+            )
+            return kwargs
+        end
         IterativeSolvers.idrs_iterable!(
             history, u, A, b, s, Pl, abstol, reltol, maxiters;
             filter_kwargs(; alg.kwargs...)...
@@ -167,14 +178,21 @@ function SciMLBase.solve!(cache::LinearCache, alg::IterativeSolversJL; kwargs...
         # TODO inject callbacks KSP into solve! cb!(cache.cacheval)
     end
 
-    resid = cache.cacheval isa IterativeSolvers.IDRSIterable ? cache.cacheval.R :
-        cache.cacheval.residual
+    resid = _iterable_residual(cache.cacheval)
     if resid isa IterativeSolvers.Residual
         resid = resid.current
     end
 
     return SciMLBase.build_linear_solution(alg, cache.u, resid, nothing; iters = i)
 end
+
+# IterativeSolvers does not name this field consistently across its iterables.
+# Reading `.residual` unconditionally made `IterativeSolversJL_MINRES` throw a
+# `FieldError` on every solve, because `MINRESIterable` calls it `resnorm`
+# (SciML/LinearSolve.jl#24).
+_iterable_residual(iterable) = iterable.residual
+_iterable_residual(iterable::IterativeSolvers.IDRSIterable) = iterable.R
+_iterable_residual(iterable::IterativeSolvers.MINRESIterable) = iterable.resnorm
 
 purge_history!(iter, x, b) = nothing
 function purge_history!(iter::IterativeSolvers.GMRESIterable, x, b)

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -732,13 +732,38 @@ end
                     ("GMRES", IterativeSolversJL_GMRES(; kwargs...)),
                     ("IDRS", IterativeSolversJL_IDRS(; kwargs...)),
                     ("IDRS(2)", IterativeSolversJL_IDRS(; idrs_s = 2, kwargs...)),
+                    ("MINRES", IterativeSolversJL_MINRES(; kwargs...)),
+                    # BICGSTAB stays out: IterativeSolvers' own bicgstabl breaks
+                    # down on the identity `prob1` here and throws
+                    # "matrix contains Infs or NaNs" out of LAPACK, which is an
+                    # upstream numerical issue rather than a wiring problem on
+                    # this side.
                     # ("BICGSTAB",IterativeSolversJL_BICGSTAB(; kwargs...)),
-                    # ("MINRES",IterativeSolversJL_MINRES(; kwargs...)),
                 )
                 @testset "$(alg[1])" begin
                     test_interface(alg[2], prob1, prob2)
                     test_interface(alg[2], prob3, prob4)
                     test_tolerance_update(alg[2], prob5, u5)
+                end
+            end
+
+            @testset "tolerances as algorithm kwargs (#24)" begin
+                # `idrs_iterable!` takes abstol/reltol/maxiter positionally and
+                # accepts only `smoothing`/`verbose` as keywords, so forwarding
+                # them from `alg.kwargs` used to raise a MethodError. MINRES read
+                # `.residual`, which its iterable calls `resnorm`, and threw a
+                # FieldError on every solve.
+                # Note these solves report `ReturnCode.Default` rather than
+                # `Success`: this extension never passes a retcode to
+                # `build_linear_solution`. That is pre-existing and separate from
+                # what is tested here, so assert on the solution itself.
+                for alg in (
+                        IterativeSolversJL_IDRS(abstol = 1.0e-10, reltol = 1.0e-10),
+                        IterativeSolversJL_MINRES(abstol = 1.0e-10, reltol = 1.0e-10),
+                        IterativeSolversJL_CG(abstol = 1.0e-10, reltol = 1.0e-10),
+                    )
+                    sol = solve(LinearProblem(A5, b5), alg)
+                    @test sol.u ≈ u5 rtol = 1.0e-6
                 end
             end
         end


### PR DESCRIPTION
Fixes #24.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Found while checking whether #181 still reproduces. It does not, but two IterativeSolvers algorithms turned out to be broken outright, which is what #24 reports.

### MINRES threw on every solve

`solve!` read `cache.cacheval.residual` unconditionally. `MINRESIterable` calls that field `resnorm`, so `IterativeSolversJL_MINRES` failed with `FieldError: type IterativeSolvers.MINRESIterable has no field 'residual'` for any input. Residual extraction is now per iterable type, which also keeps the existing `IDRSIterable` special case in one place.

### IDRS threw whenever tolerances were passed as algorithm kwargs

`idrs_iterable!` takes `abstol`, `reltol` and `maxiter` positionally and accepts only `smoothing` and `verbose` as keywords. The filter dropped `idrs_s` alone, so `IterativeSolversJL_IDRS(abstol = 1e-10)` forwarded `abstol` a second time as a keyword and failed with a `MethodError`. All four positionally passed names are now dropped. `IterativeSolversJL_IDRS()` with no kwargs was unaffected, which is why the existing tests missed it.

### Test coverage

- MINRES is enabled in the `IterativeSolversJL` testset, where it had been commented out. It passes the full `test_interface` on both the real and complex problems plus `test_tolerance_update`.
- BICGSTAB stays commented out, now with the reason recorded. It fails differently: IterativeSolvers' own `bicgstabl` breaks down on the identity `prob1` and throws `ArgumentError: matrix contains Infs or NaNs` out of LAPACK. That is upstream numerics rather than anything wired wrong here, so it is not in scope.
- A new case covers tolerances passed as algorithm kwargs for IDRS, MINRES and CG. The existing testset only ever passed `gmres_restart`, so it could not have caught the IDRS bug.

### Notes for review

- That new test asserts the solution rather than `successful_retcode`. This extension calls `build_linear_solution` without a retcode, so every IterativeSolvers algorithm reports `ReturnCode.Default` and `successful_retcode` is false, while KrylovJL reports `Success` on the same problem. That is pre-existing and I left it alone deliberately: the extension never checks convergence, so reporting `Success` unconditionally would claim something it has not verified, for example when a solve simply runs out of iterations. Happy to change it if you want that behaviour, but it seemed like its own decision rather than part of a bug fix.
- On #181 itself: the reported wrong answer no longer reproduces. That report used `LinearSolve.set_b`, which no longer exists; with the current cache API, updating `cache.b` and re-solving gives errors around 5e-18 for CG, GMRES and BICGSTAB. It can be closed as fixed independently of this PR.

### Verification

- All five `IterativeSolversJL_*` variants solve correctly, bare and with tolerance kwargs, both on a fresh solve and after a `b` update through the cache: 10 of 10 combinations, previously 6.
- Full `GROUP=Core` suite passes with zero failures.
- Runic clean.

AI Disclosure: Used Opus 5