### PR TITLE
Eigenvalue: add the ArnoldiMethodJL keyword constructor

### DIFF
--- a/src/eigenvalue.jl
+++ b/src/eigenvalue.jl
@@ -41,13 +41,22 @@ end
 ArpackJL(; kwargs...) = ArpackJL((; kwargs...))
 
 """
-    ArnoldiMethodJL
+    ArnoldiMethodJL(; kwargs...)
 
-Algorithm type constructed by [`ArnoldiMethod`](@ref); see its docstring for details.
+Same solver as [`ArnoldiMethod`](@ref); see its docstring for details.
+
+Prefer this spelling when the ArnoldiMethod.jl package is in scope. Loading that
+package is what makes this solver available, and it binds the name
+`ArnoldiMethod` to the module, so after `using LinearSolve, ArnoldiMethod` a bare
+`ArnoldiMethod(; kwargs...)` reaches the module rather than the constructor and
+fails with "objects of type Module are not callable". `ArnoldiMethodJL` does not
+collide, and matches how the other backends are named.
 """
 struct ArnoldiMethodJL{K <: NamedTuple} <: AbstractEigenvalueAlgorithm
     kwargs::K
 end
+
+ArnoldiMethodJL(; kwargs...) = ArnoldiMethodJL((; kwargs...))
 
 """
     ArnoldiMethod(; kwargs...)

--- a/test/Core/eigenvalue.jl
+++ b/test/Core/eigenvalue.jl
@@ -47,6 +47,17 @@ sol_arnoldi = solve(
 )
 @test sol_arnoldi.u ≈ [8.0, 7.0]
 
+# `using ArnoldiMethod` is what makes this backend available, and it binds
+# `ArnoldiMethod` to the module, so the unqualified constructor name is shadowed
+# here. `ArnoldiMethodJL` is the spelling that survives that, and every other
+# assertion in this file goes through the qualified form, which is why the
+# missing keyword constructor was never caught.
+@test ArnoldiMethodJL(; tol = 1.0e-12) == LinearSolve.ArnoldiMethod(; tol = 1.0e-12)
+sol_arnoldi_jl = solve(
+    EigenvalueProblem(A_backend; num_eigenpairs = 2), ArnoldiMethodJL()
+)
+@test sol_arnoldi_jl.u ≈ [8.0, 7.0]
+
 sol_arnoldi_default = solve(EigenvalueProblem(A_backend), LinearSolve.ArnoldiMethod())
 @test length(sol_arnoldi_default.u) == 6
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- `ArnoldiMethodJL` is exported but had no keyword constructor, only the positional `ArnoldiMethodJL(::NamedTuple)`. Its siblings all have one, so this adds the matching `ArnoldiMethodJL(; kwargs...)`.
- Using this backend requires `using ArnoldiMethod`, which binds `ArnoldiMethod` to the module, so a bare `ArnoldiMethod(; kwargs...)` then fails with `objects of type Module are not callable`. With no keyword constructor on the JL name either, a `using LinearSolve` user had no working unqualified spelling.
- Nothing renamed or removed. `LinearSolve.ArnoldiMethod(...)` still works and the two produce identical objects, which the new test asserts.
- Every existing assertion in `test/Core/eigenvalue.jl` uses the qualified form, which is why this was never caught. The new test uses the unqualified one.
- Verified on a 50x50 SPD matrix: the new constructor forwards kwargs and its eigenvalues match `eigvals` to 8 significant digits. `test/Core/eigenvalue.jl` passes, Runic clean.
- Found while checking #487, but this does not close it: the eigensolvers are already implemented, and the ModelingToolkit preconditioner interface that issue also asks for is not built.

AI Disclosure: Used Opus 5
