### PR TITLE
Update Downstream CI to Julia 1

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -22,5 +22,5 @@ jobs:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
       group: "${{ matrix.package.group }}"
-      julia-version: "lts"
+      julia-version: "1"
     secrets: "inherit"


### PR DESCRIPTION
<!-- NOTE: This PR should be ignored until reviewed by @ChrisRackauckas. -->

## Summary
- Updates `.github/workflows/Downstream.yml` to set `julia-version: "1"` (replacing `"lts"`).

## Verification
- Validated YAML syntax locally with PyYAML.
