### PR TITLE
Solve the adjoint from the cached factorization

### DIFF
--- a/ext/LinearSolveChainRulesCoreExt.jl
+++ b/ext/LinearSolveChainRulesCoreExt.jl
@@ -55,29 +55,14 @@ function CRC.rrule(
         ∂∅ = NoTangent()
 
         ∂u = hasproperty(∂sol, :u) ? ∂sol.u : ∂sol
-        adj_alg = sensealg.linsolve === missing ? alg : sensealg.linsolve
-        adj_Pl, adj_Pr = LinearSolve._adjoint_precs(adj_alg, sensealg, cache.Pl, cache.Pr)
         if sensealg.linsolve === missing
-            cached_adjoint_solution = LinearSolve._adjoint_factorization_solve(
-                alg, cache.cacheval, cache.A, ∂u
-            )
-            λ = if cached_adjoint_solution !== nothing
-                cached_adjoint_solution
-            elseif alg isa AbstractKrylovSubspaceMethod
-                LinearSolve._adjoint_krylov_solve(
-                    alg, cache.A, ∂u; cache.abstol, cache.reltol, cache.verbose,
-                    Pl = adj_Pl, Pr = adj_Pr
-                )
-            elseif alg isa DefaultLinearSolver
-                LinearSolve.defaultalg_adjoint_eval(cache, ∂u)
-            else
-                invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
-                solve(
-                    invprob, alg; cache.abstol, cache.reltol, cache.verbose,
-                    Pl = adj_Pl, Pr = adj_Pr
-                ).u
-            end
+            # Same route as `solve!(cache; adjoint = true)`. `A_` is the copy preserved
+            # above when the factorization may have overwritten `cache.A`.
+            λ = LinearSolve._adjoint_solve(cache, ∂u, A_ === nothing ? cache.A : A_)
         else
+            adj_Pl, adj_Pr = LinearSolve._adjoint_precs(
+                sensealg.linsolve, sensealg, cache.Pl, cache.Pr
+            )
             invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
             λ = solve(
                 invprob, sensealg.linsolve; cache.abstol, cache.reltol, cache.verbose,

--- a/ext/LinearSolveEnzymeExt.jl
+++ b/ext/LinearSolveEnzymeExt.jl
@@ -713,28 +713,9 @@ function EnzymeRules.reverse(
         # Add the contribution from direct `linsolve.u` modifications
         dy .+= dy2.u
 
-        cached_adjoint_solution = LinearSolve._adjoint_factorization_solve(
-            _linsolve.alg, _linsolve.cacheval, _linsolve.A, dy
-        )
-        z = if cached_adjoint_solution !== nothing
-            cached_adjoint_solution
-        elseif _linsolve.alg isa LinearSolve.AbstractKrylovSubspaceMethod
-            # Doesn't modify `A`, so it's safe to just reuse it
-            adj_Pl, adj_Pr = LinearSolve._adjoint_precs(
-                _linsolve.alg, _linsolve.sensealg, _linsolve.Pl, _linsolve.Pr
-            )
-            LinearSolve._adjoint_krylov_solve(
-                _linsolve.alg, _linsolve.A, dy;
-                abstol = _linsolve.abstol,
-                reltol = _linsolve.reltol,
-                verbose = _linsolve.verbose,
-                Pl = adj_Pl, Pr = adj_Pr
-            )
-        elseif _linsolve.alg isa LinearSolve.DefaultLinearSolver
-            LinearSolve.defaultalg_adjoint_eval(_linsolve, dy)
-        else
-            error("Algorithm $(_linsolve.alg) is currently not supported by Enzyme rules on LinearSolve.jl. Please open an issue on LinearSolve.jl detailing which algorithm is missing the adjoint handling")
-        end
+        # Same route as `solve!(cache; adjoint = true)`. The cache is the one this solve
+        # ran against, so `A` is read from it rather than passed separately.
+        z = LinearSolve._adjoint_solve(_linsolve, dy)
 
         # Use sparse-safe outer product subtraction to preserve sparsity pattern
         _sparse_outer_sub!(dA, z, y)

--- a/ext/LinearSolveMooncakeExt.jl
+++ b/ext/LinearSolveMooncakeExt.jl
@@ -94,30 +94,15 @@ function Mooncake.rrule!!(
         cachenew = init(LinearProblem(cache.A, cache.b), alg, _args...; kwargs...)
         new_sol = solve!(cachenew)
         ∂u = sol.dx.data.u
-        adj_alg = sensealg.linsolve === missing ? alg : sensealg.linsolve
-        adj_Pl, adj_Pr = LinearSolve._adjoint_precs(adj_alg, sensealg, cache.Pl, cache.Pr)
 
         if sensealg.linsolve === missing
-            cached_adjoint_solution = LinearSolve._adjoint_factorization_solve(
-                alg, cache.cacheval, cache.A, ∂u
-            )
-            λ = if cached_adjoint_solution !== nothing
-                cached_adjoint_solution
-            elseif alg isa AbstractKrylovSubspaceMethod
-                LinearSolve._adjoint_krylov_solve(
-                    alg, cache.A, ∂u; cache.abstol, cache.reltol, cache.verbose,
-                    Pl = adj_Pl, Pr = adj_Pr
-                )
-            elseif alg isa DefaultLinearSolver
-                LinearSolve.defaultalg_adjoint_eval(cache, ∂u)
-            else
-                invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
-                solve(
-                    invprob, alg; cache.abstol, cache.reltol, cache.verbose,
-                    Pl = adj_Pl, Pr = adj_Pr
-                ).u
-            end
+            # Same route as `solve!(cache; adjoint = true)`. `A_` is the copy preserved
+            # above when the factorization may have overwritten `cache.A`.
+            λ = LinearSolve._adjoint_solve(cache, ∂u, A_ === nothing ? cache.A : A_)
         else
+            adj_Pl, adj_Pr = LinearSolve._adjoint_precs(
+                sensealg.linsolve, sensealg, cache.Pl, cache.Pr
+            )
             invprob = LinearProblem(adjoint(A_), ∂u) # We cached `A`
             λ = solve(
                 invprob, sensealg.linsolve; cache.abstol, cache.reltol, cache.verbose,

--- a/src/adjoint_factorization.jl
+++ b/src/adjoint_factorization.jl
@@ -226,3 +226,34 @@ function _custom_adjoint_factorization_solve(
     end
     return x
 end
+
+"""
+    _adjoint_solve(cache::LinearCache, b)
+
+Solve `adjoint(A) x = b` for the cache's current `A`, reusing the factorization the
+cache already holds when the algorithm has opted into that, and falling back to the
+Krylov, default-solver and generic routes otherwise.
+
+This is the one place that decides how an adjoint solve is carried out, so the public
+`solve!(cache; adjoint = true)` and the reverse-mode rules take the same path.
+"""
+function _adjoint_solve(cache::LinearCache, b, A = cache.A)
+    alg = cache.alg
+    cached = _adjoint_factorization_solve(alg, cache.cacheval, A, b)
+    cached === nothing || return cached
+
+    if alg isa AbstractKrylovSubspaceMethod
+        Pl, Pr = _adjoint_precs(alg, cache.sensealg, cache.Pl, cache.Pr)
+        return _adjoint_krylov_solve(
+            alg, A, b; cache.abstol, cache.reltol, cache.verbose, Pl, Pr
+        )
+    elseif alg isa DefaultLinearSolver
+        return defaultalg_adjoint_eval(cache, b)
+    end
+
+    # No cached factorization to reuse, so factorize the adjoint directly. `A` is a
+    # parameter because a factorization may have overwritten `cache.A`, and the reverse
+    # rules keep the copy that was preserved before that happened.
+    invprob = LinearProblem(adjoint(A), b)
+    return solve(invprob, alg; cache.abstol, cache.reltol, cache.verbose).u
+end

--- a/src/common.jl
+++ b/src/common.jl
@@ -940,8 +940,38 @@ function SciMLBase.solve(
     return solve!(init(prob, alg, args...; kwargs...))
 end
 
-function SciMLBase.solve!(cache::LinearCache, args...; kwargs...)
+"""
+    solve!(cache::LinearCache, args...; adjoint = false, kwargs...)
+
+`adjoint = true` solves `adjoint(A) x = b` instead of `A x = b`, reusing the
+factorization the cache already holds rather than factorizing the adjoint afresh:
+
+```julia
+cache = init(LinearProblem(A, b))
+x = solve!(cache).u
+cache.b = c
+lambda = solve!(cache; adjoint = true).u   # adjoint(A) lambda = c, same factorization
+```
+
+Algorithms that have not opted into reusing their factorization for an adjoint solve
+fall back to factorizing `adjoint(A)`, so the keyword is always answerable. The
+solution is written into `cache.u` as usual.
+"""
+@inline function SciMLBase.solve!(
+        cache::LinearCache, args...; adjoint::Bool = false, kwargs...
+    )
+    adjoint && return _solve_adjoint!(cache, args...; kwargs...)
     return solve!(cache, cache.alg, args...; kwargs...)
+end
+
+function _solve_adjoint!(cache::LinearCache, args...; kwargs...)
+    # The reuse is only possible once a factorization exists, and a fresh `A` has not
+    # been factorized yet.
+    cache.isfresh && solve!(cache, cache.alg, args...; kwargs...)
+    copyto!(cache.u, _adjoint_solve(cache, cache.b))
+    return SciMLBase.build_linear_solution(
+        cache.alg, cache.u, nothing, cache; retcode = ReturnCode.Success
+    )
 end
 
 # Special Case for StaticArrays

--- a/test/Core/adjoint.jl
+++ b/test/Core/adjoint.jl
@@ -442,3 +442,53 @@ end
     @test ovPl === Pl
     @test ovPr === Pr
 end
+
+@testset "solve! with adjoint = true reuses the factorization (#92)" begin
+    # `adjoint = true` solves `adjoint(A) x = b` from the factorization the cache already
+    # holds, which is what a hand-written rrule previously had no public way to reach.
+    Random.seed!(92)
+    m = 60
+
+    @testset "matches a fresh adjoint solve" begin
+        for alg in (
+                LUFactorization(), QRFactorization(), RFLUFactorization(),
+                KrylovJL_GMRES(), nothing,
+            )
+            A = rand(m, m) + m * I
+            bvec = rand(m)
+            cvec = rand(m)
+            cache = alg === nothing ? init(LinearProblem(A, bvec)) :
+                init(LinearProblem(A, bvec), alg)
+
+            @test solve!(cache).u ≈ A \ bvec rtol = 1.0e-6
+            cache.b = cvec
+            @test solve!(cache; adjoint = true).u ≈ adjoint(A) \ cvec rtol = 1.0e-6
+        end
+    end
+
+    @testset "the same cache answers both directions" begin
+        A = rand(m, m) + m * I
+        bvec = rand(m)
+        cache = init(LinearProblem(A, bvec), LUFactorization())
+        @test solve!(cache).u ≈ A \ bvec
+        @test solve!(cache; adjoint = true).u ≈ adjoint(A) \ bvec
+        # and back again, without the keyword
+        @test solve!(cache).u ≈ A \ bvec
+    end
+
+    @testset "a fresh cache factorizes first" begin
+        A = rand(m, m) + m * I
+        bvec = rand(m)
+        cache = init(LinearProblem(A, bvec), LUFactorization())
+        # no primal solve first, so the adjoint has to build the factorization
+        @test solve!(cache; adjoint = true).u ≈ adjoint(A) \ bvec
+    end
+
+    @testset "complex matrices take the conjugate transpose" begin
+        A = rand(ComplexF64, m, m) + m * I
+        bvec = rand(ComplexF64, m)
+        cache = init(LinearProblem(A, bvec), LUFactorization())
+        solve!(cache)
+        @test solve!(cache; adjoint = true).u ≈ adjoint(A) \ bvec
+    end
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #92, following your note that it should be a solve level thing and that the AD overloads should use the same route.

- `solve!(cache; adjoint = true)` solves `adjoint(A) x = b` from the factorization the cache already holds. This is the case from the thread: solve, then solve the adjoint on the same cache without building a second `LinearProblem`. On a 400x400 dense LU that was 0.425 s refactorizing against 0.164 s reusing.
- The ChainRulesCore, Enzyme and Mooncake rules each carried the same four-way cascade over cached factorization, Krylov, default solver and a generic fallback. All three now call the one shared `_adjoint_solve`, so the behaviour lives in a single place.
- The matrix is a parameter of `_adjoint_solve` rather than always `cache.A`, since a factorization may have overwritten `cache.A` and the rules keep the copy taken before that.
- Algorithms with no cached adjoint reuse fall back to factorizing `adjoint(A)`, so the keyword is always answerable.

Two things worth a look:

- The entry point is `@inline`. Without it the added keyword puts kwarg handling on the hot path and the warm aliased refactorize loop in `test/Core/lightweight_solution.jl` stops being allocation free. With it that test is back to 0 bytes over 100 solves.
- Enzyme previously raised "not supported" for an algorithm with no cached adjoint reuse, and now factorizes the adjoint like the other two backends. No test pinned that message and it is strictly more capable, but it is a behaviour change and easy to put back if you would rather keep the error.

Tests cover LU, QR, RFLU, GMRES and the default solver, both directions on one cache, a fresh cache that has to factorize first, and a complex matrix so the conjugate transpose is exercised. Core is 137 of 137 on adjoint sensitivity, and the AD group passes with Enzyme 49 of 49 and Mooncake 46 of 46.

AI Disclosure: Used Opus 5