### PR TITLE
Set sequential release versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.9.0"
+version = "5.10.0"
 authors = ["SciML"]
 
 [deps]

--- a/lib/LinearSolveAutotune/Project.toml
+++ b/lib/LinearSolveAutotune/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearSolveAutotune"
 uuid = "67398393-80e8-4254-b7e4-1b9a36a3c5b6"
 authors = ["SciML"]
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/lib/LinearSolvePyAMG/Project.toml
+++ b/lib/LinearSolvePyAMG/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearSolvePyAMG"
 uuid = "7a56c47d-7ab1-4e99-b0e3-2952e463d64a"
 authors = ["SciML"]
-version = "1.3.1"
+version = "1.3.2"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| LinearSolve | 5.9.0 | 5.9.0 | 5.10.0 | minor |
| LinearSolveAutotune | 1.13.0 | 1.13.0 | 1.14.0 | minor |
| LinearSolvePyAMG | 1.3.1 | 1.3.1 | 1.3.2 | patch |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:              | Pass  Total   Time / SupernodalLU Allocation QA |    8      8  15.0s / Test Summary:     | Pass  Total     Time / Quality Assurance |   48     48  5m13.1s / Testing LinearSolve tests passed`
- `GROUP=LinearSolveAutotune /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:             | Pass  Total     Time / LinearSolveAutotune Tests |  174    174  6m53.9s / Testing LinearSolve tests passed`
- `GROUP=LinearSolvePyAMG /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:          | Pass  Total   Time / LinearSolvePyAMG Tests |   20     20  15.9s / Testing LinearSolve tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:              | Pass  Total  Time / SpecializingFactorizations |   18     18  3.1s / Test Summary:        | Pass  Total  Time / LinearSolveSTRUMPACK |   13     13  3.3s / Testing LinearSolve tests passed`
- `GROUP=LinearSolveAutotune_QA /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:             | Pass  Total     Time / Code quality (Aqua + JET) |   21     21  4m03.1s / Testing LinearSolve tests passed`
- `GROUP=LinearSolvePyAMG_QA /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:             | Pass  Total     Time / Code quality (Aqua + JET) |   21     21  1m54.3s / Testing LinearSolve tests passed`
- General registry cross-check: https://github.com/JuliaRegistries/General/commit/68b34239ba8d0f990dbb4e07a0fd3181f35b28c8
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml lib/LinearSolveAutotune/Project.toml lib/LinearSolvePyAMG/Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- LinearSolve: `@JuliaRegistrator register`
- LinearSolveAutotune: `@JuliaRegistrator register subdir=lib/LinearSolveAutotune`
- LinearSolvePyAMG: `@JuliaRegistrator register subdir=lib/LinearSolvePyAMG`