### PR TITLE
Docs: document the LoadMKL_JLL preference in the FAQ

### DIFF
--- a/docs/src/basics/FAQ.md
+++ b/docs/src/basics/FAQ.md
@@ -87,3 +87,36 @@ Pr = LA.Diagonal(weights)
 prob = LS.LinearProblem(A, b)
 sol = LS.solve(prob, LS.KrylovJL_GMRES(precs = Returns((Pl, Pr))))
 ```
+
+## Why does LinearSolve.jl depend on MKL_jll, and how do I stop it from loading?
+
+MKL is the fastest BLAS on most x86 hardware, often by a wide margin, so LinearSolve.jl
+ships it by default and lets the default algorithm choice pick `MKLLUFactorization`
+where it wins. Without it, most installations end up substantially slower.
+
+If you would rather not load it, for example because you only solve small static-array
+systems where it brings nothing, set the `LoadMKL_JLL` preference to `false`:
+
+```julia
+using Preferences, UUIDs
+
+Preferences.set_preferences!(
+    UUID("7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"),  # LinearSolve
+    "LoadMKL_JLL" => false; force = true
+)
+```
+
+The preference is read when LinearSolve.jl loads, so restart Julia afterwards and let
+the package recompile. From then on `LinearSolve.usemkl` is `false`, MKL_jll is never
+`using`'d, and the default algorithm falls back to the next best choice for your
+matrix, typically `LUFactorization` or `RFLUFactorization`. Nothing else about the
+interface changes and every algorithm you select explicitly keeps working.
+
+Two details worth knowing:
+
+  - The default is already architecture aware. MKL is only considered on `x86_64` and
+    `i686`, and it is off by default on AMD EPYC CPUs, where it does not win. On other
+    architectures such as Apple Silicon it is never loaded regardless of this setting.
+  - The preference controls whether LinearSolve.jl *loads and uses* MKL_jll, not
+    whether it is installed. MKL_jll stays a declared dependency, so it remains in the
+    dependency graph and Pkg still installs it.


### PR DESCRIPTION
Fixes #524.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- Documentation only, one new FAQ entry, no source change.
- The question in #524 was whether the MKL dependency can be made optional. It can, through the `LoadMKL_JLL` preference, and that was answered in the issue thread, but the preference is not documented anywhere: it appears only in `src/LinearSolve.jl` and had no mention in `docs/`.
- The entry says why MKL is there, gives the `Preferences.set_preferences!` call with the LinearSolve UUID, and notes that the preference is read at load time so Julia has to be restarted.
- Verified rather than transcribed: setting the preference in a scratch environment and reloading in a fresh process flips `LinearSolve.usemkl` to `false`, and the default algorithm falls back from MKL to `LUFactorization` with solves still correct.
- Two behaviours worth documenting turned up while reading the source, and both are in the entry. The default is already architecture aware, x86_64 and i686 only, and off by default on AMD EPYC. And the preference controls whether MKL_jll is loaded and used, not whether it is installed: it stays a declared dependency. That second point matters because the reporter's actual complaint was the artifact download during precompilation, which this does not remove.
- Left as a plain fenced block rather than `@example`, so the docs build does not execute `set_preferences!` during CI.
- Tests box is unchecked because there is no test surface for a docs page. The recipe itself was verified as described above.

AI Disclosure: Used Opus 5
