### PR TITLE
Preserve scalar arithmetic for small GenericLU systems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.10.0"
+version = "5.10.1"
 authors = ["SciML"]
 
 [deps]

--- a/src/blocked_lufact.jl
+++ b/src/blocked_lufact.jl
@@ -53,9 +53,7 @@ end
     return kp, amax
 end
 
-# Unblocked factorization for the whole matrix at small sizes. Identical
-# control flow to the scalar `generic_lufact!` RowMaximum path, with hoisted
-# multipliers, `muladd`, and `@simd ivdep` on the column updates.
+# Keep small factorizations identical to the scalar `generic_lufact!` RowMaximum path.
 function _blocked_lu_unblocked!(A::AbstractMatrix{T}, ipiv, m::Int, n::Int) where {T}
     minmn = min(m, n)
     info = 0
@@ -79,8 +77,8 @@ function _blocked_lu_unblocked!(A::AbstractMatrix{T}, ipiv, m::Int, n::Int) wher
         end
         for j in (k + 1):n
             Akj = A[k, j]
-            @simd ivdep for i in (k + 1):m
-                A[i, j] = muladd(-A[i, k], Akj, A[i, j])
+            for i in (k + 1):m
+                A[i, j] -= A[i, k] * Akj
             end
         end
     end

--- a/test/Core/blocked_lufact.jl
+++ b/test/Core/blocked_lufact.jl
@@ -41,6 +41,17 @@ end
         @test !endswith(String(m_generic.file), "blocked_lufact.jl")
     end
 
+    @testset "small path matches scalar arithmetic" begin
+        A = randn(MersenneTwister(1234), 4, 4)
+        F = LinearSolve.generic_lufact!(copy(A), RowMaximum(), _ipiv(4); check = false)
+        A_scalar_dispatch = @view copy(A)[:, [1, 2, 3, 4]]
+        F_scalar = LinearSolve.generic_lufact!(
+            A_scalar_dispatch, RowMaximum(), _ipiv(4); check = false
+        )
+        @test F.factors == F_scalar.factors
+        @test F.ipiv == F_scalar.ipiv
+    end
+
     @testset "residual, square, default params ($T)" for T in (Float64, Float32)
         for n in (
                 1, 2, 3, 5, 7, 8, 9, 13, 16, 17, 31, 32, 33, 40, 41, 63, 64, 65,


### PR DESCRIPTION
## What changed

For matrices of order at most eight, make the blocked GenericLU entry point use the same update arithmetic as the vendored scalar `generic_lufact!` implementation. This avoids the architecture-sensitive Broyden trajectory regression tracked in https://github.com/SciML/NonlinearSolve.jl/issues/1158 while retaining the blocked kernel for larger matrices.

This also adds a focused comparison against the scalar implementation and bumps LinearSolve from 5.10.0 to 5.10.1.

Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failure before the fix

Clean NonlinearSolve master fails deterministically on macOS aarch64 with LinearSolve 5.7.0 or later:

```text
4: Wood function | alg #2: Test Failed
  Expression: norm(res, Inf) ≤ ϵ
   Evaluated: 0.00487307057804981 ≤ 0.001

23 Test Problems: Broyden | 93 passed, 1 failed, 21 broken
```

The same focused LinearSolve test added here fails before the source change on Linux x86_64, Julia 1.12.6:

```text
small path matches scalar arithmetic | 1 pass 1 fail 2 total
blocked generic_lufact! kernel       | 526 pass 1 fail 527 total
```

The failing assertion is exact factor equality between the small strided path and the vendored scalar implementation.

## Boundary

The last green NonlinearSolve macOS run resolved LinearSolve 5.6.0. The first failing run resolved LinearSolve 5.7.0 with the other relevant dependencies unchanged. A formal source bisect identified https://github.com/SciML/LinearSolve.jl/commit/6bbb233daa4bd647fa289b96b4a3d9ff6fe0b7e0 as the first trajectory-changing commit.

With current NonlinearSolve sources on Linux x86_64, the Wood problem changes from 1,014 function evaluations on LinearSolve 5.6.0 to 325 on 5.7.0. Both converge on Linux, but macOS aarch64 stops at residual `0.00487307057804981`. The test tolerance is unchanged.

## Verification after the fix

Focused LinearSolve tests, Julia 1.12.6:

```text
blocked generic_lufact! kernel                       | 527 pass 527 total
GenericLUFactorization through the blocked kernel    | 72 pass 72 total
```

Focused NonlinearSolve Wood problem with this checkout:

```text
pkgversion(LinearSolve) = v"5.10.1"
sol.retcode = SciMLBase.ReturnCode.Success
sol.stats = SciMLBase.NLStats(1014, 2, 0, 0, 1012)
norm(res, Inf) = 2.5757174171303632e-14
```

Full local validation:

```bash
GROUP=Core JULIA_NUM_THREADS=2 julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'
GROUP=QA JULIA_NUM_THREADS=2 julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'
```

```text
Blocked generic_lufact! kernel | 599 pass 599 total 32.3s
SpecializingFactorizations     | 18 pass 18 total 2.7s
Testing LinearSolve tests passed
Quality Assurance | 49 pass 49 total 12m39.3s
Testing LinearSolve tests passed
```

The following checks also exited successfully with no output:

```bash
julia +1.12 --startup-file=no -e 'using Runic; exit(Runic.main(["--check", "src/blocked_lufact.jl", "test/Core/blocked_lufact.jl"]))'
typos src/blocked_lufact.jl test/Core/blocked_lufact.jl Project.toml
git diff --check
```

I could not execute macOS aarch64 locally. The macOS failing-before evidence comes from clean-master GitHub Actions; the new arithmetic-equivalence test fails before and passes after on Linux.

## Links

- Tracking issue: https://github.com/SciML/NonlinearSolve.jl/issues/1158
- Exact clean-master macOS failure: https://github.com/SciML/NonlinearSolve.jl/actions/runs/31767689486/job/94669721733
- Exact assigned-PR macOS failure: https://github.com/SciML/NonlinearSolve.jl/actions/runs/31797173620/job/94759239832
- Last green macOS control: https://github.com/SciML/NonlinearSolve.jl/actions/runs/31291773452/job/93190218073
- First trajectory-changing commit: https://github.com/SciML/LinearSolve.jl/commit/6bbb233daa4bd647fa289b96b4a3d9ff6fe0b7e0
