### PR TITLE
Solve a sparse GPU QR through cuSOLVER

### DIFF
--- a/ext/LinearSolveCUDAExt.jl
+++ b/ext/LinearSolveCUDAExt.jl
@@ -143,6 +143,25 @@ function LinearSolve.init_cacheval(
     return qr(CUDACore.CuArray(A))
 end
 
+# `qr` on a `CuSparseMatrix` falls through to the generic sparse path and dies on scalar
+# indexing, so a sparse QR on the GPU was not reachable through `QRFactorization` at all.
+# cuSOLVER's `csrlsvqr!` does the whole thing on the device. It wants CSR with `Int32`
+# indices, which is also the layout cuSOLVER's other sparse entry points take.
+# See https://github.com/SciML/LinearSolve.jl/issues/410.
+function SciMLBase.solve!(
+        cache::LinearSolve.LinearCache{<:cuSPARSE.CuSparseMatrixCSR{T, Int32}},
+        alg::LinearSolve.QRFactorization; kwargs...
+    ) where {T}
+    A = cache.A
+    # `csrlsvqr!` factorizes and solves in one call, so there is nothing to cache between
+    # solves; `cache.isfresh` is cleared only to keep the flag honest.
+    cuSOLVER.csrlsvqr!(A, cache.b, cache.u, T(cache.reltol), Cint(1), 'O')
+    cache.isfresh = false
+    return SciMLBase.build_linear_solution(
+        alg, cache.u, nothing, cache; retcode = LinearSolve.ReturnCode.Success
+    )
+end
+
 for AlgType in (SparspakFactorization, LinearSolve.QRFactorization)
     @eval function LinearSolve.init_cacheval(
             ::$AlgType, A::cuSPARSE.CuSparseMatrixCSR, b, u,


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #410, along the lines @amontoison pointed at in the thread.

- `QRFactorization` on a `CuSparseMatrix` had `init_cacheval` returning `nothing`, so it fell through to the generic sparse `qr`, which dies on scalar indexing. Checked on a T4: both `CuSparseMatrixCSC` and `CuSparseMatrixCSR` raise `Scalar indexing is disallowed` on current main, so the densification in the original report has since become an error.
- cuSOLVER's `csrlsvqr!` does the factorization and the solve on the device. It takes CSR with `Int32` indices, which is the layout its other sparse entry points use.

On a T4, 200x200 tridiagonal:

  | | main | this branch |
  | --- | --- | --- |
  | `QRFactorization` on CSR | errors | 3.02e-16 |
  | cached resolve, new `b` | errors | 3.5e-16 |

- `csrlsvqr!` factorizes and solves in one call, so there is nothing to keep between solves and a resolve against a new right-hand side refactorizes. `cuSOLVER.SparseQR` does expose a reusable object and would be the next step if repeated solves against one matrix matter.
- No test in the suite, since the GPU group does not currently run. The snippet in the issue is the check.
