### PR TITLE
Fix the default solver's Krylov adjoint branch

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -1243,13 +1243,16 @@ end
                 )
             )
             quote
-                invprob = LinearSolve.LinearProblem(transpose(cache.A), dy)
+                # `adjoint` rather than `transpose` to match the other branches, which
+                # differ for a complex eltype, and `.u` because the caller wants the
+                # solution vector the sibling branches return.
+                invprob = LinearSolve.LinearProblem(adjoint(cache.A), dy)
                 solve(
                     invprob, cache.alg;
-                    abstol = cache.val.abstol,
-                    reltol = cache.val.reltol,
-                    verbose = cache.val.verbose
-                )
+                    abstol = cache.abstol,
+                    reltol = cache.reltol,
+                    verbose = cache.verbose
+                ).u
             end
         else
             # Interpolate the algorithm name at generator time: inside `quote`, the


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #1217. Three things in the same branch:

- `cache.val.abstol`, `cache.val.reltol` and `cache.val.verbose`. All three callers (the ChainRulesCore, Enzyme and Mooncake rules) pass a `LinearCache`, and `hasproperty(cache, :val)` is `false` for that type, so the branch throws wherever it is reached.
- It returned the `LinearSolution` where the four sibling branches return an array, so the caller's `λ .* tu` would get a solution object.
- It used `transpose(cache.A)` where the rest of the function takes the adjoint, which differ for a complex eltype.

There is no test. Reaching this branch needs the default solver to pick a Krylov method, which happens for a square `AbstractSciMLOperator` without `ldiv!`. I confirmed that selection, but could not stand up a working matrix-free operator here: `FunctionOperator` probes the operator with `u === nothing` during construction in the version I have, on every keyword combination I tried.

It is worth sending anyway, because the current code cannot run at all rather than merely running badly, and the change only makes the branch agree with its siblings. It also stops being unreachable-in-practice if #1222 lands, since `solve!(cache; adjoint = true)` routes through here for a default-solver cache. Happy to hold this until someone can add a test with a real operator.

Core passes.
