### PR TITLE
Carry the forward preconditioners into the adjoint solve

### DIFF
--- a/ext/LinearSolveChainRulesCoreExt.jl
+++ b/ext/LinearSolveChainRulesCoreExt.jl
@@ -55,6 +55,8 @@ function CRC.rrule(
         ∂∅ = NoTangent()
 
         ∂u = hasproperty(∂sol, :u) ? ∂sol.u : ∂sol
+        adj_alg = sensealg.linsolve === missing ? alg : sensealg.linsolve
+        adj_Pl, adj_Pr = LinearSolve._adjoint_precs(adj_alg, sensealg, cache.Pl, cache.Pr)
         if sensealg.linsolve === missing
             cached_adjoint_solution = LinearSolve._adjoint_factorization_solve(
                 alg, cache.cacheval, cache.A, ∂u
@@ -63,18 +65,23 @@ function CRC.rrule(
                 cached_adjoint_solution
             elseif alg isa AbstractKrylovSubspaceMethod
                 LinearSolve._adjoint_krylov_solve(
-                    alg, cache.A, ∂u; cache.abstol, cache.reltol, cache.verbose
+                    alg, cache.A, ∂u; cache.abstol, cache.reltol, cache.verbose,
+                    Pl = adj_Pl, Pr = adj_Pr
                 )
             elseif alg isa DefaultLinearSolver
                 LinearSolve.defaultalg_adjoint_eval(cache, ∂u)
             else
                 invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
-                solve(invprob, alg; cache.abstol, cache.reltol, cache.verbose).u
+                solve(
+                    invprob, alg; cache.abstol, cache.reltol, cache.verbose,
+                    Pl = adj_Pl, Pr = adj_Pr
+                ).u
             end
         else
             invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
             λ = solve(
-                invprob, sensealg.linsolve; cache.abstol, cache.reltol, cache.verbose
+                invprob, sensealg.linsolve; cache.abstol, cache.reltol, cache.verbose,
+                Pl = adj_Pl, Pr = adj_Pr
             ).u
         end
 

--- a/ext/LinearSolveEnzymeExt.jl
+++ b/ext/LinearSolveEnzymeExt.jl
@@ -720,11 +720,15 @@ function EnzymeRules.reverse(
             cached_adjoint_solution
         elseif _linsolve.alg isa LinearSolve.AbstractKrylovSubspaceMethod
             # Doesn't modify `A`, so it's safe to just reuse it
+            adj_Pl, adj_Pr = LinearSolve._adjoint_precs(
+                _linsolve.alg, _linsolve.sensealg, _linsolve.Pl, _linsolve.Pr
+            )
             LinearSolve._adjoint_krylov_solve(
                 _linsolve.alg, _linsolve.A, dy;
                 abstol = _linsolve.abstol,
                 reltol = _linsolve.reltol,
-                verbose = _linsolve.verbose
+                verbose = _linsolve.verbose,
+                Pl = adj_Pl, Pr = adj_Pr
             )
         elseif _linsolve.alg isa LinearSolve.DefaultLinearSolver
             LinearSolve.defaultalg_adjoint_eval(_linsolve, dy)

--- a/ext/LinearSolveMooncakeExt.jl
+++ b/ext/LinearSolveMooncakeExt.jl
@@ -94,6 +94,8 @@ function Mooncake.rrule!!(
         cachenew = init(LinearProblem(cache.A, cache.b), alg, _args...; kwargs...)
         new_sol = solve!(cachenew)
         ∂u = sol.dx.data.u
+        adj_alg = sensealg.linsolve === missing ? alg : sensealg.linsolve
+        adj_Pl, adj_Pr = LinearSolve._adjoint_precs(adj_alg, sensealg, cache.Pl, cache.Pr)
 
         if sensealg.linsolve === missing
             cached_adjoint_solution = LinearSolve._adjoint_factorization_solve(
@@ -103,18 +105,23 @@ function Mooncake.rrule!!(
                 cached_adjoint_solution
             elseif alg isa AbstractKrylovSubspaceMethod
                 LinearSolve._adjoint_krylov_solve(
-                    alg, cache.A, ∂u; cache.abstol, cache.reltol, cache.verbose
+                    alg, cache.A, ∂u; cache.abstol, cache.reltol, cache.verbose,
+                    Pl = adj_Pl, Pr = adj_Pr
                 )
             elseif alg isa DefaultLinearSolver
                 LinearSolve.defaultalg_adjoint_eval(cache, ∂u)
             else
                 invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
-                solve(invprob, alg; cache.abstol, cache.reltol, cache.verbose).u
+                solve(
+                    invprob, alg; cache.abstol, cache.reltol, cache.verbose,
+                    Pl = adj_Pl, Pr = adj_Pr
+                ).u
             end
         else
             invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
             λ = solve(
-                invprob, sensealg.linsolve; cache.abstol, cache.reltol, cache.verbose
+                invprob, sensealg.linsolve; cache.abstol, cache.reltol, cache.verbose,
+                Pl = adj_Pl, Pr = adj_Pr
             ).u
         end
 

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -1,7 +1,5 @@
-# TODO: Preconditioners? Should Pl be transposed and made Pr and similar for Pr.
-
 @doc doc"""
-    LinearSolveAdjoint(; linsolve = missing)
+    LinearSolveAdjoint(; linsolve = missing, Pl = missing, Pr = missing)
 
 Given a Linear Problem ``A x = b`` computes the sensitivities for ``A`` and ``b`` as:
 
@@ -22,8 +20,49 @@ forward solve (this is done by keeping the linsolve as `missing`). For example, 
 forward solve was performed via a Factorization, then we can reuse the factorization for the
 adjoint solve. However, for specific structured matrices if ``A'`` is known to have a
 specific structure distinct from ``A`` then passing in a `linsolve` will be more efficient.
+
+## Choice of Preconditioner
+
+The adjoint solve is preconditioned from the forward preconditioners by default, which is
+what keeps an iterative adjoint converging on a system that needs preconditioning at all.
+Left preconditioning the forward system solves with the operator ``Pl^{-1} A``, whose
+adjoint is ``A' Pl^{-*}``, that is the adjoint system *right* preconditioned by ``Pl^*``.
+The two sides therefore swap and each is conjugated. Methods restricted to centered
+preconditioning have no right slot to swap into, so for those the forward left
+preconditioner is kept on the left; such methods apply to symmetric systems, where
+``A' = A`` and the same preconditioner is the right one to reuse.
+
+`Pl` and `Pr` override the respective sides of the adjoint solve. This is what a
+matrix-free preconditioner needs, since it generally has no usable `adjoint`.
 """
-@kwdef struct LinearSolveAdjoint{L} <:
+@kwdef struct LinearSolveAdjoint{L, Tl, Tr} <:
     SciMLBase.AbstractSensitivityAlgorithm{0, false, :central}
     linsolve::L = missing
+    Pl::Tl = missing
+    Pr::Tr = missing
 end
+
+"""
+    _adjoint_precs(alg, sensealg, Pl, Pr)
+
+Preconditioner pair for the adjoint system ``A' λ = ∂x`` given the forward pair, following
+the swap described in [`LinearSolveAdjoint`](@ref). Returns `nothing` for a side that
+should fall back to the identity, matching the `Pl`/`Pr` keyword of `init`.
+"""
+function _adjoint_precs(alg, sensealg, Pl, Pr)
+    # A sensealg other than `LinearSolveAdjoint` carries no overrides to honour.
+    userPl = sensealg isa LinearSolveAdjoint ? sensealg.Pl : missing
+    userPr = sensealg isa LinearSolveAdjoint ? sensealg.Pr : missing
+    _side(user, derived) = user === missing ? _drop_identity(derived) : user
+    if _supports_right_preconditioning(alg)
+        return _side(userPl, adjoint(Pr)), _side(userPr, adjoint(Pl))
+    end
+    # No right slot to swap into: the forward left preconditioner stays on the left.
+    return _side(userPl, adjoint(Pl)), _side(userPr, nothing)
+end
+
+_drop_identity(P) = (P === nothing || _isidentity_struct(P)) ? nothing : P
+
+# Mirrors the preconditioner dispatch in the `KrylovJL` `solve!`, where the methods for
+# symmetric systems warn on and discard a right preconditioner.
+_supports_right_preconditioning(_) = true

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -54,6 +54,11 @@ function _adjoint_precs(alg, sensealg, Pl, Pr)
     userPl = sensealg isa LinearSolveAdjoint ? sensealg.Pl : missing
     userPr = sensealg isa LinearSolveAdjoint ? sensealg.Pr : missing
     _side(user, derived) = user === missing ? _drop_identity(derived) : user
+    # An algorithm carrying its own `precs` rebuilds the pair against `A'` when the adjoint
+    # problem is initialized, so deriving one here would apply two preconditioners.
+    if _has_own_precs(alg)
+        return _side(userPl, nothing), _side(userPr, nothing)
+    end
     if _supports_right_preconditioning(alg)
         return _side(userPl, adjoint(Pr)), _side(userPr, adjoint(Pl))
     end
@@ -62,6 +67,8 @@ function _adjoint_precs(alg, sensealg, Pl, Pr)
 end
 
 _drop_identity(P) = (P === nothing || _isidentity_struct(P)) ? nothing : P
+
+_has_own_precs(alg) = hasproperty(alg, :precs) && alg.precs !== nothing
 
 # Mirrors the preconditioner dispatch in the `KrylovJL` `solve!`, where the methods for
 # symmetric systems warn on and discard a right preconditioner.

--- a/src/adjoint_factorization.jl
+++ b/src/adjoint_factorization.jl
@@ -187,10 +187,11 @@ _adjoint_factorization_solve(::_AdjointFactorizationReuse, alg, cacheval, A, b) 
     nothing
 
 function _adjoint_krylov_solve(
-        alg::AbstractKrylovSubspaceMethod, A, b; abstol, reltol, verbose
+        alg::AbstractKrylovSubspaceMethod, A, b; abstol, reltol, verbose,
+        Pl = nothing, Pr = nothing
     )
     invprob = LinearProblem(adjoint(A), b)
-    return solve(invprob, alg; abstol, reltol, verbose).u
+    return solve(invprob, alg; abstol, reltol, verbose, Pl, Pr).u
 end
 
 _custom_can_reuse_adjoint_factorization(::SimpleLUFactorization, ::LUSolver) = true

--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -492,6 +492,16 @@ function _krylov_warm_start!(workspace, cache, mode::WarmStart.T, M, atol, rtol)
     return atol + rtol * bnorm, zero(rtol)
 end
 
+# The methods for symmetric systems below take centered preconditioning only, and warn on
+# and discard a right preconditioner. Keep this in step with the dispatch in `solve!`.
+function _supports_right_preconditioning(alg::KrylovJL)
+    return !(
+        alg.KrylovAlg === Krylov.cg! || alg.KrylovAlg === Krylov.minres! ||
+            alg.KrylovAlg === Krylov.block_minres! || alg.KrylovAlg === Krylov.cgls! ||
+            alg.KrylovAlg === Krylov.crls!
+    )
+end
+
 function SciMLBase.solve!(cache::LinearCache, alg::KrylovJL; kwargs...)
     if cache.precsisfresh && !isnothing(alg.precs)
         Pl, Pr = alg.precs(cache.A, cache.p)

--- a/test/Core/adjoint.jl
+++ b/test/Core/adjoint.jl
@@ -395,6 +395,20 @@ end
     @test norm(gb - λ) / norm(λ) < 1.0e-5
 end
 
+@testset "An algorithm with its own precs is left alone (#476)" begin
+    # `precs` rebuilds the pair against `A'` when the adjoint problem is initialized, so
+    # deriving a second pair here would apply two preconditioners.
+    Random.seed!(4760)
+    m = 128
+    A = Diagonal(10.0 .^ range(-8, 8, m)) * (rand(m, m) + m * I)
+    bvec = rand(m)
+    λ = adjoint(A) \ (2 .* (A \ bvec))
+
+    alg = KrylovJL_GMRES(precs = (A, p) -> (Diagonal(diag(A)), I))
+    gb = Zygote.gradient(bvec -> sum(abs2, solve(LinearProblem(A, bvec), alg).u), bvec)[1]
+    @test norm(gb - λ) / norm(λ) < 1.0e-5
+end
+
 @testset "Adjoint preconditioner pairing (#476)" begin
     m = 8
     Pl = Diagonal(rand(m) .+ 1)

--- a/test/Core/adjoint.jl
+++ b/test/Core/adjoint.jl
@@ -336,3 +336,95 @@ end
         sum(solve(prob2).u)
     end
 end
+
+@testset "Preconditioners carry over to the adjoint solve (#476)" begin
+    # An adjoint solve that drops the forward preconditioner runs unpreconditioned, so on
+    # a system that needs preconditioning it stops at `maxiters` and the gradient is
+    # silently wrong rather than merely slow.
+    Random.seed!(476)
+    alg = KrylovJL_GMRES()
+
+    for m in (64, 256)
+        A = Diagonal(10.0 .^ range(-8, 8, m)) * (rand(m, m) + m * I)
+        bvec = rand(m)
+        Pl = Diagonal(diag(A))
+
+        uex = A \ bvec
+        λ = adjoint(A) \ (2 .* uex)
+        gA_ex = -(λ .* adjoint(uex))
+
+        gA, gb = Zygote.gradient(
+            (A, bvec) -> sum(abs2, solve(LinearProblem(A, bvec), alg; Pl = Pl).u),
+            A, bvec
+        )
+
+        @test norm(gb - λ) / norm(λ) < 1.0e-5
+        @test norm(gA - gA_ex) / norm(gA_ex) < 1.0e-5
+    end
+
+    # `Pl`/`Pr` on the sensealg override the derived pair, which is what a preconditioner
+    # with no usable `adjoint` needs.
+    m = 128
+    A = Diagonal(10.0 .^ range(-8, 8, m)) * (rand(m, m) + m * I)
+    bvec = rand(m)
+    Pl = Diagonal(diag(A))
+    λ = adjoint(A) \ (2 .* (A \ bvec))
+
+    gb = Zygote.gradient(
+        bvec -> sum(
+            abs2,
+            solve(
+                LinearProblem(A, bvec), alg;
+                Pl = Pl, sensealg = LinearSolveAdjoint(; Pr = adjoint(Pl))
+            ).u
+        ),
+        bvec
+    )[1]
+    @test norm(gb - λ) / norm(λ) < 1.0e-5
+
+    # A symmetric system solved by a method with no right slot keeps the preconditioner on
+    # the left instead of swapping it into a slot that would discard it.
+    S = rand(m, m)
+    S = S'S + m * I
+    bvec = rand(m)
+    Pl = Diagonal(diag(S))
+    λ = adjoint(S) \ (2 .* (S \ bvec))
+    gb = Zygote.gradient(
+        bvec -> sum(abs2, solve(LinearProblem(S, bvec), KrylovJL_CG(); Pl = Pl).u), bvec
+    )[1]
+    @test norm(gb - λ) / norm(λ) < 1.0e-5
+end
+
+@testset "Adjoint preconditioner pairing (#476)" begin
+    m = 8
+    Pl = Diagonal(rand(m) .+ 1)
+    Pr = Diagonal(rand(m) .+ 1)
+    sensealg = LinearSolveAdjoint()
+
+    # Left preconditioning the forward system gives `Pl \ A`, whose adjoint is right
+    # preconditioned by `Pl'`, so the two sides swap.
+    aPl, aPr = LinearSolve._adjoint_precs(KrylovJL_GMRES(), sensealg, Pl, Pr)
+    @test aPl == adjoint(Pr)
+    @test aPr == adjoint(Pl)
+
+    # An identity side is dropped rather than passed along.
+    idPl, idPr = LinearSolve._adjoint_precs(
+        KrylovJL_GMRES(), sensealg, Pl, LinearSolve.IdentityOperator(m)
+    )
+    @test idPl === nothing
+    @test idPr == adjoint(Pl)
+
+    # Methods restricted to centered preconditioning keep the left preconditioner.
+    cgPl, cgPr = LinearSolve._adjoint_precs(
+        KrylovJL_CG(), sensealg, Pl, LinearSolve.IdentityOperator(m)
+    )
+    @test cgPl == adjoint(Pl)
+    @test cgPr === nothing
+
+    # Explicit overrides win over the derived pair.
+    ovPl, ovPr = LinearSolve._adjoint_precs(
+        KrylovJL_GMRES(), LinearSolveAdjoint(; Pl = Pl, Pr = Pr), Pl, Pr
+    )
+    @test ovPl === Pl
+    @test ovPr === Pr
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -139,7 +139,7 @@ linearsolve_internal_accesses = (
     :PrecompileTools, :SciMLLinearSolveAlgorithm, :SupernodalLU,
     :_SPARSE_LU_FALLBACK_ALGORITHMS, :_SPARSE_ONLY_ALGORITHMS,
     :__is_extension_loaded, :__nonstructural_zeros, :_adjoint_factorization_solve,
-    :_adjoint_krylov_solve, :_can_reuse_cache_factorization,
+    :_adjoint_krylov_solve, :_adjoint_precs, :_can_reuse_cache_factorization,
     :_check_residual_safety,
     :_custom_adjoint_factorization_solve, :_custom_cache_factorization,
     :_custom_can_reuse_adjoint_factorization, Symbol("_direct_lu_factorize!"),


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #476, and removes the `# TODO: Preconditioners?` at the top of `src/adjoint.jl`.

- The adjoint solve was built as a bare `LinearProblem(adjoint(A), b)`, so a preconditioner passed as `Pl`/`Pr` was dropped and the adjoint ran unpreconditioned.
- The rule takes `.u` regardless of the return code, so on a system that needs preconditioning the adjoint stopped at `maxiters` and the gradient came back wrong rather than slow:

  | n | adjoint before | adjoint after |
  | --- | --- | --- |
  | 64 | MaxIters, 64 iters, 4.0e-4 relerr | Success, 5 iters, 5.7e-9 |
  | 256 | MaxIters, 256 iters, 1.2e-3 relerr | Success, 5 iters, 3.4e-9 |
  | 512 | MaxIters, 512 iters, 1.2e-3 relerr | Success, 5 iters, 1.0e-9 |

- Left preconditioning the forward system solves with `Pl \ A`, whose adjoint is `A' / Pl'`, that is the adjoint system right preconditioned by `Pl'`. So the two sides swap and each is conjugated, which is what the TODO guessed.
- Methods restricted to centered preconditioning have no right slot to swap into and would silently discard it, so for those the forward left preconditioner stays on the left. Per @amontoison in the issue, those apply to symmetric systems where `A' = A`, so the same preconditioner is the right one to reuse.
- An algorithm carrying its own `precs` is left alone, since `precs` is evaluated against the matrix the adjoint problem is initialized with and already rebuilds the pair for `A'`. Deriving a second pair applied both at once and measured worse than the original bug.
- `LinearSolveAdjoint` gains `Pl` and `Pr` to override either side, which answers the "some way to specify adjoint preconditioners" question in the issue and covers a matrix-free preconditioner with no usable `adjoint`.
- Applied in the ChainRulesCore, Mooncake, and Enzyme rules.
- Separately noticed while reading this code: the Krylov branch of `defaultalg_adjoint_eval` refers to `cache.val.abstol` and returns the solution rather than `.u`. Both callers pass a `LinearCache`, which has no `val`, so that branch looks like it would throw if reached. I could not construct a default selection that reaches it, so it is left alone here.

AI Disclosure: Used Opus 5