### PR TITLE
QA: drop api-docs/JET overrides that SciMLTesting 2.8 supplies by default

### DIFF
--- a/lib/LinearSolveAutotune/test/qa/qa.jl
+++ b/lib/LinearSolveAutotune/test/qa/qa.jl
@@ -9,8 +9,7 @@ run_qa(
     # `plot` is deliberately re-exported from Plots: the package extends it with
     # AutotuneResults methods and exports it as the plotting entry point.
     reexports_allow = (:plot,),
-    api_docs_kwargs = (; rendered = true, docs_src),
-    jet_kwargs = (; target_defined_modules = true),
+    api_docs_kwargs = (; docs_src),
     ei_kwargs = (;
         # BlasFloat (LinearAlgebra.BLAS, reached via LinearAlgebra) and Base.run.
         all_qualified_accesses_via_owners = (; ignore = (:BlasFloat, :run)),

--- a/lib/LinearSolvePyAMG/test/qa/qa.jl
+++ b/lib/LinearSolvePyAMG/test/qa/qa.jl
@@ -6,8 +6,7 @@ docs_src = normpath(joinpath(pkgdir(LinearSolvePyAMG), "..", "..", "docs", "src"
 run_qa(
     LinearSolvePyAMG;
     explicit_imports = true,
-    api_docs_kwargs = (; rendered = true, docs_src),
-    jet_kwargs = (; target_defined_modules = true),
+    api_docs_kwargs = (; docs_src),
     ei_kwargs = (;
         # Non-public names accessed qualified: SciMLBase / LinearSolve internals the
         # solver wrapper relies on (build_linear_solution, default_alias_A/b, ...).

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -199,21 +199,17 @@ external_internal_accesses = (
     Symbol("rdiv!"),
 )
 
-docs_src = normpath(joinpath(@__DIR__, "..", "..", "docs", "src"))
+# `@reexport using SciMLBase` puts every SciMLBase export in LinearSolve's public API,
+# so the reexport audit needs them allowed; the list is computed so it tracks
+# SciMLBase. The API-docs checks need no matching ignore: SciMLTesting follows each
+# binding to SciMLBase's docstring, exempts the reexported module name, and only
+# requires a local `@docs` entry for names LinearSolve owns.
 scimlbase_reexports = Tuple(names(LinearSolve.SciMLBase; all = false, imported = false))
 
 run_qa(
     LinearSolve;
     explicit_imports = true,
     reexports_allow = scimlbase_reexports,
-    # `scimlbase_reexports` covers both checks: `names(SciMLBase)` includes the
-    # module's own name, so re-exporting it puts `:SciMLBase` in LinearSolve's public
-    # API, where the docstring check counts it as undocumented. It is SciMLBase's name
-    # to document, not LinearSolve's, hence the same ignore list as the rendered check.
-    api_docs_kwargs = (;
-        rendered = true, docs_src,
-        ignore = scimlbase_reexports, rendered_ignore = scimlbase_reexports,
-    ),
     aqua_kwargs = (;
         # `MKL_jll` is not stale: `src/LinearSolve.jl` and `src/mkl.jl` load it
         # (`using MKL_jll: MKL_jll` / `libmkl_rt`) behind a `@static if` gated on a
@@ -280,4 +276,4 @@ run_qa(
     ),
 )
 
-run_api_docs(LinearSolve.KLU; rendered = true, docs_src)
+run_api_docs(LinearSolve.KLU)


### PR DESCRIPTION
> **Ignore until reviewed by @ChrisRackauckas.** Draft; QA/docs test infrastructure only, no solver code changes.

## What changed and why

Audit of the repo's `run_qa` calls against what SciMLTesting (compat floor already `2.8`) supplies by default. Removed the per-repo overrides that duplicate the harness defaults; kept the two genuine external-owner exceptions.

| File | Removed | Kept |
|---|---|---|
| `test/qa/qa.jl` | `api_docs_kwargs = (; rendered = true, docs_src, ignore = scimlbase_reexports, rendered_ignore = scimlbase_reexports)`; `docs_src` variable; `rendered = true, docs_src` on the `run_api_docs(LinearSolve.KLU)` call | `reexports_allow = scimlbase_reexports` (comment rewritten to say why it is still needed and why the api-docs ignores are not) |
| `lib/LinearSolvePyAMG/test/qa/qa.jl` | `rendered = true`; `jet_kwargs = (; target_defined_modules = true)` | `docs_src` (points the sublibrary at the shared monorepo `docs/src`) |
| `lib/LinearSolveAutotune/test/qa/qa.jl` | `rendered = true`; `jet_kwargs = (; target_defined_modules = true)` | `docs_src` (same); `reexports_allow = (:plot,)` (Plots.plot is deliberately re-exported, existing comment) |

Why each removal is a no-op or an improvement on SciMLTesting 2.8.0 (= current master; features landed in v2.4.0/v2.5.0/v2.6.3):

- `rendered = true` — `run_api_docs` default (`rendered::Bool = true`).
- root `docs_src` — `_default_docs_src(LinearSolve)` and `_default_docs_src(LinearSolve.KLU)` both resolve to `<pkgroot>/docs/src`, identical to the removed `normpath(joinpath(@__DIR__, "..", "..", "docs", "src"))` (verified below).
- `ignore = scimlbase_reexports` / `rendered_ignore = scimlbase_reexports` — the old comment justified these by "`:SciMLBase` counts as undocumented". SciMLTesting now exempts a re-exported external *module* name from the docstring check (SciMLTesting #45, v2.6.3), follows every other re-exported binding to SciMLBase's own docstring, and only requires a local `@docs` entry for names LinearSolve owns (`_requires_local_rendering`). With no ignores at all, both checks pass: 0 undocumented, 0 unrendered out of 252 public names (149 of them SciMLBase re-exports).
- `reexports_allow = scimlbase_reexports` — **retained, irreducible**: without it `public_reexports(LinearSolve)` flags all 149 SciMLBase names; the reexport audit has no owner-following exemption by design (`@reexport using SciMLBase` is the intentional facade behaviour).
- `jet_kwargs = (; target_defined_modules = true)` (sublibraries) — this replaced SciMLTesting's standard `(; target_modules = (pkg,), mode = :typo)` wholesale (so it also silently dropped `mode = :typo`), and `target_defined_modules` is a JET config key that JET 0.12 no longer has (zero mentions in the 0.12.0/0.12.1 sources; present through 0.11.6). Both sublibrary QA groups pass under the standard config.

## Verification

Commands run from a fresh clone at `f85eb092`. Julia versions match `test_groups.toml` `[QA] versions = ["lts", "1"]` (1.10.11 and 1.12.6).

```
$ julia +1.12 --project=@runic -m Runic --check test/qa/qa.jl lib/LinearSolvePyAMG/test/qa/qa.jl lib/LinearSolveAutotune/test/qa/qa.jl ; echo $?
0
$ typos test/qa/qa.jl lib/LinearSolvePyAMG/test/qa/qa.jl lib/LinearSolveAutotune/test/qa/qa.jl ; echo $?
0
$ julia -e 'using TOML; for f in [...8 Project/test_groups TOMLs...]; TOML.parsefile(f); end'   # all parse
```

Default-vs-explicit evidence (SciMLTesting v2.8.0, Julia 1.10.11, root QA env):

```
explicit docs_src: .../LinearSolve.jl/docs/src
default docs_src (LinearSolve): .../LinearSolve.jl/docs/src  equal=true
default docs_src (LinearSolve.KLU): .../LinearSolve.jl/docs/src  equal=true
public API names: 252; of which SciMLBase reexports: 149
undocumented without `ignore`: Symbol[]
autodocs=false; unrendered without `rendered_ignore`: Symbol[]
SciMLBase reexports that _requires_local_rendering: Symbol[]
public_reexports without allow: 149
public_reexports with allow=scimlbase_reexports: Symbol[]
--- run_api_docs(LinearSolve) with NO kwargs:
Test Summary:            | Pass  Total  Time
Public API documentation |    2      2  0.2s
--- run_api_docs(LinearSolve.KLU) with NO kwargs:
Test Summary:            | Pass  Total  Time
Public API documentation |    2      2  0.1s
```

QA groups (`GROUP=QA julia --project -e 'using Pkg; Pkg.test()'` at the root; `LINEARSOLVE_TEST_GROUP=QA julia --project=lib/<Sublib> -e 'using Pkg; Pkg.test()'` for the sublibraries):

| Lane | Julia | Result |
|---|---|---|
| root `GROUP=QA` | 1.10.11 | `JET Tests 20 pass / 22 broken (pre-existing markers) / 42`, `Allocation QA 55/55`, `SupernodalLU Allocation QA 6/6`, `Quality Assurance 47/47` → `Testing LinearSolve tests passed` |
| root `GROUP=QA` | 1.12.6 | `JET Tests 34 pass / 8 broken (pre-existing) / 42`, `Allocation QA 64/64`, `SupernodalLU Allocation QA 8/8`, `Quality Assurance 49/49` → `Testing LinearSolve tests passed` |
| `LinearSolvePyAMG` QA | 1.10.11 | `Code quality (Aqua + JET) 19/19` → `tests passed` |
| `LinearSolvePyAMG` QA | 1.12.6 | `Code quality (Aqua + JET) 21/21` → `tests passed` |
| `LinearSolveAutotune` QA | 1.12.6 | `Code quality (Aqua + JET) 21/21` → `tests passed` |
| `LinearSolveAutotune` QA | 1.10.11 | **Not finished at push time.** The process reached `Testing Running tests...` and had only emitted the usual non-macOS `Metal.jl is only supported on macOS` init message after ~12 min; it was still running (not failed) when this PR was opened. Left running locally; will update this PR with the result. CI's own `lts` lane covers it. |

The Quality Assurance / Code-quality testsets above are the ones that exercise the changed `run_qa` calls (api-docs check without ignores, standard JET config on the sublibraries).

## Not verified

- CI's own runners (self-hosted lanes); everything above was run locally on x86_64 Linux without a GPU — the GPU extension modules load for ExplicitImports as before, no device code runs.
- I did not widen the sublibraries' `JET = "0.9, 0.10, 0.11"` compat to include 0.12; that is a separate compat bump. Removing `target_defined_modules` is what makes it possible.

## Reviewer judgment calls

- Removing `ignore = scimlbase_reexports` couples LinearSolve's QA lane to SciMLBase's docstring hygiene: if a future SciMLBase release exports an undocumented name, LinearSolve's "public API has docstrings" check fails. That is the harness's documented design for re-exporting packages (the check "follows the binding, not a local docstring"), and it is what every other `run_qa` caller gets, but it is a behavioural tightening rather than a pure no-op.
- Sublibrary `docs_src` was kept on purpose even though `_find_docs_src` also discovers the monorepo `docs/src` for `lib/<Name>` — it is the package-layout requirement, spelled explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgfA9buX6dosUMurPiwum5
