### PR TITLE
Banded: stop dropping the QR fill when factoring in place

### DIFF
--- a/ext/LinearSolveBandedMatricesExt.jl
+++ b/ext/LinearSolveBandedMatricesExt.jl
@@ -45,9 +45,15 @@ function do_factorization(alg::QRFactorization, A::BandedMatrix, b, u)
         # solve goes through `Aᵀ`, which is banded too since the bandwidths swap.
         # `alg.inplace` does not apply: `A` itself is not what gets factored.
         return LinearSolve.MinNormQR(qr(BandedMatrix(transpose(A))))
-    else
-        return alg.inplace ? qr!(A) : qr(A)
     end
+    # `alg.inplace` is deliberately not honoured here. The R of a banded QR has
+    # upper bandwidth `l + u`, so factoring into `A`'s own `(l, u)` storage has
+    # nowhere to put the fill and drops it, silently returning a wrong answer for
+    # square systems and a non-least-squares one for overdetermined ones. `qr`
+    # allocates storage of the right bandwidth, so the copy is what makes the
+    # result correct rather than an avoidable overhead. See
+    # SciML/LinearSolve.jl#1202.
+    return qr(A)
 end
 
 function do_factorization(alg::LUFactorization, A::BandedMatrix, b, u)

--- a/test/Core/banded.jl
+++ b/test/Core/banded.jl
@@ -85,6 +85,44 @@ end
     end
 end
 
+# The R of a banded QR has upper bandwidth `l + u`, so factoring in place into
+# `A`'s own `(l, u)` storage drops the fill. That used to return a wrong answer
+# for square systems and a non-least-squares one for overdetermined ones, with no
+# error or warning. See #1202.
+@testset "Banded QR keeps the l+u fill (#1202)" begin
+    for (m, k, l, u) in (
+            (10, 6, 2, 1), (20, 8, 3, 2), (30, 11, 4, 3),
+            (10, 6, 2, 0), (10, 6, 0, 2),
+        )
+        Aod = BandedMatrix(brand(m, k, l, u))
+        bod = rand(m)
+        reference = Matrix(Aod) \ bod
+        sol = solve(LinearProblem(Aod, bod), QRFactorization())
+        @test sol.retcode == LinearSolve.ReturnCode.Success
+        @test sol.u ≈ reference
+        # The least-squares optimum, not merely some solution.
+        @test norm(Aod * sol.u - bod) <= norm(Aod * reference - bod) + 1.0e-10
+    end
+
+    # Square banded reaches QR only when asked for explicitly, and was wrong
+    # outright there rather than just suboptimal.
+    for (k, l, u) in ((8, 2, 1), (15, 3, 2))
+        Asq = BandedMatrix(brand(k, k, l, u))
+        Asq[band(0)] .+= k
+        bsq = rand(k)
+        sol = solve(LinearProblem(Asq, bsq), QRFactorization())
+        @test sol.retcode == LinearSolve.ReturnCode.Success
+        @test sol.u ≈ Matrix(Asq) \ bsq
+        @test norm(Asq * sol.u - bsq) < 1.0e-10
+    end
+
+    # `inplace = true` is the default and must agree with the explicit opt-out.
+    Aip = BandedMatrix(brand(12, 7, 2, 2))
+    bip = rand(12)
+    @test solve(LinearProblem(Aip, bip), QRFactorization()).u ≈
+        solve(LinearProblem(Aip, bip), QRFactorization(NoPivot(), false)).u
+end
+
 # Overdetermined
 A = BandedMatrix(ones(10, 8), (2, 0))
 b = rand(10)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

- Closes #1202. The R of a banded QR has upper bandwidth `l + u`, but `qr!(A)` factors into `A`'s own `(l, u)` storage, so the fill was dropped with no error or warning.
- `QRFactorization` defaults to `inplace = true`, so this was the path taken unless the caller opted out.
- Square systems came back simply wrong, not just suboptimal: residual 0.0733832 against 1.9e-16 for an 8x8 with bandwidths (2, 1). Overdetermined ones came back non-least-squares, for instance 1.93972 against an optimum of 1.83864 at 20x8.
- The fix stops honouring `alg.inplace` for `BandedMatrix`. `qr` allocates storage of the right bandwidth, so the copy is what makes the result correct rather than overhead worth avoiding.
- `LUFactorization` is unaffected, checked rather than assumed: `lu!` errors on unpadded input instead of dropping fill, and square banded goes to LU by default, so the default square path was never wrong. `AlmostBandedMatrix` is unaffected as well.
- Tests cover five overdetermined shapes including both zero-bandwidth edges, two square sizes, and that the default agrees with an explicit `inplace = false`. They were confirmed to fail without the fix.
- Verified on Julia 1.10 and 1.12. Core and QA groups pass locally.

AI Disclosure: Used Opus 5