### PR TITLE
test: bound HSL environment SciMLTesting

### DIFF
--- a/test/LinearSolveHSL/Project.toml
+++ b/test/LinearSolveHSL/Project.toml
@@ -7,3 +7,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+SciMLTesting = "2.8"


### PR DESCRIPTION
Adds the missing SciMLTesting compatibility floor to the isolated `LinearSolveHSL` test environment. It now matches the root and QA environments at `2.8`.

The diff changes only `test/LinearSolveHSL/Project.toml`: no dependency entries, package source, or license surface changed.

Ignore until reviewed by @ChrisRackauckas.

## Verification

- `/home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=test/LinearSolveHSL -e 'using Pkg; Pkg.develop(path = pwd()); Pkg.resolve(); Pkg.status()'`
  - resolved the local LinearSolve checkout with `SciMLTesting v2.8.0`.
- `/home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=test/LinearSolveHSL -e 'using Pkg; Pkg.develop(path = pwd()); Pkg.resolve(); Pkg.status()'`
  - resolved the same test environment with `SciMLTesting v2.8.0`.
- `/home/crackauc/.juliaup/bin/julia +1 --project=@runic -m Runic --check .`
- `typos --config .typos.toml test/LinearSolveHSL/Project.toml`
- `git diff --check`

I did not run `GROUP=LinearSolveHSL`: this machine has no functional `libHSL`, and the test file's nonfunctional-HSL path reports a skip. This PR does not modify that behavior.