### PR TITLE
Copy the cache where it changes rather than on every solve

### DIFF
--- a/ext/LinearSolveEnzymeExt.jl
+++ b/ext/LinearSolveEnzymeExt.jl
@@ -621,6 +621,16 @@ function EnzymeRules.reverse(
     return (nothing, nothing)
 end
 
+"""
+    _shadow_of_constant(x)
+
+Shadow value to store alongside a constant assigned into a cache. A constant carries no
+derivative, so an array shadow is zeroed; anything else is a field the shadow cache holds
+verbatim (the staleness flags, the algorithm, a cacheval), and is passed through.
+"""
+_shadow_of_constant(x::AbstractArray) = zero(x)
+_shadow_of_constant(x) = x
+
 # `setproperty!` is the public way to change a `LinearCache` between solves, so it is the
 # one place that has to copy. Reverse restores what the assignment overwrote, which walks
 # the cache backwards into the state each earlier `solve!` ran against, and that is what
@@ -644,7 +654,7 @@ function EnzymeRules.augmented_primal(
     if !(cache isa Const)
         dcaches = EnzymeRules.width(config) == 1 ? (cache.dval,) : cache.dval
         dxs = if x isa Const
-            ntuple(_ -> EnzymeCore.make_zero(x.val), Val(EnzymeRules.width(config)))
+            ntuple(_ -> _shadow_of_constant(x.val), Val(EnzymeRules.width(config)))
         elseif EnzymeRules.width(config) == 1
             (x.dval,)
         else

--- a/ext/LinearSolveEnzymeExt.jl
+++ b/ext/LinearSolveEnzymeExt.jl
@@ -621,6 +621,60 @@ function EnzymeRules.reverse(
     return (nothing, nothing)
 end
 
+# `setproperty!` is the public way to change a `LinearCache` between solves, so it is the
+# one place that has to copy. Reverse restores what the assignment overwrote, which walks
+# the cache backwards into the state each earlier `solve!` ran against, and that is what
+# lets the `solve!` rule hold the live cache instead of copying it defensively every time.
+# See https://github.com/SciML/LinearSolve.jl/issues/380.
+function EnzymeRules.augmented_primal(
+        config, func::Const{typeof(Base.setproperty!)}, ::Type{RT},
+        cache::EnzymeCore.Annotation{<:LinearSolve.LinearCache},
+        name::Const{Symbol}, x::EnzymeCore.Annotation
+    ) where {RT}
+    field = name.val
+    old = getfield(cache.val, field)
+    # Assigning any of these also flips the staleness flags, so they rewind together.
+    old_isfresh = getfield(cache.val, :isfresh)
+    old_precsisfresh = getfield(cache.val, :precsisfresh)
+    # A new `A` is what invalidates the factorization, and the next `solve!` builds the
+    # replacement over the same cacheval, so this is the assignment that has to copy.
+    old_cacheval = field === :A ? deepcopy(getfield(cache.val, :cacheval)) : nothing
+
+    func.val(cache.val, field, x.val)
+    if !(cache isa Const)
+        dcaches = EnzymeRules.width(config) == 1 ? (cache.dval,) : cache.dval
+        dxs = if x isa Const
+            ntuple(_ -> EnzymeCore.make_zero(x.val), Val(EnzymeRules.width(config)))
+        elseif EnzymeRules.width(config) == 1
+            (x.dval,)
+        else
+            x.dval
+        end
+        for (dcache, dx) in zip(dcaches, dxs)
+            func.val(dcache, field, dx)
+        end
+    end
+
+    tape = (field, old, old_isfresh, old_precsisfresh, old_cacheval)
+    primal = EnzymeRules.needs_primal(config) ? x.val : nothing
+    return EnzymeRules.AugmentedReturn(primal, nothing, tape)
+end
+
+function EnzymeRules.reverse(
+        config, func::Const{typeof(Base.setproperty!)}, ::Type{RT}, tape,
+        cache::EnzymeCore.Annotation{<:LinearSolve.LinearCache},
+        name::Const{Symbol}, x::EnzymeCore.Annotation
+    ) where {RT}
+    field, old, old_isfresh, old_precsisfresh, old_cacheval = tape
+    # `setfield!` rather than `setproperty!`: this is a rewind, so it must not re-run the
+    # bookkeeping that the forward assignment already did.
+    setfield!(cache.val, field, old)
+    setfield!(cache.val, :isfresh, old_isfresh)
+    setfield!(cache.val, :precsisfresh, old_precsisfresh)
+    old_cacheval === nothing || setfield!(cache.val, :cacheval, old_cacheval)
+    return (nothing, nothing, nothing)
+end
+
 # y=inv(A) B
 #   dA −= z y^T
 #   dB += z, where  z = inv(A^T) dy
@@ -675,9 +729,9 @@ function EnzymeRules.augmented_primal(
         end
     end
 
-    cachesolve = deepcopy(linsolve.val)
-
-    cache = (copy(res.u), resvals, cachesolve, dAs, dbs)
+    # No copy: the `setproperty!` rules above rewind the cache as the tape unwinds, so by
+    # the time this solve's reverse runs the live cache is back to what this solve saw.
+    cache = (copy(res.u), resvals, linsolve.val, dAs, dbs)
 
     _res = EnzymeRules.needs_primal(config) ? res : nothing
     _dres = EnzymeRules.needs_shadow(config) ? dres : nothing

--- a/test/AD/enzyme.jl
+++ b/test/AD/enzyme.jl
@@ -565,3 +565,49 @@ end
     @test all(isfinite, db_en)
     @test !iszero(db_en)
 end
+
+@testset "Cache mutation between solves rewinds in reverse (#380)" begin
+    # The `solve!` rule keeps the live cache rather than a defensive `deepcopy`, so the
+    # `setproperty!` rules have to restore what each assignment overwrote. Replacing `A`
+    # is the case that matters: it invalidates the factorization that the next `solve!`
+    # builds over, so the earlier solve's reverse needs the factorization it ran against.
+    n = 12
+
+    single(A, b) = sum(abs2, solve!(init(LinearProblem(A, b), LUFactorization())).u)
+
+    function new_b(A, b)
+        cache = init(LinearProblem(A, b), LUFactorization())
+        s = sum(abs2, solve!(cache).u)
+        cache.b = 2 .* b
+        return s + sum(abs2, solve!(cache).u)
+    end
+
+    function new_A(A, b)
+        cache = init(LinearProblem(A, b), LUFactorization())
+        s = sum(abs2, solve!(cache).u)
+        cache.A = 2 .* A
+        return s + sum(abs2, solve!(cache).u)
+    end
+
+    function both(A, b)
+        cache = init(LinearProblem(A, b), LUFactorization())
+        s = sum(abs2, solve!(cache).u)
+        cache.b = 2 .* b
+        s += sum(abs2, solve!(cache).u)
+        cache.A = 3 .* A
+        return s + sum(abs2, solve!(cache).u)
+    end
+
+    for f in (single, new_b, new_A, both)
+        A = rand(n, n) + n * I
+        b = rand(n)
+        dA = zeros(n, n)
+        db = zeros(n)
+        Enzyme.autodiff(
+            Enzyme.set_runtime_activity(Enzyme.Reverse), f,
+            Duplicated(copy(A), dA), Duplicated(copy(b), db)
+        )
+        @test dA ≈ ForwardDiff.gradient(X -> f(X, b), copy(A)) rtol = 1.0e-8
+        @test db ≈ ForwardDiff.gradient(y -> f(A, y), copy(b)) rtol = 1.0e-8
+    end
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #380, following the approach in the issue.

- The `solve!` augmented primal took a `deepcopy` of the whole `LinearCache` on every solve, to guard the reverse pass against a later mutation. That was about 29% of the allocations of a reverse-mode solve, independent of size.
- `setproperty!` is the public way to change a cache between solves, so it is now the one place that copies. Its rules record what an assignment overwrote and restore it in reverse, which walks the cache backwards into the state each earlier `solve!` ran against, so `solve!` can keep the live cache.
- Only an assignment to `A` copies anything, since that is what invalidates the factorization the next `solve!` builds over. A cache solved repeatedly against a fixed `A` now copies nothing.

Reverse-mode allocations, `init` plus `solve!` with `LUFactorization`, Enzyme 0.13.199 on Julia 1.12:

  | n | before | after | change |
  | --- | --- | --- | --- |
  | 50 | 149 KB | 106 KB | -28.7% |
  | 200 | 2.26 MB | 1.62 MB | -28.6% |
  | 500 | 14.05 MB | 10.04 MB | -28.6% |

- Gradients match ForwardDiff to machine precision for a plain solve and for caches whose `b`, `A`, or both are replaced between solves. Those four patterns are the added tests.
- The existing batched (`BatchDuplicated`) rules and the "Adjoint case currently not handled" check both still pass, which are the paths the new shadow handling touches.

AI Disclosure: Used Opus 5