### PR TITLE
Initialize u0 with a typed zero rather than false

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -195,6 +195,7 @@ StaticArrays = "1.9"
 StaticArraysCore = "1.4.3"
 SuperLUDIST = "1"
 Test = "1.10"
+Unitful = "1"
 Zygote = "0.7"
 blis_jll = "0.9.0"
 julia = "1.10"
@@ -231,8 +232,9 @@ SpecializingFactorizations = "fa08b7a1-13d3-4faf-875d-5cbc1520e3f3"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 blis_jll = "6136c539-28a5-5bf0-87cc-b183200dce32"
 
 [targets]
-test = ["AlgebraicMultigrid", "Arpack", "ArnoldiMethod", "BandedMatrices", "BlockDiagonals", "CliqueTrees", "ComponentArrays", "FastAlmostBandedMatrices", "FastLapackInterface", "FiniteDiff", "FixedSizeArrays", "ForwardDiff", "InteractiveUtils", "IterativeSolvers", "JLArrays", "JacobiDavidson", "KrylovKit", "LAPACK_jll", "MultiFloats", "Pkg", "PureUMFPACK", "Random", "RecursiveFactorization", "STRUMPACK_jll", "SafeTestsets", "SciMLTesting", "SparseArrays", "Sparspak", "SpecializingFactorizations", "StableRNGs", "StaticArrays", "Test", "Zygote", "blis_jll"]
+test = ["AlgebraicMultigrid", "Arpack", "ArnoldiMethod", "BandedMatrices", "BlockDiagonals", "CliqueTrees", "ComponentArrays", "FastAlmostBandedMatrices", "FastLapackInterface", "FiniteDiff", "FixedSizeArrays", "ForwardDiff", "InteractiveUtils", "IterativeSolvers", "JLArrays", "JacobiDavidson", "KrylovKit", "LAPACK_jll", "MultiFloats", "Pkg", "PureUMFPACK", "Random", "RecursiveFactorization", "STRUMPACK_jll", "SafeTestsets", "SciMLTesting", "SparseArrays", "Sparspak", "SpecializingFactorizations", "StableRNGs", "StaticArrays", "Test", "Unitful", "Zygote", "blis_jll"]

--- a/src/common.jl
+++ b/src/common.jl
@@ -532,18 +532,18 @@ corresponds to a column of `b`.
 """
 function __init_u0_from_Ab(A, b)
     u0 = similar(b, size(A, 2))
-    fill!(u0, false)
+    fill!(u0, zero(eltype(u0)))
     return u0
 end
 function __init_u0_from_Ab(A, b::AbstractMatrix)
     u0 = similar(b, size(A, 2), size(b, 2))
-    fill!(u0, false)
+    fill!(u0, zero(eltype(u0)))
     return u0
 end
 __init_u0_from_Ab(::SMatrix{S1, S2}, b) where {S1, S2} = zeros(SVector{S2, eltype(b)})
 function __init_u0_from_Ab(::SMatrix{S1, S2}, b::AbstractMatrix) where {S1, S2}
     u0 = similar(b, S2, size(b, 2))
-    fill!(u0, false)
+    fill!(u0, zero(eltype(u0)))
     return u0
 end
 function __init_u0_from_Ab(

--- a/test/Core/unitful.jl
+++ b/test/Core/unitful.jl
@@ -1,0 +1,45 @@
+using LinearSolve, Unitful, LinearAlgebra, Test, Random
+
+Random.seed!(173)
+
+# `__init_u0_from_Ab` used to build the default `u0` with `fill!(u0, false)`.
+# `false` is a strong zero for the usual number types, but it is not a valid
+# element of a Unitful array, so `init` threw `DimensionError: nm and false are
+# not dimensionally compatible` before any solver ran. See
+# SciML/LinearSolve.jl#173.
+@testset "Unitful right-hand side (#173)" begin
+    # A dimensionless system matrix acting on a dimensioned right-hand side.
+    # The units work out here, so this solves end to end and the solution
+    # carries the units of `b`.
+    A = rand(4, 4) + 4I
+    b = rand(4)u"nm"
+    xref = (A \ ustrip.(u"nm", b))u"nm"
+
+    @testset "init keeps the units of b" begin
+        cache = init(LinearProblem(A, b))
+        @test eltype(cache.u) === eltype(b)
+        @test all(iszero, cache.u)
+        @test unit(eltype(cache.u)) == u"nm"
+    end
+
+    for alg in (nothing, LUFactorization(), GenericLUFactorization())
+        @testset "$(alg === nothing ? "default" : nameof(typeof(alg)))" begin
+            sol = alg === nothing ? solve(LinearProblem(A, b)) :
+                solve(LinearProblem(A, b), alg)
+            @test SciMLBase.successful_retcode(sol)
+            @test unit(eltype(sol.u)) == u"nm"
+            @test ustrip.(u"nm", sol.u) ≈ ustrip.(u"nm", xref) rtol = 1.0e-10
+            @test ustrip.(u"nm", A * sol.u .- b) ≈ zeros(4) atol = 1.0e-12
+        end
+    end
+
+    # A matrix right-hand side takes the other `__init_u0_from_Ab` method.
+    @testset "matrix right-hand side" begin
+        B = rand(4, 2)u"nm"
+        cache = init(LinearProblem(A, B))
+        @test eltype(cache.u) === eltype(B)
+        @test all(iszero, cache.u)
+        sol = solve(LinearProblem(A, B))
+        @test ustrip.(u"nm", sol.u) ≈ A \ ustrip.(u"nm", B) rtol = 1.0e-10
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,7 @@ else
         core = function ()
             @time @safetestset "Basic Tests" include("Core/basictests.jl")
             @time @safetestset "EigenvalueProblem" include("Core/eigenvalue.jl")
+            @time @safetestset "Unitful" include("Core/unitful.jl")
             @time @safetestset "Batched RHS" include("Core/batch.jl")
             @time @safetestset "GenericLU naive back-solve" include("Core/genericlu_naive_ldiv.jl")
             @time @safetestset "Blocked generic_lufact! kernel" include("Core/blocked_lufact.jl")


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- `__init_u0_from_Ab` filled the default `u0` with `fill!(u0, false)`. `false` is a strong zero for the usual number types but is not a valid element of every array LinearSolve accepts, so `init` threw before reaching any solver. These three sites now use `zero(eltype(u0))`.
- Reported against Unitful in #173, where `init(LinearProblem(A, x))` on a `u"nm"` matrix failed with `DimensionError: nm and false are not dimensionally compatible`. Confirmed in isolation: `fill!(x, false)` throws on a `Quantity` vector while `fill!(x, zero(eltype(x)))` succeeds. `init` works after this change.
- No behaviour change for standard element types: `zero(T)` and `false` fill identically. Checked that `u0` is still all zeros, that a `Float32` problem keeps a `Float32` `u0`, and that solutions still match backslash.
- This does not make Unitful solves work, and does not close #173. Every solver path is blocked upstream: `\\`, `lu`, `qr` and `svd` all fail on a Unitful matrix in LinearAlgebra itself, Krylov.jl cannot build a workspace for `Quantity` element types, and SimpleGMRES hits dimensionally inconsistent tolerance arithmetic. Only `inv(A) * x` works. What changes here is that LinearSolve is no longer the first thing to fail.
- Full `GROUP=Core` suite passes with zero failures, Runic clean. The existing suite covers the changed path on every solve, since this is the default `u0` for any problem constructed without one.

AI Disclosure: Used Opus 5