### PR TITLE
compat: raise SciMLTesting floor to 2.10

### DIFF
--- a/lib/LinearSolveAutotune/Project.toml
+++ b/lib/LinearSolveAutotune/Project.toml
@@ -63,9 +63,11 @@ SafeTestsets = "0.1"
 Test = "1"
 blis_jll = "0.9.0"
 gh_cli_jll = "2"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/lib/LinearSolveAutotune/Project.toml
+++ b/lib/LinearSolveAutotune/Project.toml
@@ -63,7 +63,7 @@ SafeTestsets = "0.1"
 Test = "1"
 blis_jll = "0.9.0"
 gh_cli_jll = "2"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/LinearSolvePyAMG/Project.toml
+++ b/lib/LinearSolvePyAMG/Project.toml
@@ -24,7 +24,7 @@ SafeTestsets = "0.1"
 SciMLBase = "3.33"
 SparseArrays = "1.10"
 Test = "<0.0.1, 1"
-SciMLTesting = "2.4"
+SciMLTesting = "2.10"
 julia = "1.10"
 
 [extras]

--- a/lib/LinearSolvePyAMG/Project.toml
+++ b/lib/LinearSolvePyAMG/Project.toml
@@ -24,9 +24,11 @@ SafeTestsets = "0.1"
 SciMLBase = "3.33"
 SparseArrays = "1.10"
 Test = "<0.0.1, 1"
+SciMLTesting = "2.4"
 julia = "1.10"
 
 [extras]
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This is a mechanical compat-only PR. Raise every affected root/sublibrary SciMLTesting compat entry from 2.1 to 2.10 so the repository uses the strict SciMLTesting QA defaults. No source, test behavior, or documentation changes are included. Please ignore this draft until reviewed by @ChrisRackauckas. Local git diff --check and typos checks pass.