### PR TITLE
IterativeSolvers: accept LinearSolve's maxiters spelling on the algorithm

### DIFF
--- a/ext/LinearSolveIterativeSolversExt.jl
+++ b/ext/LinearSolveIterativeSolversExt.jl
@@ -59,6 +59,18 @@ end
 
 LinearSolve._isidentity_struct(::IterativeSolvers.Identity) = true
 
+# Accept LinearSolve's `maxiters` spelling on the algorithm and hand
+# IterativeSolvers the `maxiter` it expects. An explicit `maxiter` wins if both
+# are given, and the NamedTuple is rebuilt rather than mutated so the result
+# stays inferrable.
+function _rename_maxiters(kwargs)
+    haskey(kwargs, :maxiters) || return NamedTuple(kwargs)
+    nt = NamedTuple(kwargs)
+    maxiters = nt.maxiters
+    rest = Base.structdiff(nt, NamedTuple{(:maxiters,)})
+    return haskey(rest, :maxiter) ? rest : merge(rest, (; maxiter = maxiters))
+end
+
 function LinearSolve.init_cacheval(
         alg::IterativeSolversJL, A, b, u, Pl, Pr, maxiters::Int,
         abstol,
@@ -77,9 +89,18 @@ function LinearSolve.init_cacheval(
     restart = (alg.gmres_restart == 0) ? min(20, size(A, 1)) : alg.gmres_restart
     s = get(alg.kwargs, :idrs_s, 4) # shadow space
 
+    # LinearSolve spells the iteration cap `maxiters`, IterativeSolvers spells it
+    # `maxiter`. Passing the LinearSolve spelling on the algorithm, as in
+    # `IterativeSolversJL_CG(maxiters = 100)`, used to forward an unknown keyword
+    # and fail with a MethodError (SciML/LinearSolve.jl#175), so accept it as an
+    # alias here. Everything below reads the cap from `maxiters_eff` so the
+    # algorithm-level value also reaches the solvers that take it positionally.
+    alg_kwargs = _rename_maxiters(alg.kwargs)
+    maxiters_eff = get(alg_kwargs, :maxiter, maxiters)
+
     kwargs = (
-        abstol = abstol, reltol = reltol, maxiter = maxiters,
-        alg.kwargs...,
+        abstol = abstol, reltol = reltol, maxiter = maxiters_eff,
+        alg_kwargs...,
     )
 
     iterable = if alg.generate_iterator === IterativeSolvers.cg_iterator!
@@ -119,8 +140,8 @@ function LinearSolve.init_cacheval(
             return kwargs
         end
         IterativeSolvers.idrs_iterable!(
-            history, u, A, b, s, Pl, abstol, reltol, maxiters;
-            filter_kwargs(; alg.kwargs...)...
+            history, u, A, b, s, Pl, abstol, reltol, maxiters_eff;
+            filter_kwargs(; alg_kwargs...)...
         )
     elseif alg.generate_iterator === IterativeSolvers.bicgstabl_iterator!
         !!LinearSolve._isidentity_struct(Pr) &&
@@ -128,17 +149,20 @@ function LinearSolve.init_cacheval(
             "$(alg.generate_iterator) doesn't support right preconditioning",
             verbosity, :no_right_preconditioning
         )
+        # `bicgstabl_iterator!` caps work through `max_mv_products`, set just
+        # above, and has no `maxiter` keyword at all, so the normalized cap has
+        # to come out again here.
         alg.generate_iterator(
             u, A, b, alg.args...; Pl = Pl,
             abstol = abstol, reltol = reltol,
-            max_mv_products = maxiters * 2,
-            alg.kwargs...
+            max_mv_products = maxiters_eff * 2,
+            Base.structdiff(alg_kwargs, NamedTuple{(:maxiter,)})...
         )
     else # minres, qmr
         alg.generate_iterator(
             u, A, b, alg.args...;
-            abstol = abstol, reltol = reltol, maxiter = maxiters,
-            alg.kwargs...
+            abstol = abstol, reltol = reltol, maxiter = maxiters_eff,
+            alg_kwargs...
         )
     end
     return iterable

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -766,6 +766,27 @@ end
                     @test sol.u ≈ u5 rtol = 1.0e-6
                 end
             end
+
+            @testset "maxiters on the algorithm (#175)" begin
+                # LinearSolve spells it `maxiters`, IterativeSolvers `maxiter`.
+                # Passing the LinearSolve spelling on the algorithm used to
+                # forward an unknown keyword and raise a MethodError.
+                for f in (
+                        IterativeSolversJL_CG, IterativeSolversJL_GMRES,
+                        IterativeSolversJL_IDRS, IterativeSolversJL_MINRES,
+                        IterativeSolversJL_BICGSTAB,
+                    )
+                    @test solve(LinearProblem(A5, b5), f(maxiters = 200)).u ≈ u5 rtol = 1.0e-6
+                end
+
+                # The algorithm-level value caps the iteration count, and an
+                # explicit `maxiter` still wins if both are given.
+                slow = LinearProblem(Symmetric(Matrix(A5) + 0.5I), b5)
+                for m in (2, 5)
+                    @test solve(slow, IterativeSolversJL_CG(maxiters = m)).iters <= m
+                end
+                @test solve(slow, IterativeSolversJL_CG(maxiter = 3, maxiters = 50)).iters == 3
+            end
         end
     end
 


### PR DESCRIPTION
Fixes #175.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- LinearSolve spells the iteration cap `maxiters`, IterativeSolvers spells it `maxiter`. Setting it on the algorithm, as the issue does with `IterativeSolversJL_CG(maxiters = 100)`, forwarded an unknown keyword straight through and failed with a `MethodError`. The issue's own workaround was to drop the `s`.
- `maxiters` is now accepted as an alias on the algorithm. An explicit `maxiter` wins if both are given, and the resolved value is threaded through every branch, including `idrs_iterable!` and `bicgstabl_iterator!` which take the cap positionally, so an algorithm-level value actually takes effect instead of being quietly replaced by the cache's.
- Verified it caps rather than merely not throwing: `maxiters = 2`, `5` and `25` stop after exactly 2, 5 and 25 iterations, `maxiter = 3` is still honoured, and with both given `maxiter` wins.
- One thing the cross-check caught: renaming the key broke BICGSTAB, because `bicgstabl_iterator!` caps work through `max_mv_products` and has no `maxiter` keyword at all, so the normalized name reached a function that cannot accept it. It is stripped for that branch. Testing only the algorithm from the issue would have fixed four solvers and broken a fifth.
- All five `IterativeSolversJL_*` variants solve correctly, bare and with `maxiters`, 10 of 10 combinations.
- Tests cover every variant with `maxiters`, that the cap is respected, and the `maxiter` precedence rule. The existing testset only ever passed `gmres_restart`, so it could not have caught this.
- Full `GROUP=Core` suite passes with zero failures. Runic clean.

AI Disclosure: Used Opus 5
