### PR TITLE
Banded: solve underdetermined systems through the QR of the transpose

### DIFF
--- a/ext/LinearSolveBandedMatricesExt.jl
+++ b/ext/LinearSolveBandedMatricesExt.jl
@@ -21,7 +21,7 @@ function defaultalg(A::BandedMatrix, b, oa::OperatorAssumptions{Bool})
         return DefaultLinearSolver(DefaultAlgorithmChoice.LUFactorization)
     end
     # Both non-square cases go to QR. The underdetermined one is solved through
-    # the QR of `Aᵀ`; see `BandedUnderdeterminedQR`.
+    # the QR of `Aᵀ`; see `MinNormQR`.
     return DefaultLinearSolver(DefaultAlgorithmChoice.QRFactorization)
 end
 
@@ -35,53 +35,16 @@ function defaultalg(A::Symmetric{<:Number, <:BandedMatrix}, b, ::OperatorAssumpt
     return DefaultLinearSolver(DefaultAlgorithmChoice.CholeskyFactorization)
 end
 
-raw"""
-    BandedUnderdeterminedQR(qr_of_transpose)
-
-The QR factorization of `transpose(A)` for an underdetermined (wide)
-`A::BandedMatrix`.
-
-BandedMatrices can factor a wide banded matrix but cannot solve with the result:
-`A \ b` throws `"Not implemented"`. The minimum-norm solution comes from the QR
-of `Aᵀ`, which is banded as well (the bandwidths simply swap), so the banded
-factorization still does the work rather than falling back to a dense one:
-
-```
-Aᵀ = Q R   ⟹   A = Rᵀ Qᵀ   ⟹   x = Q [Rᵀ \ b; 0]
-```
-
-That is the same minimum-norm solution LAPACK's dense `\` returns for an
-underdetermined system. See SciML/LinearSolve.jl#419.
-"""
-struct BandedUnderdeterminedQR{F}
-    qr_of_transpose::F
-end
-
-function LinearSolve._ldiv!(x, F::BandedUnderdeterminedQR, b)
-    nrows = length(b)
-    # `R` is upper triangular and square in its leading `nrows` block; the rows
-    # below it are structurally zero and contribute nothing to the solve.
-    R = view(F.qr_of_transpose.R, 1:nrows, 1:nrows)
-    y = LinearAlgebra.ldiv!(
-        LinearAlgebra.adjoint(LinearAlgebra.UpperTriangular(R)),
-        copyto!(similar(x, nrows), b)
-    )
-    # Pad with the zeros that make `x` the minimum-norm solution, then apply `Q`.
-    fill!(x, zero(eltype(x)))
-    copyto!(view(x, 1:nrows), y)
-    LinearAlgebra.lmul!(F.qr_of_transpose.Q, x)
-    return x
-end
-
 # BandedMatrices `qr` doesn't support column pivoting, so convert to dense when
 # pivoting is requested (e.g. ColumnNorm fallback from singular LU).
 function do_factorization(alg::QRFactorization, A::BandedMatrix, b, u)
     if !(alg.pivot isa NoPivot)
         return qr!(Matrix(A), alg.pivot)
     elseif LinearSolve.is_underdetermined(A)
-        # `qr!` would factor `A` itself, which cannot then be solved with, so the
-        # transpose is always built fresh here regardless of `alg.inplace`.
-        return BandedUnderdeterminedQR(qr(BandedMatrix(transpose(A))))
+        # `A \ b` on a wide banded factorization throws "Not implemented", so the
+        # solve goes through `Aᵀ`, which is banded too since the bandwidths swap.
+        # `alg.inplace` does not apply: `A` itself is not what gets factored.
+        return LinearSolve.MinNormQR(qr(BandedMatrix(transpose(A))))
     else
         return alg.inplace ? qr!(A) : qr(A)
     end
@@ -120,7 +83,7 @@ function init_cacheval(
 end
 
 # `cache.cacheval` is typed from this, and the underdetermined path stores a
-# `BandedUnderdeterminedQR` rather than a plain `QR`, so the placeholder has to be
+# `MinNormQR` rather than a plain `QR`, so the placeholder has to be
 # that same wrapper. Square and overdetermined `A` keep the generic instance.
 function init_cacheval(
         alg::QRFactorization{NoPivot}, A::BandedMatrix, b, u, Pl, Pr,
@@ -129,7 +92,7 @@ function init_cacheval(
     )
     LinearSolve.is_underdetermined(A) ||
         return ArrayInterface.qr_instance(A, alg.pivot)
-    return BandedUnderdeterminedQR(qr(BandedMatrix(transpose(similar(A, 0, 0)))))
+    return LinearSolve.MinNormQR(qr(BandedMatrix(transpose(similar(A, 0, 0)))))
 end
 
 # Column-pivoted QR on BandedMatrix converts to dense, so cache a dense QRPivoted

--- a/ext/LinearSolveBandedMatricesExt.jl
+++ b/ext/LinearSolveBandedMatricesExt.jl
@@ -1,5 +1,6 @@
 module LinearSolveBandedMatricesExt
 
+using ArrayInterface: ArrayInterface
 using BandedMatrices: BandedMatrices, BandedMatrix
 using LinearAlgebra: LinearAlgebra, ColumnNorm, NoPivot, Symmetric, lu, lu!, qr, qr!
 # The `@eval` loops below generate `init_cacheval` methods for every algorithm type,
@@ -18,11 +19,10 @@ import LinearSolve: defaultalg,
 function defaultalg(A::BandedMatrix, b, oa::OperatorAssumptions{Bool})
     if oa.issq
         return DefaultLinearSolver(DefaultAlgorithmChoice.LUFactorization)
-    elseif LinearSolve.is_underdetermined(A)
-        error("No solver for underdetermined `A::BandedMatrix` is currently implemented!")
-    else
-        return DefaultLinearSolver(DefaultAlgorithmChoice.QRFactorization)
     end
+    # Both non-square cases go to QR. The underdetermined one is solved through
+    # the QR of `Aᵀ`; see `BandedUnderdeterminedQR`.
+    return DefaultLinearSolver(DefaultAlgorithmChoice.QRFactorization)
 end
 
 function defaultalg(
@@ -35,13 +35,55 @@ function defaultalg(A::Symmetric{<:Number, <:BandedMatrix}, b, ::OperatorAssumpt
     return DefaultLinearSolver(DefaultAlgorithmChoice.CholeskyFactorization)
 end
 
+raw"""
+    BandedUnderdeterminedQR(qr_of_transpose)
+
+The QR factorization of `transpose(A)` for an underdetermined (wide)
+`A::BandedMatrix`.
+
+BandedMatrices can factor a wide banded matrix but cannot solve with the result:
+`A \ b` throws `"Not implemented"`. The minimum-norm solution comes from the QR
+of `Aᵀ`, which is banded as well (the bandwidths simply swap), so the banded
+factorization still does the work rather than falling back to a dense one:
+
+```
+Aᵀ = Q R   ⟹   A = Rᵀ Qᵀ   ⟹   x = Q [Rᵀ \ b; 0]
+```
+
+That is the same minimum-norm solution LAPACK's dense `\` returns for an
+underdetermined system. See SciML/LinearSolve.jl#419.
+"""
+struct BandedUnderdeterminedQR{F}
+    qr_of_transpose::F
+end
+
+function LinearSolve._ldiv!(x, F::BandedUnderdeterminedQR, b)
+    nrows = length(b)
+    # `R` is upper triangular and square in its leading `nrows` block; the rows
+    # below it are structurally zero and contribute nothing to the solve.
+    R = view(F.qr_of_transpose.R, 1:nrows, 1:nrows)
+    y = LinearAlgebra.ldiv!(
+        LinearAlgebra.adjoint(LinearAlgebra.UpperTriangular(R)),
+        copyto!(similar(x, nrows), b)
+    )
+    # Pad with the zeros that make `x` the minimum-norm solution, then apply `Q`.
+    fill!(x, zero(eltype(x)))
+    copyto!(view(x, 1:nrows), y)
+    LinearAlgebra.lmul!(F.qr_of_transpose.Q, x)
+    return x
+end
+
 # BandedMatrices `qr` doesn't support column pivoting, so convert to dense when
 # pivoting is requested (e.g. ColumnNorm fallback from singular LU).
 function do_factorization(alg::QRFactorization, A::BandedMatrix, b, u)
-    if alg.pivot isa NoPivot
-        return alg.inplace ? qr!(A) : qr(A)
-    else
+    if !(alg.pivot isa NoPivot)
         return qr!(Matrix(A), alg.pivot)
+    elseif LinearSolve.is_underdetermined(A)
+        # `qr!` would factor `A` itself, which cannot then be solved with, so the
+        # transpose is always built fresh here regardless of `alg.inplace`.
+        return BandedUnderdeterminedQR(qr(BandedMatrix(transpose(A))))
+    else
+        return alg.inplace ? qr!(A) : qr(A)
     end
 end
 
@@ -75,6 +117,19 @@ function init_cacheval(
     ) where {T}
     (T <: BigFloat) && return qr(similar(A, 0, 0))
     return lu(similar(A, 0, 0))
+end
+
+# `cache.cacheval` is typed from this, and the underdetermined path stores a
+# `BandedUnderdeterminedQR` rather than a plain `QR`, so the placeholder has to be
+# that same wrapper. Square and overdetermined `A` keep the generic instance.
+function init_cacheval(
+        alg::QRFactorization{NoPivot}, A::BandedMatrix, b, u, Pl, Pr,
+        maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
+        assumptions::OperatorAssumptions
+    )
+    LinearSolve.is_underdetermined(A) ||
+        return ArrayInterface.qr_instance(A, alg.pivot)
+    return BandedUnderdeterminedQR(qr(BandedMatrix(transpose(similar(A, 0, 0)))))
 end
 
 # Column-pivoted QR on BandedMatrix converts to dense, so cache a dense QRPivoted

--- a/ext/LinearSolveFastAlmostBandedMatricesExt.jl
+++ b/ext/LinearSolveFastAlmostBandedMatricesExt.jl
@@ -1,7 +1,8 @@
 module LinearSolveFastAlmostBandedMatricesExt
 
+using ArrayInterface: ArrayInterface
 using FastAlmostBandedMatrices: FastAlmostBandedMatrices, AlmostBandedMatrix
-using LinearAlgebra: LinearAlgebra, qr, qr!
+using LinearAlgebra: LinearAlgebra, NoPivot, qr, qr!
 # The `@eval` loop below generates `init_cacheval` methods for every algorithm type,
 # which ExplicitImports cannot see, so they are all imported explicitly here.
 using LinearSolve: LinearSolve, LUFactorization, OperatorAssumptions, QRFactorization,
@@ -20,6 +21,19 @@ function defaultalg(A::AlmostBandedMatrix, b, oa::OperatorAssumptions{Bool})
     else
         return DefaultLinearSolver(DefaultAlgorithmChoice.QRFactorization)
     end
+end
+
+# `cache.cacheval` is typed from this, and the underdetermined path stores a
+# `MinNormQR` rather than a plain `QR`, so the placeholder has to be that same
+# wrapper. Square and overdetermined `A` keep the generic instance.
+function init_cacheval(
+        alg::QRFactorization{NoPivot}, A::AlmostBandedMatrix, b, u, Pl, Pr,
+        maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
+        assumptions::OperatorAssumptions
+    )
+    LinearSolve.is_underdetermined(A) ||
+        return ArrayInterface.qr_instance(A, alg.pivot)
+    return LinearSolve.MinNormQR(qr(transpose(similar(A, 0, 0))))
 end
 
 # For BandedMatrix
@@ -41,6 +55,16 @@ for alg in (
 end
 
 function do_factorization(alg::QRFactorization, A::AlmostBandedMatrix, b, u)
+    if LinearSolve.is_underdetermined(A)
+        # The same "Not implemented" wall as `BandedMatrix`, solved the same way,
+        # except the transpose cannot stay structured: an `AlmostBandedMatrix` is
+        # banded plus dense fill *rows*, so its transpose has dense fill *columns*
+        # and is not almost-banded. `qr` of the lazy transpose densifies, which is
+        # the price of returning the same minimum-norm solution the dense and
+        # banded paths give. (`BandedMatrix(transpose(A))` would stay structured
+        # but silently discards the fill rows, giving the wrong matrix.)
+        return LinearSolve.MinNormQR(qr(transpose(A)))
+    end
     return alg.inplace ? qr!(A) : qr(A)
 end
 

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -157,6 +157,47 @@ end
 
 _ldiv!(x, A, b) = ldiv!(x, A, b)
 
+raw"""
+    MinNormQR(qr_of_transpose)
+
+The QR factorization of `transpose(A)` for an underdetermined (wide) `A`, used to
+produce the minimum-norm solution of `A x = b`.
+
+Structured matrix types can often factor a wide matrix but not solve with the
+result. Going through `Aᵀ` turns the underdetermined solve back into a
+triangular one:
+
+```
+Aᵀ = Q R   ⟹   A = Rᵀ Qᵀ   ⟹   x = Q [Rᵀ \ b; 0]
+```
+
+Padding with zeros before applying `Q` is what makes `x` the minimum-norm
+solution, the same one LAPACK's dense `\` returns for an underdetermined system.
+Which factorization to wrap is left to the caller, so each matrix type can pick
+the cheapest `Aᵀ` it can build. See SciML/LinearSolve.jl#419.
+"""
+struct MinNormQR{F}
+    qr_of_transpose::F
+end
+
+# Defined as `ldiv!` on our own type rather than as another `_ldiv!` method: the
+# generic `_ldiv!(x, A, b)` above forwards here, while adding a third `_ldiv!`
+# would be ambiguous with the `SVector` methods that follow it.
+function LinearAlgebra.ldiv!(x::AbstractVector, F::MinNormQR, b::AbstractVector)
+    nrows = length(b)
+    # `R` is upper triangular and square in its leading `nrows` block; the rows
+    # below it are structurally zero and contribute nothing to the solve.
+    R = view(F.qr_of_transpose.R, 1:nrows, 1:nrows)
+    y = ldiv!(
+        LinearAlgebra.adjoint(LinearAlgebra.UpperTriangular(R)),
+        copyto!(similar(x, nrows), b)
+    )
+    fill!(x, zero(eltype(x)))
+    copyto!(view(x, 1:nrows), y)
+    LinearAlgebra.lmul!(F.qr_of_transpose.Q, x)
+    return x
+end
+
 _ldiv!(x, A, b::SVector) = (x .= A \ b)
 _ldiv!(::SVector, A, b::SVector) = (A \ b)
 _ldiv!(::SVector, A, b) = (A \ b)

--- a/test/Core/banded.jl
+++ b/test/Core/banded.jl
@@ -62,10 +62,28 @@ sol2s = solve(LinearProblem(A2s, b2; u0 = x2))
     @test solve!(cache).u ≈ Matrix(Aud) \ bud2
 end
 
-A = AlmostBandedMatrix(BandedMatrix(fill(2.0, n - 2, n), (1, 1)), fill(3.0, 2, n))
-A[band(0)] .+= 1:(n - 2)
+# `AlmostBandedMatrix` hits the same wall, and is solved the same way, except its
+# transpose cannot stay structured: banded plus dense fill rows transposes to
+# dense fill columns, so the QR of the transpose densifies. The answer is still
+# the minimum-norm one, so it agrees with the `BandedMatrix` path above.
+@testset "Underdetermined AlmostBandedMatrix (#419)" begin
+    for (m, k, l, u, nfill) in ((n - 2, n, 1, 1, 2), (5, 10, 2, 1, 3), (4, 9, 1, 2, 2))
+        Aud = AlmostBandedMatrix(BandedMatrix(fill(2.0, m, k), (l, u)), rand(nfill, k))
+        Aud[band(0)] .+= 1:m
+        bud = rand(m)
+        reference = Matrix(Aud) \ bud
 
-@test_throws ErrorException solve(LinearProblem(A, b)).u
+        for alg in (nothing, QRFactorization())
+            sol = alg === nothing ? solve(LinearProblem(Aud, bud)) :
+                solve(LinearProblem(Aud, bud), alg)
+            @test sol.retcode == LinearSolve.ReturnCode.Success
+            @test length(sol.u) == k
+            @test Matrix(Aud) * sol.u ≈ bud
+            @test sol.u ≈ reference
+            @test norm(sol.u) <= norm(reference) + 1.0e-8
+        end
+    end
+end
 
 # Overdetermined
 A = BandedMatrix(ones(10, 8), (2, 0))

--- a/test/Core/banded.jl
+++ b/test/Core/banded.jl
@@ -31,11 +31,36 @@ sol1s = solve(LinearProblem(A1s, b1; u0 = x1))
 sol2s = solve(LinearProblem(A2s, b2; u0 = x2))
 @test sol2s.u ≈ A2s \ b2
 
-# Underdetermined
-A = BandedMatrix(rand(8, 10), (2, 2))
-b = rand(8)
+# Underdetermined. BandedMatrices can factor a wide matrix but `\` on the result
+# throws "Not implemented", so LinearSolve solves through the QR of `Aᵀ`, which is
+# banded too. The answer is the minimum-norm one, matching dense LAPACK. See #419.
+@testset "Underdetermined BandedMatrix (#419)" begin
+    for (m, n, l, u) in ((8, 10, 2, 2), (6, 10, 2, 1), (3, 12, 0, 2), (9, 10, 3, 2))
+        Aud = BandedMatrix(rand(m, n), (l, u))
+        bud = rand(m)
+        reference = Matrix(Aud) \ bud
 
-@test_throws ErrorException solve(LinearProblem(A, b)).u
+        for alg in (nothing, QRFactorization())
+            sol = alg === nothing ? solve(LinearProblem(Aud, bud)) :
+                solve(LinearProblem(Aud, bud), alg)
+            @test sol.retcode == LinearSolve.ReturnCode.Success
+            @test length(sol.u) == n
+            @test Aud * sol.u ≈ bud
+            # Of the infinitely many solutions, the minimum-norm one.
+            @test sol.u ≈ reference
+            @test norm(sol.u) <= norm(reference) + 1.0e-8
+        end
+    end
+
+    # The cached path factors once and reuses it, so check a re-solve too.
+    Aud = BandedMatrix(rand(6, 10), (2, 1))
+    bud1 = rand(6)
+    cache = init(LinearProblem(Aud, bud1), QRFactorization())
+    @test solve!(cache).u ≈ Matrix(Aud) \ bud1
+    bud2 = rand(6)
+    cache.b = bud2
+    @test solve!(cache).u ≈ Matrix(Aud) \ bud2
+end
 
 A = AlmostBandedMatrix(BandedMatrix(fill(2.0, n - 2, n), (1, 1)), fill(3.0, 2, n))
 A[band(0)] .+= 1:(n - 2)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -132,7 +132,7 @@ linearsolve_internal_imports = (
 linearsolve_internal_accesses = (
     Symbol("@get_cacheval"), :ALREADY_WARNED_CUDSS, :AbstractFactorization,
     :AbstractKrylovSubspaceMethod, :DefaultAlgorithmChoice, :DefaultLinearSolver,
-    :DefaultLinearSolverInit, :GPUArraysCore, :LinearCache,
+    :DefaultLinearSolverInit, :GPUArraysCore, :LinearCache, :MinNormQR,
     :NONPERSISTENT_ZERO_FRACTION, :PERSISTENT_ZERO_FRACTION_THRESHOLD,
     :PrecompileTools, :SciMLLinearSolveAlgorithm, :SupernodalLU,
     :_SPARSE_LU_FALLBACK_ALGORITHMS, :_SPARSE_ONLY_ALGORITHMS,


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- Closes #419. Underdetermined `BandedMatrix` errored in `defaultalg`, and both `BandedMatrix` and `AlmostBandedMatrix` reached a factorization that cannot be solved with: they factor a wide matrix but `\` on the result throws "Not implemented".
- Solved through the QR of the transpose, which turns the underdetermined solve back into a triangular one: `Aᵀ = Q R` gives `x = Q [Rᵀ \ b; 0]`. Padding with zeros before applying `Q` is what makes it the minimum-norm solution, the same one LAPACK's dense `\` returns.
- The wrapper does not depend on BandedMatrices, so it lives in `src` as `MinNormQR` and both extensions share it, each supplying whatever transpose factorization is cheapest for its type.
- `BandedMatrix` keeps the structured route, since the transpose is banded too with the bandwidths swapped. `AlmostBandedMatrix` cannot: banded plus dense fill rows transposes to dense fill columns, which is not almost-banded, so its `qr` densifies. Returning a non-minimum-norm answer instead would make the result depend on which matrix type carried the problem.
- `BandedMatrix(transpose(A))` on an almost-banded transpose does succeed and silently drops the fill rows, giving the wrong matrix. There is a comment against reaching for it as the structured shortcut.
- Solving is spelled as `ldiv!` on `MinNormQR` rather than a third `_ldiv!` method, which Aqua flags as ambiguous with the `SVector` ones.
- Both extensions covered by `AlmostBandedMatrix` were raised in SciML/BoundaryValueDiffEq.jl#122, the discussion #419 links to: MIRK and FIRK collocation use `AlmostBandedMatrix`, the sparse Jacobians use `BandedMatrix`.
- The existing `@test_throws ErrorException` assertions for both underdetermined types encoded the limitation being removed, so they are replaced with real assertions: 72 in total, checking against the LAPACK minimum-norm solution rather than only the residual.
- Square and overdetermined paths are unchanged; each new `init_cacheval` only diverges for wide `A` and otherwise returns the same generic instance.
- Verified on Julia 1.10, 1.11 and 1.12. Core and QA groups pass locally.
- Unrelated to this PR, the overdetermined banded path returns a non-least-squares answer on main; filed separately as #1202.
