### PR TITLE
Correct the exported docstrings against the code they document

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,10 +26,6 @@ makedocs(
     linkcheck_ignore = [
         "https://cli.github.com/manual/installation",
         "https://pyamg.readthedocs.io",
-        # These cross-package API links are user-facing, but the docs host
-        # rejects Documenter's automated linkcheck requests with HTTP 403.
-        "https://docs.sciml.ai/SciMLBase/stable/interfaces/LinearProblem/",
-        "https://docs.sciml.ai/SciMLBase/stable/interfaces/EigenvalueProblem/",
         # GitHub rate-limits this stable SuiteSparse source link during CI.
         "https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/dev/UMFPACK/Doc/UMFPACK_UserGuide.pdf",
     ],

--- a/docs/src/assets/Project.toml
+++ b/docs/src/assets/Project.toml
@@ -1,0 +1,23 @@
+[deps]
+BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
+CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+LinearSolveAutotune = "67398393-80e8-4254-b7e4-1b9a36a3c5b6"
+LinearSolvePyAMG = "7a56c47d-7ab1-4e99-b0e3-2952e463d64a"
+SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[sources]
+LinearSolve = {path = ".."}
+LinearSolveAutotune = {path = "../lib/LinearSolveAutotune"}
+LinearSolvePyAMG = {path = "../lib/LinearSolvePyAMG"}
+
+[compat]
+BlockDiagonals = "0.2"
+CommonSolve = "0.2"
+Documenter = "1"
+LinearSolve = "5"
+LinearSolveAutotune = "1.1"
+LinearSolvePyAMG = "1"
+SciMLOperators = "1"

--- a/docs/src/basics/EigenvalueProblem.md
+++ b/docs/src/basics/EigenvalueProblem.md
@@ -1,5 +1,75 @@
-# Eigenvalue Problems
+# [Eigenvalue Problems](@id eigenvalue_problem)
 
-`EigenvalueProblem` and `EigenvalueTarget` are provided by SciMLBase and
-reexported by LinearSolve. Their owning API documentation is available in the
-[SciMLBase eigenvalue interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/EigenvalueProblem/).
+`EigenvalueProblem` and `EigenvalueTarget` are SciMLBase types re-exported by
+LinearSolve.jl. Their docstrings are maintained in SciMLBase and rendered in the
+[SciMLBase problem interface documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/);
+this page summarizes how LinearSolve.jl uses them. See the
+[eigenvalue tutorial](@ref eigenvalue_tutorial) for worked examples and the
+[eigenvalue solvers](@ref eigenvaluesolvers) page for the available algorithms.
+
+## Mathematical Specification
+
+The standard problem finds pairs ``(\lambda, v)`` with
+
+```math
+A v = \lambda v
+```
+
+and, when a second operator `B` is given, the generalized problem
+
+```math
+A v = \lambda B v
+```
+
+Eigenvectors follow the type of `u0` when supplied, otherwise the dense vector
+type matching a row of `A`. Eigenvalues have `eltype(A)` when real and
+`Complex{eltype(A)}` when a general real `A` yields conjugate pairs.
+
+## Constructor
+
+```julia
+EigenvalueProblem(A, B = nothing, p = NullParameters();
+    num_eigenpairs = nothing, eigentarget = EigenvalueTarget.LargestMagnitude,
+    shift = nothing, u0 = nothing, kwargs...)
+```
+
+  - `num_eigenpairs`: how many eigenpairs to compute; `nothing` requests all of
+    them from the dense solver or a solver-chosen default from the iterative
+    backends.
+  - `eigentarget`: which part of the spectrum to return, an `EigenvalueTarget`
+    (below).
+  - `shift`: when supplied, the eigenvalues nearest this value are returned
+    (shift-and-invert).
+  - `u0`: an optional starting vector for the iterative backends.
+  - `kwargs`: extra keyword arguments passed on to the solver.
+
+## `EigenvalueTarget`
+
+`EigenvalueTarget` is an [EnumX](https://github.com/fredrikekre/EnumX.jl) enum
+selecting the part of the spectrum returned when only a subset of the eigenpairs
+is requested:
+
+| Value                                    | Selects                                       |
+|:---------------------------------------- |:--------------------------------------------- |
+| `EigenvalueTarget.LargestMagnitude`      | largest `abs(λ)` (the default)                |
+| `EigenvalueTarget.SmallestMagnitude`     | smallest `abs(λ)`                             |
+| `EigenvalueTarget.LargestRealPart`       | largest (most positive) real part             |
+| `EigenvalueTarget.SmallestRealPart`      | smallest (most negative) real part            |
+| `EigenvalueTarget.LargestImaginaryPart`  | largest (most positive) imaginary part        |
+| `EigenvalueTarget.SmallestImaginaryPart` | smallest (most negative) imaginary part       |
+
+Not every backend supports every target directly; the
+[eigenvalue solvers](@ref eigenvaluesolvers) page lists each algorithm's
+restrictions.
+
+## Example
+
+```julia
+using LinearSolve
+
+A = [2.0 1.0; 1.0 3.0]
+prob = EigenvalueProblem(A; num_eigenpairs = 1,
+    eigentarget = EigenvalueTarget.LargestMagnitude)
+sol = solve(prob)
+sol.values, sol.vectors
+```

--- a/docs/src/basics/LinearProblem.md
+++ b/docs/src/basics/LinearProblem.md
@@ -1,5 +1,61 @@
-# Linear Problems
+# [Linear Problems](@id linear_problem)
 
-`LinearProblem` is provided by SciMLBase and reexported by LinearSolve. See the
-[SciMLBase linear problem interface](https://docs.sciml.ai/SciMLBase/stable/interfaces/LinearProblem/)
-for its owning API documentation.
+`LinearProblem` is the SciMLBase problem type for linear systems, re-exported by
+LinearSolve.jl. Its docstring is maintained in SciMLBase and rendered in the
+[SciMLBase problem interface documentation](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/);
+this page summarizes how LinearSolve.jl uses it.
+
+## Mathematical Specification
+
+A `LinearProblem` defines the system
+
+```math
+Au = b
+```
+
+where `A` is either a concrete `AbstractMatrix` (dense, sparse, GPU, ...) or a
+matrix-free operator from the
+[SciMLOperators](https://docs.sciml.ai/SciMLOperators/stable/) interface, and `b`
+is the right-hand side. Matrix-free operators are not compatible with every
+solver; a solver's `needs_concrete_A(alg)` reports whether it requires a
+materialized matrix.
+
+## Constructors
+
+```julia
+LinearProblem(A, b, p = NullParameters(); u0 = nothing, kwargs...)
+LinearProblem{isinplace}(A, b, p = NullParameters(); u0 = nothing, kwargs...)
+LinearProblem(f::AbstractSciMLOperator, b, p = NullParameters(); u0 = nothing, kwargs...)
+```
+
+  - `A`, `b`: the operator and right-hand side.
+  - `p`: problem parameters, `NullParameters()` when absent (currently unused by
+    the solvers).
+  - `u0`: an optional initial guess, used by iterative methods.
+  - `isinplace`: whether solvers may mutate `A` and `b`; defaults to `true` for
+    an `AbstractMatrix` and follows the operator's own setting for an
+    `AbstractSciMLOperator`.
+  - `kwargs`: any extra keyword arguments are stored on the problem and passed to
+    `solve`; see [Common Solver Options](@ref "Common Solver Options (Keyword Arguments for Solve)").
+
+## Fields
+
+  - `A`: the linear operator.
+  - `b`: the right-hand side.
+  - `p`: the parameters.
+  - `u0`: the initial guess, or `nothing`.
+  - `symbolic_interface`: a `SymbolicLinearInterface` when the problem was built
+    by a symbolic front end, else `nothing`.
+  - `kwargs`: keyword arguments forwarded to the solvers.
+
+## Example
+
+```julia
+using LinearSolve
+
+A = rand(4, 4)
+b = rand(4)
+prob = LinearProblem(A, b)
+sol = solve(prob)
+sol.u
+```

--- a/docs/src/solvers/eigenvalue_solvers.md
+++ b/docs/src/solvers/eigenvalue_solvers.md
@@ -1,6 +1,6 @@
 # [Eigenvalue Problem Solvers](@id eigenvaluesolvers)
 
-`LS.solve(prob, alg; kwargs)` for a [`SciMLBase.EigenvalueProblem`](https://docs.sciml.ai/SciMLBase/stable/interfaces/EigenvalueProblem/).
+`LS.solve(prob, alg; kwargs)` for an [`EigenvalueProblem`](@ref eigenvalue_problem).
 
 Solves for the eigenpairs $$(\lambda, v)$$ of $$Av = \lambda v$$ (or the generalized
 problem $$Av = \lambda Bv$$ when a second operator is supplied) defined by `prob` using

--- a/docs/src/tutorials/eigenvalue.md
+++ b/docs/src/tutorials/eigenvalue.md
@@ -1,4 +1,4 @@
-# Getting Started with Solving Eigenvalue Problems in Julia
+# [Getting Started with Solving Eigenvalue Problems in Julia](@id eigenvalue_tutorial)
 
 An eigenvalue problem $$Av = \lambda v$$ (or, generalized, $$Av = \lambda Bv$$) is
 specified by defining an `EigenvalueProblem`. As with `LinearProblem`, the same
@@ -25,7 +25,7 @@ decomposition.
 
 For large problems, computing every eigenpair is wasteful when only a handful are
 needed. `num_eigenpairs` controls how many eigenpairs are returned, and `eigentarget`
-(an [`EigenvalueTarget`](https://docs.sciml.ai/SciMLBase/stable/interfaces/EigenvalueProblem/)) controls which part of the spectrum they come from:
+(an [`EigenvalueTarget`](@ref eigenvalue_problem)) controls which part of the spectrum they come from:
 
 ```@example eigsys1
 prob = LS.EigenvalueProblem(

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -460,13 +460,50 @@ Apply a supernodal triangular-panel operation using the requested backend.
 
 # Keywords
 
-  - `operation`: One of `:factor_right_upper`, `:factor_lower`, `:lower`, or `:upper`.
-  - `algorithm`: Panel backend. `:auto` selects between `:kernel`, `:blas`, and
-    `:triangularsolve` from the operand types and dimensions.
+  - `operation`: which triangular operation to apply. One of
+
+      + `:factor_right_upper`: `B := B / U11`, a right solve with the non-unit
+        upper triangle (used during numeric factorization to form `L21`).
+      + `:factor_lower`: `B := L11 \\ B`, a left solve with the unit-lower triangle
+        (used during numeric factorization to form `U12`).
+      + `:lower`: `B := L11 \\ B`, the unit-lower forward substitution of the solve
+        phase.
+      + `:upper`: `B := U11 \\ B`, the non-unit upper back substitution of the
+        solve phase.
+
+    Any other symbol throws an `ArgumentError`. `:factor_lower` and `:lower`
+    compute the same result; they differ only in which backend code path each
+    `algorithm` routes them to (see below).
+  - `algorithm`: backend to dispatch to through `supernodal_panel_solve_backend!`.
+    Defaults to `:auto`. Accepted values:
+
+      + `:kernel`: the in-tree column-oriented kernels (generic over the element
+        type, allocation-free) for `:lower`/`:upper`; the `:factor_*` operations
+        are forwarded to `:triangularsolve`.
+      + `:blas`: `BLAS.trsm!` for `:lower`/`:upper` when `W` and `B` are strided
+        `BlasFloat` matrices, the kernels for other element types; the `:factor_*`
+        operations are forwarded to `:triangularsolve`.
+      + `:triangularsolve`: `LinearAlgebra.ldiv!`/`rdiv!` on the triangular
+        wrappers, replaced by TriangularSolve.jl kernels for strided `Float32`
+        and `Float64` panels when RecursiveFactorization.jl and TriangularSolve.jl
+        are loaded.
+      + `:auto`: `:factor_right_upper` and `:factor_lower` always go to
+        `:triangularsolve`. `:lower` and `:upper` use `:kernel` when
+        `np <= PANEL_KERNEL_MAX_NP` (256), when `B` has a single column, or when
+        the element type is not a `BlasFloat`; otherwise `:blas` when
+        `np > PANEL_BLAS_MIN_NP` (1792) and `:triangularsolve` in between.
 
 # Returns
 
 The updated `B`.
+
+!!! note
+
+    The TriangularSolve.jl backend is only active when both RecursiveFactorization.jl
+    and TriangularSolve.jl are loaded; `using RecursiveFactorization` is enough,
+    since RecursiveFactorization.jl depends on TriangularSolve.jl. Without them
+    `:triangularsolve` routes `:lower`/`:upper` back to `:blas` and the
+    `:factor_*` operations to the stdlib triangular solves.
 """
 function supernodal_panel_solve! end
 
@@ -485,6 +522,30 @@ Unsupported operations must throw `ArgumentError`.
 The built-in backends use `Val(:kernel)`, `Val(:blas)`, and
 `Val(:triangularsolve)`. Extensions should add methods only for backend and operand
 combinations they implement; the generic methods provide the fallback behavior.
+
+# Built-in backends
+
+  - `Val(:kernel)`: runs `:lower`/`:upper` through the in-tree column-oriented
+    kernels; `:factor_right_upper`/`:factor_lower` are forwarded to
+    `Val(:triangularsolve)`.
+  - `Val(:blas)`: runs `:lower`/`:upper` through `BLAS.trsm!` when `W` and `B` are
+    strided `BlasFloat` matrices, and through the kernels otherwise;
+    `:factor_right_upper`/`:factor_lower` are forwarded to `Val(:triangularsolve)`.
+  - `Val(:triangularsolve)`: the in-tree method runs `:factor_right_upper` through
+    `LinearAlgebra.rdiv!` with `UpperTriangular` and `:factor_lower` through
+    `LinearAlgebra.ldiv!` with `UnitLowerTriangular`, and forwards
+    `:lower`/`:upper` to `Val(:blas)`.
+
+This is the extension hook: a package can add a more specific method for
+`Val(:triangularsolve)` and supported panel types. The
+`LinearSolveRecursiveFactorizationExt` extension defines
+
+    supernodal_panel_solve_backend!(::Val{:triangularsolve}, W::StridedMatrix{Tv},
+        B::StridedMatrix{Tv}, np::Int; operation::Symbol) where {Tv <: Union{Float32, Float64}}
+
+which runs all four operations through TriangularSolve.jl and is active once
+RecursiveFactorization.jl and TriangularSolve.jl are both loaded
+(`using RecursiveFactorization` is enough, since it depends on TriangularSolve.jl).
 """
 function supernodal_panel_solve_backend! end
 # after default.jl: the vendored solver caches its dense diagonal blocks

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -1,7 +1,8 @@
 """
     LinearSolveAdjoint(; linsolve = missing, Pl = missing, Pr = missing)
 
-Given a Linear Problem ``A x = b`` computes the sensitivities for ``A`` and ``b`` as:
+Sensitivity algorithm for reverse-mode differentiation of a linear solve. Given a Linear
+Problem ``A x = b`` it computes the sensitivities for ``A`` and ``b`` as:
 
 ```math
 \\begin{align}
@@ -12,6 +13,31 @@ A' \\lambda &= \\partial x   \\\\
 ```
 
 For more details, check [these notes](https://math.mit.edu/~stevenj/18.336/adjoint.pdf).
+
+## Usage
+
+The object is passed as the `sensealg` keyword of `init`/`solve`, and
+`LinearSolveAdjoint()` is already the default value of that keyword, so nothing needs to
+be done to differentiate a solve; construct one explicitly only to override the adjoint
+linear solver or preconditioners:
+
+```julia
+sol = solve(prob, alg; sensealg = LinearSolveAdjoint(linsolve = KrylovJL_GMRES()))
+```
+
+The stored settings are consulted by the reverse-mode rules for `solve` and `solve!`:
+the ChainRulesCore `rrule` (used by Zygote and other ChainRules-based tools, loaded with
+`using ChainRulesCore` or `using Zygote`) and the Mooncake rule (`using Mooncake`).
+Those rules currently accept only a `LinearSolveAdjoint` as `sensealg`.
+
+## Keyword Arguments
+
+  - `linsolve`: the LinearSolve algorithm instance (e.g. `LUFactorization()`,
+    `KrylovJL_GMRES()`) used to solve the adjoint system ``A' \\lambda = \\partial x``.
+    Defaults to `missing`, meaning reuse the forward algorithm (and, where possible, its
+    cached factorization).
+  - `Pl`, `Pr`: left and right preconditioners for the adjoint solve. Default to
+    `missing`, meaning derive them from the forward preconditioners as described below.
 
 ## Choice of Linear Solver
 

--- a/src/appleaccelerate.jl
+++ b/src/appleaccelerate.jl
@@ -4,12 +4,31 @@ using LinearAlgebra
 const global libacc = "/System/Library/Frameworks/Accelerate.framework/Accelerate"
 
 """
-```julia
-AppleAccelerateLUFactorization()
-```
+    AppleAccelerateLUFactorization(; residualsafety::Bool = false)
 
-A wrapper over Apple's Accelerate Library. Direct calls to Acceelrate in a way that pre-allocates workspace
-to avoid allocations and does not require libblastrampoline.
+A wrapper over Apple's Accelerate library. Direct calls to Accelerate's LU routines
+(`getrf!` and `getrs!`) in a way that pre-allocates workspace to avoid allocations and does
+not require libblastrampoline. Supports `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`
+element types.
+
+Use this to guarantee Accelerate's LU is used regardless of the system BLAS configuration
+(no `using AppleAccelerate` needed), or when benchmarking shows it beats `LUFactorization`
+on your Mac. Where Accelerate is available, the default algorithm choice already selects
+this method for all but the smallest dense BLAS-eltype matrices.
+
+## Keyword Arguments
+
+  - `residualsafety`: If `true`, every solve that (re)factorizes `A` is followed by a
+    residual check against a copy of the original matrix. If `‖A*x - b‖` exceeds
+    `abstol + reltol * ‖b‖` (the tolerances of the solve), the returned solution has
+    `retcode = ReturnCode.APosterioriSafetyFailure`. Defaults to `false`.
+
+!!! note
+
+    This solver is macOS-only: it requires the system Accelerate framework to be loadable
+    (`/System/Library/Frameworks/Accelerate.framework/Accelerate` exporting `dgetrf_`).
+    On other platforms, or if the framework cannot be opened, `solve!` with this algorithm
+    errors that the AppleAccelerate binary is missing.
 """
 struct AppleAccelerateLUFactorization <: AbstractFactorization
     residualsafety::Bool

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,21 +1,51 @@
 """
-`OperatorCondition`
+    EnumX.@enumx OperatorCondition
 
-Specifies the assumption of matrix conditioning for the default linear solver choices. Condition number
-is defined as the ratio of eigenvalues. The numerical stability of many linear solver algorithms
-can be dependent on the condition number of the matrix. The condition number can be computed as:
+Specifies the assumption of matrix conditioning for the default linear solver choices.
+The condition number is the ratio of the largest to the smallest singular value of `A`
+(for normal matrices this coincides with the ratio of the extreme eigenvalue magnitudes).
+The numerical stability of many linear solver algorithms can be dependent on the
+condition number of the matrix. The condition number can be computed as:
 
 ```julia
 using LinearAlgebra
 cond(rand(100, 100))
 ```
 
-However, in practice this computation is very expensive and thus not possible for most practical cases.
-Therefore, OperatorCondition lets one share to LinearSolve the expected conditioning. The higher the
-expected condition number, the safer the algorithm needs to be and thus there is a trade-off between
-numerical performance and stability. By default the method assumes the operator may be ill-conditioned
-for the standard linear solvers to converge (such as LU-factorization), though more extreme
-ill-conditioning or well-conditioning could be the case and specified through this assumption.
+However, in practice this computation is very expensive and thus not possible for most
+practical cases. Therefore, `OperatorCondition` lets one share to LinearSolve the
+expected conditioning. The higher the expected condition number, the safer the
+algorithm needs to be and thus there is a trade-off between numerical performance and
+stability. By default the method assumes the operator may be ill-conditioned for the
+standard linear solvers to converge (such as LU-factorization), though more extreme
+ill-conditioning or well-conditioning could be the case and specified through this
+assumption.
+
+The assumption is supplied through the `condition` keyword of `OperatorAssumptions`,
+which in turn is passed as the `assumptions` keyword of `init` (or the `assump`
+keyword of `solve` when no algorithm is given):
+
+```julia
+cache = init(prob; assumptions = OperatorAssumptions(true;
+    condition = OperatorCondition.WellConditioned))
+sol = solve!(cache)
+```
+
+It only affects the default algorithm (`solve(prob)` with no algorithm given). The
+members and their effect on the dense default choice are:
+
+  - `OperatorCondition.IllConditioned` (default): pivoted LU for square `A`
+    (`LUFactorization` or one of its size- and BLAS-dependent variants), QR
+    (column-pivoted when underdetermined) for non-square `A`.
+  - `OperatorCondition.WellConditioned`: LU for square `A` (as above),
+    `NormalCholeskyFactorization` for non-square `A`.
+  - `OperatorCondition.VeryIllConditioned`: `QRFactorization` (column-pivoted when
+    underdetermined).
+  - `OperatorCondition.SuperIllConditioned`: `SVDFactorization`.
+
+Sparse and structured `A` have their own default choices that do not consult this
+setting; on GPU arrays `IllConditioned` (or a non-square `A`) selects QR and the other
+members select LU.
 """
 EnumX.@enumx OperatorCondition begin
     """
@@ -98,40 +128,58 @@ end
 
 """
     OperatorAssumptions(issquare = nothing;
-                        condition::OperatorCondition.T = IllConditioned,
-                        nonstructural_zeros::NonstructuralZeros.T = Auto)
+                        condition::OperatorCondition.T = OperatorCondition.IllConditioned,
+                        nonstructural_zeros::NonstructuralZeros.T = NonstructuralZeros.Auto)
 
-Sets the operator `A` assumptions used as part of the default algorithm.
+Sets the operator `A` assumptions used as part of the default algorithm. The object is
+supplied through the `assumptions` keyword of `init` (or the `assump` keyword of
+`solve` when no algorithm is given), whose default is
+`OperatorAssumptions(issquare(prob.A))`:
 
-`issquare` asserts whether `A` is square (and thus whether a direct
-factorization vs. a least-squares solver is appropriate). `nothing` (default)
-defers the decision, letting `init`/`defaultalg` infer it from `A`.
+```julia
+cache = init(prob; assumptions = OperatorAssumptions(true;
+    condition = OperatorCondition.WellConditioned))
+sol = solve!(cache)
+```
 
-`condition` describes the conditioning of `A` and selects how aggressively the
-default algorithm trades speed for stability (see [`OperatorCondition`](@ref)):
+## Positional Arguments
 
-  - `OperatorCondition.IllConditioned` (default): assume `A` may be ill
-    conditioned; pick a stability-preserving algorithm (e.g. pivoted
-    factorizations).
-  - `OperatorCondition.WellConditioned`: assume contained conditioning and pick
-    the fastest algorithm, skipping safety work.
-  - `OperatorCondition.VeryIllConditioned` /
-    `OperatorCondition.SuperIllConditioned`: progressively more conservative,
-    favoring the most numerically robust paths.
+  - `issquare`: asserts whether `A` is square (and thus whether a direct
+    factorization vs. a least-squares solver is appropriate). `nothing` (default)
+    defers the decision, letting `init`/`defaultalg` infer it from `A`.
 
-`nonstructural_zeros` declares how `A`'s *nonstructural zeros* (stored entries
-that are numerically zero) behave across a sequence of solves, and hence whether
-and how a sparse factorization should drop them (see [`NonstructuralZeros`](@ref)):
+## Keyword Arguments
 
-  - `NonstructuralZeros.Auto` (default): detect from the starting matrix and
-    adapt (cached union, falling back to per-solve dropzeros if non-persistent).
-  - `NonstructuralZeros.None`: none worth dropping; never reduce (bit-identical).
-  - `NonstructuralZeros.Persistent`: present at stable positions; cached-union
-    reduction.
-  - `NonstructuralZeros.Present`: present but positions may vary; per-solve
-    dropzeros.
+  - `condition`: describes the conditioning of `A` and selects how aggressively the
+    default algorithm trades speed for stability (see `OperatorCondition`). Defaults
+    to `OperatorCondition.IllConditioned`.
 
-Has no effect on dense `A`.
+      + `OperatorCondition.IllConditioned` (default): assume `A` may be ill
+        conditioned; pick a stability-preserving algorithm (e.g. pivoted
+        factorizations).
+      + `OperatorCondition.WellConditioned`: assume contained conditioning and pick
+        the fastest algorithm, skipping safety work.
+      + `OperatorCondition.VeryIllConditioned` /
+        `OperatorCondition.SuperIllConditioned`: progressively more conservative,
+        favoring the most numerically robust paths.
+
+  - `nonstructural_zeros`: declares how `A`'s *nonstructural zeros* (stored entries
+    that are numerically zero) behave across a sequence of solves, and hence whether
+    and how a sparse factorization should drop them (see `NonstructuralZeros`).
+    Defaults to `NonstructuralZeros.Auto`.
+
+      + `NonstructuralZeros.Auto` (default): detect from the starting matrix and
+        adapt (cached union, falling back to per-solve dropzeros if non-persistent).
+      + `NonstructuralZeros.None`: none worth dropping; never reduce (bit-identical).
+      + `NonstructuralZeros.Persistent`: present at stable positions; cached-union
+        reduction.
+      + `NonstructuralZeros.Present`: present but positions may vary; per-solve
+        dropzeros.
+
+`issquare` and `condition` steer the dense default choice (LU vs. QR vs. SVD vs.
+`NormalCholeskyFactorization`); `nonstructural_zeros` only applies to sparse `A` and
+has no effect on dense `A`. Sparse and structured `A` consult at most `issquare` when
+picking their default.
 """
 struct OperatorAssumptions{T}
     issq::T

--- a/src/default.jl
+++ b/src/default.jl
@@ -964,13 +964,15 @@ function _algchoice_to_alg_with_safety(alg::Symbol)
     end
 end
 
-"""
-if alg.alg === DefaultAlgorithmChoice.LUFactorization
-SciMLBase.solve!(cache, LUFactorization(), args...; kwargs...))
-else
-...
-end
-"""
+# Generated body has the shape
+#
+#     if alg.alg === DefaultAlgorithmChoice.LUFactorization
+#         SciMLBase.solve!(cache, LUFactorization(), args...; kwargs...)
+#     elseif ...
+#     end
+#
+# with one branch per DefaultAlgorithmChoice, so each branch calls solve! on a
+# concrete algorithm type instead of going through a Symbol-to-algorithm lookup.
 @generated function SciMLBase.solve!(
         cache::LinearCache, alg::DefaultLinearSolver,
         args...;

--- a/src/eigenvalue.jl
+++ b/src/eigenvalue.jl
@@ -4,8 +4,25 @@ using SciMLBase: EigenvalueProblem, EigenvalueSolution, EigenvalueTarget,
 """
     AbstractEigenvalueAlgorithm
 
-Base type for algorithms that solve a
-[`SciMLBase.EigenvalueProblem`](https://docs.sciml.ai/SciMLBase/stable/interfaces/EigenvalueProblem/).
+Base type for algorithms that solve an `EigenvalueProblem`. An instance is passed as
+the second argument of `solve(prob::EigenvalueProblem, alg)`; when no algorithm is
+given, `DenseEigen()` is used.
+
+The concrete algorithms are:
+
+  - `DenseEigen`: dense `LinearAlgebra.eigen`, the default; always available.
+  - `ArpackJL`: `Arpack.eigs` (requires `using Arpack`).
+  - `ArnoldiMethodJL` / `ArnoldiMethod`: `ArnoldiMethod.partialschur` (requires
+    `using ArnoldiMethod`).
+  - `KrylovKitEigen`: `KrylovKit.eigsolve` (requires `using KrylovKit`).
+  - `JacobiDavidsonJL`: `JacobiDavidson.jdqr` (requires `using JacobiDavidson`).
+
+A new backend subtypes this type and defines
+`SciMLBase.solve(prob::EigenvalueProblem, alg::MyAlg, args...; kwargs...)`, returning
+an `EigenvalueSolution` (see `SciMLBase.build_eigenvalue_solution`). The fallback
+method for the abstract type throws "The eigenvalue backend ... is not available",
+which is what a user sees when an extension-backed algorithm is used before its
+package has been loaded.
 """
 abstract type AbstractEigenvalueAlgorithm <: SciMLBase.AbstractLinearAlgorithm end
 
@@ -44,14 +61,31 @@ ArpackJL(; kwargs...) = ArpackJL((; kwargs...))
 """
     ArnoldiMethodJL(; kwargs...)
 
-Same solver as [`ArnoldiMethod`](@ref); see its docstring for details.
+Solve the `EigenvalueProblem` with
+[ArnoldiMethod.jl](https://github.com/JuliaLinearAlgebra/ArnoldiMethod.jl)'s
+`partialschur`, a pure-Julia implicitly restarted Arnoldi method for computing a few
+eigenpairs of a large sparse or structured matrix. Extra `kwargs` are forwarded to
+`ArnoldiMethod.partialschur` (for example `tol`, `mindim`, `maxdim`, `restarts`).
 
-Prefer this spelling when the ArnoldiMethod.jl package is in scope. Loading that
-package is what makes this solver available, and it binds the name
+Restrictions of the backend:
+
+  - Standard problems only: a generalized problem (`B !== nothing`) raises an error.
+  - `eigentarget = EigenvalueTarget.SmallestMagnitude` is not supported directly
+    (ArnoldiMethod has no such target); supply `shift` for shift-and-invert, which
+    factorizes `A - shift*I` and finds the eigenvalues nearest `shift`, or use another
+    backend such as `KrylovKitEigen()` or `ArpackJL()`.
+
+`ArnoldiMethodJL(; kwargs...)` and `ArnoldiMethod(; kwargs...)` build the same
+algorithm object; this is the spelling to prefer once the ArnoldiMethod.jl package is
+loaded. Loading that package is what makes the solver available, and it binds the name
 `ArnoldiMethod` to the module, so after `using LinearSolve, ArnoldiMethod` a bare
-`ArnoldiMethod(; kwargs...)` reaches the module rather than the constructor and
-fails with "objects of type Module are not callable". `ArnoldiMethodJL` does not
-collide, and matches how the other backends are named.
+`ArnoldiMethod(; kwargs...)` reaches the module rather than the constructor and fails
+with "objects of type Module are not callable" (and `?ArnoldiMethod` shows the module's
+help). `ArnoldiMethodJL` does not collide, and matches how the other backends are named.
+
+!!! note
+
+    Using this solver requires loading ArnoldiMethod.jl, i.e. `using ArnoldiMethod`.
 """
 struct ArnoldiMethodJL{K <: NamedTuple} <: AbstractEigenvalueAlgorithm
     kwargs::K
@@ -65,9 +99,19 @@ ArnoldiMethodJL(; kwargs...) = ArnoldiMethodJL((; kwargs...))
 Solve the `EigenvalueProblem` with
 [ArnoldiMethod.jl](https://github.com/JuliaLinearAlgebra/ArnoldiMethod.jl)'s
 `partialschur`, a pure-Julia implicitly restarted Arnoldi method for large sparse or
-structured matrices. Does not support `eigentarget = EigenvalueTarget.SmallestMagnitude`
-directly; use `shift` for shift-and-invert instead, or another backend. Extra `kwargs`
-are forwarded to `ArnoldiMethod.partialschur`.
+structured matrices. Extra `kwargs` are forwarded to `ArnoldiMethod.partialschur`.
+
+Restrictions of the backend:
+
+  - Standard problems only: a generalized problem (`B !== nothing`) raises an error.
+  - `eigentarget = EigenvalueTarget.SmallestMagnitude` is not supported directly;
+    supply `shift` for shift-and-invert instead, or use another backend such as
+    `KrylovKitEigen()` or `ArpackJL()`.
+
+This constructor returns an `ArnoldiMethodJL`; the two names build the same algorithm.
+Once the ArnoldiMethod.jl package is loaded the bare name `ArnoldiMethod` refers to
+that module, so use `ArnoldiMethodJL(; kwargs...)` (or `LinearSolve.ArnoldiMethod`)
+in that case.
 
 !!! note
 
@@ -80,8 +124,23 @@ ArnoldiMethod(; kwargs...) = ArnoldiMethodJL((; kwargs...))
 
 Solve the `EigenvalueProblem` with
 [KrylovKit.jl](https://github.com/Jutho/KrylovKit.jl)'s `eigsolve`, a Krylov solver
-supporting both standard and generalized eigenvalue problems, extremal and interior
-(shifted) targets. Extra `kwargs` are forwarded to `KrylovKit.eigsolve`.
+for a few extremal or interior (shifted) eigenpairs of a large sparse or structured
+matrix. Extra `kwargs` are forwarded to the KrylovKit call (for example `tol`,
+`krylovdim`, `maxiter`, `issymmetric`, `ishermitian`, `isposdef`).
+
+Which KrylovKit routine runs depends on the problem:
+
+  - Standard problem, no `shift`: `KrylovKit.eigsolve(A, nev, which)` with `which`
+    derived from `eigentarget`; no symmetry or definiteness is required of `A`.
+  - Any problem with a `shift`: shift-and-invert. `A - shift*I` (or `A - shift*B` for a
+    generalized problem) is factorized and `KrylovKit.eigsolve` is run on the inverse
+    operator, so general (non-Hermitian) pencils are supported on this path.
+  - Generalized problem without a `shift`: `KrylovKit.geneigsolve((A, B), nev, which)`.
+    KrylovKit only implements the symmetric/Hermitian case with positive definite `B`
+    and throws an `ArgumentError` otherwise (it also rejects the imaginary-part
+    targets). For matrices these properties are detected automatically; for other
+    operator types pass `issymmetric = true`/`ishermitian = true` and `isposdef = true`
+    through `kwargs`. For a non-Hermitian pencil supply a `shift` instead.
 
 !!! note
 

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -252,31 +252,44 @@ end
 needs_concrete_A(::HYPREAlgorithm) = true
 
 """
-`PartitionedSolversAlgorithm(solver = nothing; kwargs...)`
+    PartitionedSolversAlgorithm(solver = nothing; kwargs...)
 
 [PartitionedSolvers](https://github.com/PartitionedArrays/PartitionedArrays.jl/tree/master/PartitionedSolvers)
 provides distributed linear solver building blocks for
 [PartitionedArrays.jl](https://github.com/PartitionedArrays/PartitionedArrays.jl).
 
-This algorithm is intended for `PSparseMatrix` / `PVector` inputs. The integration
-delegates actual solves to the local `PartitionedSolvers` solver constructors and caches
-the resulting solver object for repeated solves. The default dispatch for `PSparseMatrix`
-inputs chooses the CG-backed PartitionedSolvers path, but the integration is
-solver-agnostic: any PartitionedSolvers solver constructor (for example
-`PartitionedSolvers.cg`, `PartitionedSolvers.jacobi`, or `PartitionedSolvers.amg`) can be
-passed, and only the convergence keywords that the chosen solver actually accepts are
-forwarded automatically.
+This algorithm requires `PSparseMatrix` / `PVector` inputs: `init` throws an
+`ArgumentError` if `A` is not a `PSparseMatrix`, if `b` is not a `PVector`, or if a
+`u0` is given that is not a `PVector`. The integration delegates actual solves to the
+local `PartitionedSolvers` solver constructors and caches the resulting solver object
+for repeated solves. The default dispatch for `PSparseMatrix` inputs chooses the
+CG-backed PartitionedSolvers path, but the integration is solver-agnostic: any
+PartitionedSolvers solver constructor (for example `PartitionedSolvers.cg`,
+`PartitionedSolvers.jacobi`, or `PartitionedSolvers.amg`) can be passed, and only the
+convergence keywords that the chosen solver actually accepts (`iterations`, `abstol`,
+`reltol`, `verbose`, and `Pl` when a left preconditioner is set, otherwise
+`update_Pl = false`) are forwarded automatically.
+
+!!! note
+
+    Using this solver requires that both PartitionedArrays.jl and PartitionedSolvers.jl
+    are loaded, i.e. `using PartitionedArrays, PartitionedSolvers`. The constructor
+    errors otherwise.
 
 ## Positional Arguments
 
-  - `solver`: optional PartitionedSolvers solver object or constructor such as
-    `PartitionedSolvers.cg`. If omitted, the integration uses the local
-    `PartitionedSolvers` default solver.
+  - `solver`: optional PartitionedSolvers solver constructor such as
+    `PartitionedSolvers.cg`, or an already constructed `PartitionedSolvers.AbstractSolver`.
+    Defaults to `nothing`, in which case `PartitionedSolvers.default_solver(problem)` is
+    used.
 
 ## Keyword Arguments
 
-  - `kwargs...`: forwarded when constructing an explicit underlying PartitionedSolvers
-    solver. They take precedence over the auto-derived convergence keywords.
+  - `kwargs...`: forwarded when a solver constructor is called for the problem. They take
+    precedence over the auto-derived convergence keywords. They are not used when `solver`
+    is `nothing` (the default solver takes no options) or when `solver` is an already
+    constructed `AbstractSolver` (which is updated with the new problem via
+    `PartitionedSolvers.update` instead).
 
 ## Example
 
@@ -307,10 +320,22 @@ needs_concrete_A(::PartitionedSolversAlgorithm) = true
 
 # Debug: About to define CudaOffloadLUFactorization
 """
-`CudaOffloadLUFactorization()`
+    CudaOffloadLUFactorization(; throwerror = true, residualsafety = false)
 
 An offloading technique used to GPU-accelerate CPU-based computations using LU factorization.
+The dense CPU matrix `A` is copied to a `CuArray`, factored with cuSOLVER's `lu`, and each
+solve copies `b` to the GPU, back-solves there, and copies the result back to `cache.u`.
 Requires a sufficiently large `A` to overcome the data transfer costs.
+
+## Keyword Arguments
+
+  - `throwerror`: whether to throw an error at construction when the CUDA extension is not
+    loaded. Defaults to `true`. Passing `false` is what lets the default solver build the
+    algorithm speculatively.
+  - `residualsafety`: intended to enable the post-solve residual check described for
+    `LUFactorization`. Defaults to `false`. That check lives in the generic factorization
+    `solve!`, which the CUDA extension replaces with its own `solve!` for this algorithm,
+    so the flag currently has no effect here.
 
 !!! note
 
@@ -329,12 +354,17 @@ struct CudaOffloadLUFactorization <: AbstractFactorization
 end
 
 """
-`CUDAOffload32MixedLUFactorization()`
+    CUDAOffload32MixedLUFactorization(; throwerror = true)
 
 A mixed precision GPU-accelerated LU factorization that converts matrices to Float32
-before offloading to CUDA GPU for factorization, then converts back for the solve.
-This can provide speedups when the reduced precision is acceptable and memory
-bandwidth is a bottleneck.
+(ComplexF32 for complex inputs) before offloading to CUDA GPU for factorization, then
+converts back for the solve. This can provide speedups when the reduced precision is
+acceptable and memory bandwidth is a bottleneck.
+
+## Keyword Arguments
+
+  - `throwerror`: whether to throw an error at construction when the CUDA extension is not
+    loaded. Defaults to `true`.
 
 ## Performance Notes
 - Converts Float64 matrices to Float32 for GPU factorization
@@ -448,7 +478,9 @@ end
 ## RFLUFactorization
 
 """
-    RFLUFactorization{P, T}(; pivot = Val(true), thread = Val(true))
+    RFLUFactorization(; pivot = Val(true), thread = Val(true), throwerror = true,
+                      residualsafety = false)
+    RFLUFactorization(pivot::Val, thread::Val; throwerror = true, residualsafety = false)
 
 A fast pure Julia LU-factorization implementation using RecursiveFactorization.jl.
 This is by far the fastest LU-factorization implementation, usually outperforming
@@ -466,6 +498,10 @@ is in the works.
 - `thread = Val(true)`: Enable multi-threading. Set to `Val{false}` for single-threaded
   execution.
 - `throwerror = true`: Whether to throw an error if RecursiveFactorization.jl is not loaded.
+- `residualsafety = false`: intended to enable the post-solve residual check described
+  for `LUFactorization`. That check lives in the generic factorization `solve!`, which
+  the RecursiveFactorization extension replaces with its own `solve!` for this
+  algorithm, so the flag currently has no effect here.
 
 ## Performance Notes
 - Fastest for dense matrices with dimensions roughly < 500×500
@@ -501,11 +537,30 @@ function RFLUFactorization(; pivot = Val(true), thread = Val(true), throwerror =
 end
 
 """
-`ButterflyFactorization()`
+    ButterflyFactorization(; thread = Val(true), throwerror = true)
+    ButterflyFactorization(thread::Val; throwerror = true)
 
-A fast pure Julia LU-factorization implementation
-using RecursiveFactorization.jl. This method utilizes a butterfly
-factorization approach rather than pivoting.
+A fast pure Julia LU-factorization implementation using RecursiveFactorization.jl.
+Instead of pivoting, the matrix is first mixed with RecursiveFactorization.jl's random
+butterfly transform and then factored with the pivot-free `RecursiveFactorization.lu!`,
+and each solve applies the transform to the right-hand side around a `TriangularSolve`
+back-solve. This trades the row swaps of partial pivoting for two cheap dense
+multiplies, which can be faster than `RFLUFactorization` on dense square `Array` inputs
+while being less robust for matrices that need pivoting for stability. Only square
+matrices are supported (an assertion fires on the first factorization otherwise).
+
+## Keyword Arguments
+
+  - `thread`: threading choice as `Val{Bool}`, forwarded to
+    `RecursiveFactorization.lu!` and to the triangular back-solves. Defaults to
+    `Val(true)`.
+  - `throwerror`: whether to throw an error at construction when
+    RecursiveFactorization.jl is not loaded. Defaults to `true`.
+
+!!! note
+
+    Using this solver requires that RecursiveFactorization.jl is loaded, i.e.
+    `using RecursiveFactorization`.
 """
 struct ButterflyFactorization{T} <: AbstractDenseFactorization
     thread::Val{T}
@@ -562,22 +617,28 @@ sol = solve(prob, alg)
 struct FastLUFactorization <: AbstractDenseFactorization end
 
 """
-    FastQRFactorization{P}(; pivot = ColumnNorm(), blocksize = 36)
+    FastQRFactorization()
+    FastQRFactorization(pivot, blocksize)
 
 A high-performance QR factorization using the FastLapackInterface.jl package.
 This provides an optimized interface to LAPACK QR routines with reduced overhead
-compared to the standard LinearAlgebra LAPACK wrappers.
+compared to the standard LinearAlgebra LAPACK wrappers. The zero-argument constructor
+is `FastQRFactorization(NoPivot(), 36)`; there is no keyword constructor, so both
+fields are set positionally.
 
 ## Type Parameters
 - `P`: The type of pivoting strategy used
 
-## Fields
-- `pivot::P`: Pivoting strategy (e.g., `ColumnNorm()` for column pivoting, `nothing` for no pivoting)
-- `blocksize::Int`: Block size for the blocked QR algorithm (default: 36)
+## Positional Arguments
+- `pivot`: Pivoting strategy. `NoPivot()` (the default) uses the blocked
+  unpivoted `geqrt!` path; `ColumnNorm()` selects the column-pivoted `geqp3!` path.
+  These are the only two pivot types the extension implements.
+- `blocksize`: Block size for the blocked (unpivoted) QR algorithm, passed to
+  FastLapackInterface's `QRWYWs` workspace. Defaults to `36`. It is not used by the
+  column-pivoted path.
 
 ## Features
 - Reduced function call overhead compared to standard LAPACK wrappers
-- Supports various pivoting strategies for numerical stability
 - Configurable block size for optimal performance
 - Suitable for dense matrices, especially overdetermined systems
 
@@ -591,13 +652,13 @@ Using this solver requires that FastLapackInterface.jl is loaded: `using FastLap
 
 ## Example
 ```julia
-using FastLapackInterface
-# QR with column pivoting
+using FastLapackInterface, LinearAlgebra
+# QR without pivoting, block size 36
 alg1 = FastQRFactorization()
-# QR without pivoting for speed
-alg2 = FastQRFactorization(pivot=nothing)
+# QR with column pivoting
+alg2 = FastQRFactorization(ColumnNorm(), 36)
 # Custom block size
-alg3 = FastQRFactorization(blocksize=64)
+alg3 = FastQRFactorization(NoPivot(), 64)
 ```
 """
 struct FastQRFactorization{P} <: AbstractDenseFactorization
@@ -618,7 +679,13 @@ MKLPardisoFactorize(; nprocs::Union{Int, Nothing} = nothing,
     dparm::Union{Vector{Tuple{Int, Int}}, Nothing} = nothing)
 ```
 
-A sparse factorization method using MKL Pardiso.
+A sparse direct (LU) factorization method using MKL Pardiso, i.e.
+`PardisoJL(; vendor = :MKL, solver_type = 0, kwargs...)`. It solves square sparse
+systems (`SparseMatrixCSC`, real or complex element types) with a multithreaded
+supernodal LU and is a good choice for large sparse systems on Intel hardware where
+MKL is available. Use `MKLPardisoIterate` when the same sparsity pattern is factored
+repeatedly and the LU-preconditioned iteration is likely to converge without a
+refactorization.
 
 !!! note
 
@@ -626,14 +693,23 @@ A sparse factorization method using MKL Pardiso.
 
 ## Keyword Arguments
 
-Setting `cache_analysis = true` disables Pardiso's scaling and matching defaults
-and caches the result of the initial analysis phase for all further computations
-with this solver.
+  - `nprocs`: number of threads, passed to `Pardiso.set_nprocs!`. Defaults to `nothing`
+    (Pardiso's default).
+  - `matrix_type`: Pardiso matrix type (`Pardiso.MatrixType` or its integer code),
+    overriding the automatic choice of `Pardiso.REAL_NONSYM` for real and
+    `Pardiso.COMPLEX_NONSYM` for complex element types. Defaults to `nothing`.
+  - `cache_analysis`: when `true`, disables Pardiso's scaling and matching defaults
+    (`iparm[11] = iparm[13] = 0`), runs the analysis phase once at `init`, and reuses it
+    for all further factorizations with this solver. Defaults to `false`.
+  - `iparm`: vector of `(index, value)` tuples applied via `Pardiso.set_iparm!`.
+    Defaults to `nothing`.
+  - `dparm`: vector of `(index, value)` tuples applied via `Pardiso.set_dparm!`.
+    Defaults to `nothing`.
 
-For the definition of the other keyword arguments, see the Pardiso.jl documentation.
-All values default to `nothing` and the solver internally determines the values
-given the input types, and these keyword arguments are only for overriding the
-default handling process. This should not be required by most users.
+The defaults let the solver determine everything from the input types; these keywords
+are only for overriding that handling and should not be required by most users. See
+`PardisoJL` for the full description of each keyword and the Pardiso.jl documentation
+for the meaning of the individual `iparm`/`dparm` entries.
 """
 MKLPardisoFactorize(; kwargs...) = PardisoJL(; vendor = :MKL, solver_type = 0, kwargs...)
 
@@ -646,7 +722,16 @@ MKLPardisoIterate(; nprocs::Union{Int, Nothing} = nothing,
     dparm::Union{Vector{Tuple{Int, Int}}, Nothing} = nothing)
 ```
 
-A mixed factorization+iterative method using MKL Pardiso.
+A mixed factorization+iterative method using MKL Pardiso, i.e.
+`PardisoJL(; vendor = :MKL, solver_type = 1, kwargs...)`. Pardiso computes an LU
+factorization for the first system and then reuses those exact factors as the
+preconditioner of a Krylov (CGS) iteration for the following solves, falling back to a
+fresh numerical factorization when the iteration does not converge. `iparm[4]` is set
+from the `reltol` given to `init`/`solve` to control the iteration's stopping
+tolerance. This is worthwhile when the same sparsity pattern is solved many times with
+slowly changing values (for example inside a nonlinear or time-stepping loop) and each
+new factorization is expensive; use `MKLPardisoFactorize` for a plain direct solve.
+Square sparse systems (`SparseMatrixCSC`, real or complex) are supported.
 
 !!! note
 
@@ -654,14 +739,23 @@ A mixed factorization+iterative method using MKL Pardiso.
 
 ## Keyword Arguments
 
-Setting `cache_analysis = true` disables Pardiso's scaling and matching defaults
-and caches the result of the initial analysis phase for all further computations
-with this solver.
+  - `nprocs`: number of threads, passed to `Pardiso.set_nprocs!`. Defaults to `nothing`
+    (Pardiso's default).
+  - `matrix_type`: Pardiso matrix type (`Pardiso.MatrixType` or its integer code),
+    overriding the automatic choice of `Pardiso.REAL_NONSYM` for real and
+    `Pardiso.COMPLEX_NONSYM` for complex element types. Defaults to `nothing`.
+  - `cache_analysis`: when `true`, disables Pardiso's scaling and matching defaults
+    (`iparm[11] = iparm[13] = 0`), runs the analysis phase once at `init`, and reuses it
+    for all further factorizations with this solver. Defaults to `false`.
+  - `iparm`: vector of `(index, value)` tuples applied via `Pardiso.set_iparm!`.
+    Defaults to `nothing`.
+  - `dparm`: vector of `(index, value)` tuples applied via `Pardiso.set_dparm!`.
+    Defaults to `nothing`.
 
-For the definition of the other keyword arguments, see the Pardiso.jl documentation.
-All values default to `nothing` and the solver internally determines the values
-given the input types, and these keyword arguments are only for overriding the
-default handling process. This should not be required by most users.
+The defaults let the solver determine everything from the input types; these keywords
+are only for overriding that handling and should not be required by most users. See
+`PardisoJL` for the full description of each keyword and the Pardiso.jl documentation
+for the meaning of the individual `iparm`/`dparm` entries.
 """
 MKLPardisoIterate(; kwargs...) = PardisoJL(; vendor = :MKL, solver_type = 1, kwargs...)
 
@@ -674,7 +768,13 @@ PanuaPardisoFactorize(; nprocs::Union{Int, Nothing} = nothing,
     dparm::Union{Vector{Tuple{Int, Int}}, Nothing} = nothing)
 ```
 
-A sparse factorization method using Panua Pardiso.
+A sparse direct (LU) factorization method using Panua Pardiso (formerly
+pardiso-project.org), i.e. `PardisoJL(; vendor = :Panua, solver_type = 0, kwargs...)`.
+It solves square sparse systems (`SparseMatrixCSC`, real or complex element types) with
+a multithreaded supernodal LU and is the choice when a Panua Pardiso license is
+available, including on platforms where MKL Pardiso is not. Use `PanuaPardisoIterate` when
+the same sparsity pattern is factored repeatedly and the LU-preconditioned iteration is
+likely to converge without a refactorization.
 
 !!! note
 
@@ -682,14 +782,23 @@ A sparse factorization method using Panua Pardiso.
 
 ## Keyword Arguments
 
-Setting `cache_analysis = true` disables Pardiso's scaling and matching defaults
-and caches the result of the initial analysis phase for all further computations
-with this solver.
+  - `nprocs`: number of threads. Defaults to `nothing` (Pardiso's default). The
+    extension currently applies this only for the MKL vendor, so it has no effect here.
+  - `matrix_type`: Pardiso matrix type (`Pardiso.MatrixType` or its integer code),
+    overriding the automatic choice of `Pardiso.REAL_NONSYM` for real and
+    `Pardiso.COMPLEX_NONSYM` for complex element types. Defaults to `nothing`.
+  - `cache_analysis`: when `true`, disables Pardiso's scaling and matching defaults
+    (`iparm[11] = iparm[13] = 0`), runs the analysis phase once at `init`, and reuses it
+    for all further factorizations with this solver. Defaults to `false`.
+  - `iparm`: vector of `(index, value)` tuples applied via `Pardiso.set_iparm!`.
+    Defaults to `nothing`.
+  - `dparm`: vector of `(index, value)` tuples applied via `Pardiso.set_dparm!`.
+    Defaults to `nothing`.
 
-For the definition of the keyword arguments, see the Pardiso.jl documentation.
-All values default to `nothing` and the solver internally determines the values
-given the input types, and these keyword arguments are only for overriding the
-default handling process. This should not be required by most users.
+The defaults let the solver determine everything from the input types; these keywords
+are only for overriding that handling and should not be required by most users. See
+`PardisoJL` for the full description of each keyword and the Pardiso.jl documentation
+for the meaning of the individual `iparm`/`dparm` entries.
 """
 PanuaPardisoFactorize(; kwargs...) = PardisoJL(;
     vendor = :Panua, solver_type = 0, kwargs...
@@ -699,11 +808,21 @@ PanuaPardisoFactorize(; kwargs...) = PardisoJL(;
 ```julia
 PanuaPardisoIterate(; nprocs::Union{Int, Nothing} = nothing,
     matrix_type = nothing,
+    cache_analysis = false,
     iparm::Union{Vector{Tuple{Int, Int}}, Nothing} = nothing,
     dparm::Union{Vector{Tuple{Int, Int}}, Nothing} = nothing)
 ```
 
-A mixed factorization+iterative method using Panua Pardiso.
+A mixed factorization+iterative method using Panua Pardiso, i.e.
+`PardisoJL(; vendor = :Panua, solver_type = 1, kwargs...)`. `Pardiso.set_solver!` selects
+Panua's iterative solver: an LU factorization is computed for the first system and then
+reused as the preconditioner of a Krylov iteration for the following solves, with a
+fresh numerical factorization when the iteration does not converge. `iparm[4]` is set
+from the `reltol` given to `init`/`solve` to control the iteration's stopping tolerance.
+This is worthwhile when the same sparsity pattern is solved many times with slowly
+changing values and each new factorization is expensive; use `PanuaPardisoFactorize`
+for a plain direct solve. Square sparse systems (`SparseMatrixCSC`, real or complex)
+are supported.
 
 !!! note
 
@@ -711,10 +830,23 @@ A mixed factorization+iterative method using Panua Pardiso.
 
 ## Keyword Arguments
 
-For the definition of the keyword arguments, see the Pardiso.jl documentation.
-All values default to `nothing` and the solver internally determines the values
-given the input types, and these keyword arguments are only for overriding the
-default handling process. This should not be required by most users.
+  - `nprocs`: number of threads. Defaults to `nothing` (Pardiso's default). The
+    extension currently applies this only for the MKL vendor, so it has no effect here.
+  - `matrix_type`: Pardiso matrix type (`Pardiso.MatrixType` or its integer code),
+    overriding the automatic choice of `Pardiso.REAL_NONSYM` for real and
+    `Pardiso.COMPLEX_NONSYM` for complex element types. Defaults to `nothing`.
+  - `cache_analysis`: when `true`, disables Pardiso's scaling and matching defaults
+    (`iparm[11] = iparm[13] = 0`), runs the analysis phase once at `init`, and reuses it
+    for all further factorizations with this solver. Defaults to `false`.
+  - `iparm`: vector of `(index, value)` tuples applied via `Pardiso.set_iparm!`.
+    Defaults to `nothing`.
+  - `dparm`: vector of `(index, value)` tuples applied via `Pardiso.set_dparm!`.
+    Defaults to `nothing`.
+
+The defaults let the solver determine everything from the input types; these keywords
+are only for overriding that handling and should not be required by most users. See
+`PardisoJL` for the full description of each keyword and the Pardiso.jl documentation
+for the meaning of the individual `iparm`/`dparm` entries.
 """
 PanuaPardisoIterate(; kwargs...) = PardisoJL(; vendor = :Panua, solver_type = 1, kwargs...)
 
@@ -723,13 +855,20 @@ PanuaPardisoIterate(; kwargs...) = PardisoJL(; vendor = :Panua, solver_type = 1,
 PardisoJL(; nprocs::Union{Int, Nothing} = nothing,
     solver_type = nothing,
     matrix_type = nothing,
+    cache_analysis = false,
     iparm::Union{Vector{Tuple{Int, Int}}, Nothing} = nothing,
     dparm::Union{Vector{Tuple{Int, Int}}, Nothing} = nothing,
     vendor::Union{Symbol, Nothing} = nothing
 )
 ```
 
-A generic method using  Pardiso. Specifying `solver_type` is required.
+A generic sparse direct solver using Pardiso through Pardiso.jl. It supports square
+sparse systems (`SparseMatrixCSC`, real or complex element types) and both the Panua
+and MKL Pardiso libraries. The convenience constructors `MKLPardisoFactorize`,
+`MKLPardisoIterate`, `PanuaPardisoFactorize` and `PanuaPardisoIterate` fix `vendor` and
+`solver_type` and are what most users should use; `PardisoJL` itself is for choosing
+those settings by hand. `solver_type` is optional: when it is left as `nothing`,
+Pardiso's default (direct) solver is used.
 
 !!! note
 
@@ -737,13 +876,39 @@ A generic method using  Pardiso. Specifying `solver_type` is required.
 
 ## Keyword Arguments
 
-The `vendor` keyword allows to choose between Panua pardiso  (former pardiso-project.org; `vendor=:Panua`)
-and  MKL Pardiso (`vendor=:MKL`). If `vendor==nothing`, Panua pardiso is preferred over MKL Pardiso.
+  - `vendor`: `:Panua` for Panua Pardiso (formerly pardiso-project.org) or `:MKL` for
+    MKL Pardiso. Defaults to `nothing`, which selects Panua Pardiso when it is available
+    and MKL Pardiso otherwise.
+  - `solver_type`: `0` for the sparse direct (LU) solver, `1` for the LU-preconditioned
+    Krylov iteration (Pardiso factors the first system and reuses those factors as a
+    preconditioner for the following solves, refactoring when the iteration does not
+    converge). A `Pardiso.Solver` value is also accepted. Defaults to `nothing`, which
+    keeps Pardiso's default. For `vendor = :Panua` the value is passed to
+    `Pardiso.set_solver!`; for `vendor = :MKL` it is not passed to Pardiso, but
+    `solver_type = 1` still sets `iparm[4]` from `reltol` for either vendor, which is
+    what enables MKL's CGS iteration.
+  - `nprocs`: number of threads, passed to `Pardiso.set_nprocs!`. Defaults to `nothing`
+    (Pardiso's default). The extension currently applies this only for `vendor = :MKL`.
+  - `matrix_type`: Pardiso matrix type (`Pardiso.MatrixType` or its integer code),
+    passed to `Pardiso.set_matrixtype!`. Defaults to `nothing`, which selects
+    `Pardiso.REAL_NONSYM` for real and `Pardiso.COMPLEX_NONSYM` for complex element
+    types.
+  - `cache_analysis`: when `true`, disables Pardiso's scaling and matching defaults
+    (`iparm[11] = iparm[13] = 0`), runs the analysis phase once at `init`, and reuses it
+    for every later factorization, so only the numerical factorization is repeated when
+    `A` changes with the same sparsity pattern. Defaults to `false`, in which case
+    analysis and numerical factorization are redone together on each fresh `A`.
+  - `iparm`: vector of `(index, value)` tuples, each applied as
+    `Pardiso.set_iparm!(solver, index, value)` after the settings above, so they
+    override them. Defaults to `nothing`. `iparm[12]` is set by the extension to
+    account for the CSC storage and should not be overridden.
+  - `dparm`: vector of `(index, value)` tuples, each applied as
+    `Pardiso.set_dparm!(solver, index, value)`. Defaults to `nothing`. Note that the
+    field is typed `Vector{Tuple{Int, Int}}`, so only integer values can be passed.
 
-For the definition of the other keyword arguments, see the Pardiso.jl documentation.
-All values default to `nothing` and the solver internally determines the values
-given the input types, and these keyword arguments are only for overriding the
-default handling process. This should not be required by most users.
+The defaults let the solver determine everything from the input types; these keywords
+are only for overriding that handling and should not be required by most users. See the
+Pardiso.jl documentation for the meaning of the individual `iparm`/`dparm` entries.
 """
 struct PardisoJL{T1, T2} <: AbstractSparseFactorization
     nprocs::Union{Int, Nothing}
@@ -780,15 +945,44 @@ end
 
 """
 ```julia
-KrylovKitJL(args...; KrylovAlg = Krylov.gmres!, kwargs...)
+KrylovKitJL(args...; KrylovAlg = KrylovKit.GMRES, gmres_restart = 0,
+    precs = DEFAULT_PRECS, kwargs...)
 ```
 
-A generic iterative solver implementation allowing the choice of KrylovKit.jl
-solvers.
+A generic iterative solver wrapping `KrylovKit.linsolve` from KrylovKit.jl. Each solve
+calls `KrylovKit.linsolve(A, b, u; atol = abstol, rtol = reltol, maxiter = maxiters,
+krylovdim, verbosity, kwargs...)`, so `A` may be any matrix or operator supporting
+`mul!`. KrylovKit selects the actual method from its `issymmetric`, `ishermitian` and
+`isposdef` keywords (checked automatically for an `AbstractMatrix`, `false` by default
+for other operators): CG for Hermitian positive definite input, GMRES otherwise. Use
+`KrylovKitJL_CG` and `KrylovKitJL_GMRES` for the common cases; use `KrylovJL_GMRES`
+instead when preconditioning is needed, since KrylovKit has no preconditioner support.
 
 !!! note
 
     Using this solver requires adding the package KrylovKit.jl, i.e. `using KrylovKit`
+
+## Positional Arguments
+
+  - `args...`: stored on the algorithm; not currently used by the solve.
+
+## Keyword Arguments
+
+  - `KrylovAlg`: the KrylovKit algorithm type, `KrylovKit.GMRES` or `KrylovKit.CG`.
+    Defaults to `KrylovKit.GMRES`. It is stored on the algorithm but not passed to
+    `KrylovKit.linsolve`; the method is chosen by KrylovKit as described above
+    (`KrylovKitJL_CG` requests CG by forcing `isposdef = true`).
+  - `gmres_restart`: the GMRES restart length, passed to KrylovKit as `krylovdim`.
+    `0` means `min(20, size(A, 1))`. Defaults to `0`. Note that KrylovKit's `maxiter`
+    (set from `maxiters`) counts restart cycles for GMRES, and the CG iteration cap is
+    `krylovdim * maxiter`.
+  - `precs`: a preconditioner builder `(A, p) -> (Pl, Pr)`, called at `init` like for
+    `KrylovJL`. Defaults to `DEFAULT_PRECS` (identity). KrylovKit ignores
+    preconditioners: any non-identity `Pl`/`Pr`, whether from `precs` or from
+    `init`/`solve`, only produces a one-time warning and is otherwise dropped.
+  - `kwargs...`: any remaining keywords are forwarded to `KrylovKit.linsolve` on every
+    solve (for example `issymmetric`, `ishermitian`, `isposdef`, `orth`), on top of the
+    `atol`/`rtol`/`maxiter`/`krylovdim`/`verbosity` set by the cache.
 """
 struct KrylovKitJL{F, I, P, A, K} <: LinearSolve.AbstractKrylovSubspaceMethod
     KrylovAlg::F
@@ -800,10 +994,19 @@ end
 
 """
 ```julia
-KrylovKitJL_CG(args...; Pl = nothing, Pr = nothing, kwargs...)
+KrylovKitJL_CG(args...; kwargs...)
 ```
 
-A generic CG implementation for Hermitian and positive definite linear systems
+A CG implementation for Hermitian (real symmetric) positive definite linear systems
+via KrylovKit.jl. It is `KrylovKitJL(args...; KrylovAlg = KrylovKit.CG, kwargs...,
+isposdef = true)`, so `isposdef = true` is always forwarded to `KrylovKit.linsolve`;
+KrylovKit then runs CG when it also knows the operator is Hermitian, which is detected
+automatically for an `AbstractMatrix` but must be stated with `ishermitian = true` (or
+`issymmetric = true` for a real problem) for a function-like operator, otherwise
+KrylovKit falls back to GMRES. Keyword arguments (`gmres_restart`, `precs`, and any `KrylovKit.linsolve`
+keywords) are those of `KrylovKitJL`. There are no `Pl`/`Pr` keywords: KrylovKit does
+not support preconditioners, and any set through `precs` or `init`/`solve` are ignored
+with a warning.
 
 !!! note
 
@@ -813,10 +1016,17 @@ function KrylovKitJL_CG end
 
 """
 ```julia
-KrylovKitJL_GMRES(args...; Pl = nothing, Pr = nothing, gmres_restart = 0, kwargs...)
+KrylovKitJL_GMRES(args...; gmres_restart = 0, kwargs...)
 ```
 
-A generic GMRES implementation.
+A GMRES implementation for general (square, possibly non-symmetric) linear systems via
+KrylovKit.jl. It is `KrylovKitJL(args...; KrylovAlg = KrylovKit.GMRES, kwargs...)`.
+Keyword arguments (`gmres_restart`, `precs`, and any `KrylovKit.linsolve` keywords)
+are those of `KrylovKitJL`; in particular `gmres_restart` becomes KrylovKit's
+`krylovdim`, with `0` meaning `min(20, size(A, 1))`. There are no `Pl`/`Pr` keywords:
+KrylovKit does not support preconditioners, and any set through `precs` or
+`init`/`solve` are ignored with a warning. Use `KrylovJL_GMRES` when preconditioning
+is needed.
 
 !!! note
 
@@ -840,6 +1050,21 @@ for you. Remaining keywords are forwarded to the underlying solver, so
 ConjugateGradients.jl solves for real element types in a plain `Vector` only, so a
 complex or otherwise-typed problem is rejected at `init` rather than partway
 through a solve.
+
+## Keyword Arguments
+
+  - `solver`: `:cg` (for symmetric positive definite systems) or `:bicgstab` (for
+    general square systems). Defaults to `:cg`.
+  - `precs`: a preconditioner builder, a function `(A, p) -> (Pl, Pr)`, called at
+    `init` and again in `solve!` whenever `A` or `p` has changed; its result becomes
+    `cache.Pl`/`cache.Pr`. `nothing` means no preconditioning unless `Pl` is given to
+    `init`/`solve`. Defaults to `nothing`. Only a left preconditioner is supported: `Pl`
+    is applied as `ldiv!(z, Pl, r)`, and `solve!` throws an `ArgumentError` if a
+    non-identity `Pr` is present.
+  - `kwargs...`: forwarded to `ConjugateGradients.cg!`/`bicgstab!` on every solve.
+
+Only `reltol` and `maxiters` from the cache are used: they are passed as
+ConjugateGradients.jl's `tol` and `maxIter`. `abstol` is not used.
 
 !!! note
 
@@ -884,15 +1109,48 @@ function ConjugateGradientsJL_BICGSTAB end
 ```julia
 IterativeSolversJL(args...;
     generate_iterator = IterativeSolvers.gmres_iterable!,
-    Pl = nothing, Pr = nothing,
-    gmres_restart = 0, kwargs...)
+    gmres_restart = 0, precs = DEFAULT_PRECS, kwargs...)
 ```
 
-A generic wrapper over the IterativeSolvers.jl solvers.
+A generic wrapper over the IterativeSolvers.jl solvers. The chosen iterator constructor
+is called with the cache's `u`, `A`, `b`, tolerances and iteration cap on every fresh
+`A` (and, for every iterator other than `gmres_iterable!`, on every solve), and each
+`solve!` then steps through the resulting iterable. The convenience
+constructors `IterativeSolversJL_CG`, `IterativeSolversJL_GMRES`,
+`IterativeSolversJL_IDRS`, `IterativeSolversJL_BICGSTAB` and `IterativeSolversJL_MINRES`
+select `generate_iterator` for you.
 
 !!! note
 
     Using this solver requires adding the package IterativeSolvers.jl, i.e. `using IterativeSolvers`
+
+## Positional Arguments
+
+  - `args...`: passed positionally to the iterator constructor after `u, A, b` for
+    `bicgstabl_iterator!` (where the first one is the BiCGStab(l) `l`) and for
+    `minres_iterable!` (which takes none). They are not used by the CG, GMRES and
+    IDR(s) iterators.
+
+## Keyword Arguments
+
+  - `generate_iterator`: the IterativeSolvers.jl iterator constructor to use, one of
+    `IterativeSolvers.cg_iterator!`, `gmres_iterable!`, `idrs_iterable!`,
+    `bicgstabl_iterator!` or `minres_iterable!`. Defaults to
+    `IterativeSolvers.gmres_iterable!`.
+  - `gmres_restart`: the GMRES restart length, passed as `restart` to
+    `gmres_iterable!`. `0` means `min(20, size(A, 1))`. Defaults to `0`. Ignored by
+    the other iterators.
+  - `precs`: a preconditioner builder `(A, p) -> (Pl, Pr)`, called at `init` like for
+    `KrylovJL`; the resulting `cache.Pl`/`cache.Pr` are handed to the iterator
+    constructor. Defaults to `DEFAULT_PRECS` (identity). Explicit `Pl`/`Pr` are given
+    to `init`/`solve`, not to this constructor: a `Pl` or `Pr` keyword passed here would
+    be forwarded to the iterator constructor as-is. Which preconditioners each iterator
+    supports is listed on the convenience constructors.
+  - `kwargs...`: any remaining keywords are forwarded to the iterator constructor on top
+    of `abstol`, `reltol` and `maxiter` from the cache (for example `initially_zero`,
+    `orth_meth`, `skew_hermitian`). `maxiters` is accepted here as an alias for
+    IterativeSolvers' `maxiter` and overrides the cache's `maxiters`. `idrs_s` is read
+    by the IDR(s) path.
 """
 struct IterativeSolversJL{F, I, P, A, K} <: LinearSolve.AbstractKrylovSubspaceMethod
     generate_iterator::F
@@ -904,10 +1162,18 @@ end
 
 """
 ```julia
-IterativeSolversJL_CG(args...; Pl = nothing, Pr = nothing, kwargs...)
+IterativeSolversJL_CG(args...; kwargs...)
 ```
 
-A wrapper over the IterativeSolvers.jl CG.
+A wrapper over the IterativeSolvers.jl CG (`IterativeSolvers.cg_iterator!`) for
+symmetric positive definite systems. It is
+`IterativeSolversJL(args...; generate_iterator = IterativeSolvers.cg_iterator!, kwargs...)`,
+so the keyword arguments (`precs` and any `cg_iterator!` keywords such as
+`initially_zero`) are those of `IterativeSolversJL`; `args...` are not used. There are
+no `Pl`/`Pr` constructor keywords: preconditioners come from `precs` or from
+`init`/`solve`, and passing a `Pl` keyword here would reach `cg_iterator!` as an
+unknown keyword. Only left preconditioning is supported; a non-identity `Pr` is dropped
+with a `no_right_preconditioning` message.
 
 !!! note
 
@@ -917,10 +1183,17 @@ function IterativeSolversJL_CG end
 
 """
 ```julia
-IterativeSolversJL_GMRES(args...; Pl = nothing, Pr = nothing, gmres_restart = 0, kwargs...)
+IterativeSolversJL_GMRES(args...; gmres_restart = 0, kwargs...)
 ```
 
-A wrapper over the IterativeSolvers.jl GMRES.
+A wrapper over the IterativeSolvers.jl GMRES (`IterativeSolvers.gmres_iterable!`) for
+general square systems. It is
+`IterativeSolversJL(args...; generate_iterator = IterativeSolvers.gmres_iterable!, kwargs...)`,
+so the keyword arguments (`gmres_restart`, `precs` and any `gmres_iterable!` keywords
+such as `orth_meth`) are those of `IterativeSolversJL`; `args...` are not used.
+`gmres_restart` is the restart length, with `0` meaning `min(20, size(A, 1))`. Both left
+and right preconditioning are supported; `Pl`/`Pr` are taken from `precs` or from
+`init`/`solve`, not from constructor keywords.
 
 !!! note
 
@@ -930,10 +1203,18 @@ function IterativeSolversJL_GMRES end
 
 """
 ```julia
-IterativeSolversJL_IDRS(args...; Pl = nothing, idrs_s = 4, kwargs...)
+IterativeSolversJL_IDRS(args...; idrs_s = 4, kwargs...)
 ```
 
-A wrapper over the IterativeSolvers.jl IDR(S).
+A wrapper over the IterativeSolvers.jl IDR(s) (`IterativeSolvers.idrs_iterable!`) for
+general square systems. It is
+`IterativeSolversJL(args...; generate_iterator = IterativeSolvers.idrs_iterable!, kwargs...)`,
+so the keyword arguments are those of `IterativeSolversJL`; `args...` are not used.
+`idrs_s` is the dimension of the shadow space `s` (larger values typically converge in
+fewer iterations at more work per iteration). Defaults to `4`. Remaining keywords are
+forwarded to `idrs_iterable!`, which only accepts `smoothing` and `verbose`. Only left
+preconditioning is supported: `Pl` comes from `precs` or from `init`/`solve` (not from
+a constructor keyword), and a right preconditioner is dropped.
 
 !!! note
 
@@ -943,10 +1224,18 @@ function IterativeSolversJL_IDRS end
 
 """
 ```julia
-IterativeSolversJL_BICGSTAB(args...; Pl = nothing, Pr = nothing, kwargs...)
+IterativeSolversJL_BICGSTAB(args...; kwargs...)
 ```
 
-A wrapper over the IterativeSolvers.jl BICGSTAB.
+A wrapper over the IterativeSolvers.jl BiCGStab(l) (`IterativeSolvers.bicgstabl_iterator!`)
+for general square systems. It is
+`IterativeSolversJL(args...; generate_iterator = IterativeSolvers.bicgstabl_iterator!, kwargs...)`.
+The first positional argument, if given, is the BiCGStab(l) parameter `l`
+(IterativeSolvers' default is `2`). The keyword arguments are those of
+`IterativeSolversJL`; `maxiters` is mapped to `max_mv_products = 2 * maxiters`, and
+remaining keywords (for example `initial_zero`) are forwarded to `bicgstabl_iterator!`.
+Only left preconditioning is supported: `Pl` comes from `precs` or from `init`/`solve`
+(not from a constructor keyword), and a right preconditioner is dropped.
 
 !!! note
 
@@ -956,10 +1245,17 @@ function IterativeSolversJL_BICGSTAB end
 
 """
 ```julia
-IterativeSolversJL_MINRES(args...; Pl = nothing, Pr = nothing, kwargs...)
+IterativeSolversJL_MINRES(args...; kwargs...)
 ```
 
-A wrapper over the IterativeSolvers.jl MINRES.
+A wrapper over the IterativeSolvers.jl MINRES (`IterativeSolvers.minres_iterable!`) for
+symmetric (Hermitian) indefinite systems. It is
+`IterativeSolversJL(args...; generate_iterator = IterativeSolvers.minres_iterable!, kwargs...)`.
+`args...` are passed positionally to `minres_iterable!`, which takes none, so leave
+them empty. The keyword arguments are those of `IterativeSolversJL`; remaining keywords
+(for example `skew_hermitian`, `initially_zero`) are forwarded to `minres_iterable!`.
+This iterator accepts no preconditioner at all: any `Pl`/`Pr`, whether from `precs` or
+from `init`/`solve`, is silently ignored.
 
 !!! note
 
@@ -980,16 +1276,27 @@ including OpenMP, CUDA, HIP, and SYCL, making it suitable for both CPU and GPU c
 
     Using this solver requires adding the package Ginkgo.jl, i.e. `using Ginkgo`
 
+## Positional Arguments
+
+  - `args...`: stored on the algorithm; not currently forwarded to Ginkgo.
+
 ## Keyword Arguments
 
   - `KrylovAlg`: The Ginkgo solver to use. Supported values:
-    - `:gmres` (default): GMRES — for general non-symmetric systems
-      (not yet exposed by Ginkgo.jl v1; use `GinkgoJL_CG()` in the meantime)
-    - `:cg`: Conjugate Gradient — for symmetric positive definite systems only
-  - `executor`: The Ginkgo backend executor. Options:
+    - `:gmres` (default): GMRES, for general non-symmetric systems
+      (not yet exposed by Ginkgo.jl v1, so this errors at solve time; use
+      `GinkgoJL_CG()` in the meantime)
+    - `:cg`: Conjugate Gradient, for symmetric positive definite systems only
+  - `executor`: The Ginkgo backend executor, passed to `Ginkgo.create`. Options:
     - `:omp` (default): OpenMP CPU executor
     - `:cuda`: NVIDIA GPU executor
     - `:reference`: Reference (single-threaded) executor
+  - `kwargs...`: stored on the algorithm; not currently forwarded to Ginkgo, so extra
+    solver options passed here have no effect.
+
+Each solve rebuilds Ginkgo's CSR matrix and dense vectors from the cache and calls the
+Ginkgo solver with `maxiters` and `reltol` from the cache. `abstol` and any `Pl`/`Pr`
+preconditioners are not used.
 
 !!! warning
 
@@ -1023,7 +1330,20 @@ needs_concrete_A(::GinkgoJL) = true
 GinkgoJL_CG(args...; executor = :omp, kwargs...)
 ```
 
-A CG solver via Ginkgo.jl for symmetric positive definite systems.
+A CG solver via Ginkgo.jl for symmetric positive definite systems. It is
+`GinkgoJL(args...; KrylovAlg = :cg, executor, kwargs...)`; see `GinkgoJL` for the full
+description.
+
+## Keyword Arguments
+
+  - `executor`: The Ginkgo backend executor: `:omp` (OpenMP CPU), `:cuda` (NVIDIA GPU)
+    or `:reference` (single-threaded). Defaults to `:omp`.
+  - `kwargs...`: stored on the algorithm; not currently forwarded to Ginkgo. Likewise
+    `args...` are stored and unused.
+
+The solve uses `maxiters` and `reltol` from the cache; `abstol` and preconditioners are
+not used. Ginkgo.jl currently only supports `Float32` with `Int32` indices, so the
+matrix and vectors are converted to `Float32` on every solve.
 
 !!! note
 
@@ -1036,7 +1356,19 @@ function GinkgoJL_CG end
 GinkgoJL_GMRES(args...; executor = :omp, kwargs...)
 ```
 
-A GMRES solver via Ginkgo.jl for general non-symmetric systems.
+A GMRES solver via Ginkgo.jl for general non-symmetric systems. It is
+`GinkgoJL(args...; KrylovAlg = :gmres, executor, kwargs...)`; see `GinkgoJL` for the
+full description.
+
+## Keyword Arguments
+
+  - `executor`: The Ginkgo backend executor: `:omp` (OpenMP CPU), `:cuda` (NVIDIA GPU)
+    or `:reference` (single-threaded). Defaults to `:omp`.
+  - `kwargs...`: stored on the algorithm; not currently forwarded to Ginkgo. Likewise
+    `args...` are stored and unused.
+
+Once available, the solve will use `maxiters` and `reltol` from the cache like
+`GinkgoJL_CG`, with the same `Float32`/`Int32` conversion of the inputs.
 
 !!! note
 
@@ -1047,18 +1379,31 @@ A GMRES solver via Ginkgo.jl for general non-symmetric systems.
 function GinkgoJL_GMRES end
 
 """
-    MetalLUFactorization()
+    MetalLUFactorization(; throwerror = true, residualsafety = false)
 
-A wrapper over Apple's Metal GPU library for LU factorization. Direct calls to Metal
-in a way that pre-allocates workspace to avoid allocations and automatically offloads
-to the GPU. This solver is optimized for Metal-capable Apple Silicon Macs.
+A wrapper over Apple's Metal GPU library for LU factorization. On each fresh
+factorization the dense CPU matrix is copied to an `MtlArray` and factored on the GPU
+with Metal's `lu`; the resulting factors and pivots are copied back to the host, and
+the back-solve for each right-hand side then runs on the CPU with `ldiv!`. Only the
+factorization is offloaded, and the GPU array is allocated per factorization. This
+solver targets Metal-capable Apple Silicon Macs.
+
+## Keyword Arguments
+
+  - `throwerror`: whether to throw an error at construction when not on an Apple
+    platform or when the Metal extension is not loaded. Defaults to `true`.
+  - `residualsafety`: intended to enable the post-solve residual check described for
+    `LUFactorization`. Defaults to `false`. That check lives in the generic
+    factorization `solve!`, which the Metal extension replaces with its own `solve!` for
+    this algorithm, so the flag currently has no effect here.
 
 ## Requirements
-Using this solver requires that Metal.jl is loaded: `using Metal`
+Using this solver requires that Metal.jl is loaded: `using Metal`. The constructor also
+errors on any non-Apple platform, even with Metal.jl loaded, unless
+`throwerror = false`.
 
 ## Performance Notes
-- Most efficient for large dense matrices where GPU acceleration benefits outweigh transfer costs
-- Automatically manages GPU memory and transfers
+- Most efficient for large dense matrices where GPU acceleration of the factorization outweighs transfer costs
 - Particularly effective on Apple Silicon Macs with unified memory
 
 ## Example
@@ -1089,11 +1434,17 @@ struct MetalLUFactorization <: AbstractFactorization
 end
 
 """
-    MetalOffload32MixedLUFactorization()
+    MetalOffload32MixedLUFactorization(; throwerror = true)
 
 A mixed precision Metal GPU-accelerated LU factorization that converts matrices to Float32
-before offloading to Metal GPU for factorization, then converts back for the solve.
-This can provide speedups on Apple Silicon when reduced precision is acceptable.
+(ComplexF32 for complex inputs) before offloading to Metal GPU for factorization, then
+converts back for the solve. This can provide speedups on Apple Silicon when reduced
+precision is acceptable.
+
+## Keyword Arguments
+
+  - `throwerror`: whether to throw an error at construction when not on an Apple
+    platform or when the Metal extension is not loaded. Defaults to `true`.
 
 ## Performance Notes
 - Converts Float64 matrices to Float32 for GPU factorization
@@ -1102,7 +1453,8 @@ This can provide speedups on Apple Silicon when reduced precision is acceptable.
 - May have reduced accuracy compared to full precision methods
 
 ## Requirements
-Using this solver requires that Metal.jl is loaded: `using Metal`
+Using this solver requires that Metal.jl is loaded: `using Metal`, and an Apple
+platform.
 
 ## Example
 ```julia
@@ -1270,7 +1622,8 @@ sol = solve(prob, alg)
 struct OpenBLAS32MixedLUFactorization <: AbstractDenseFactorization end
 
 """
-    RF32MixedLUFactorization{P, T}(; pivot = Val(true), thread = Val(true))
+    RF32MixedLUFactorization(; pivot = Val(true), thread = Val(true), throwerror = true)
+    RF32MixedLUFactorization(pivot::Val, thread::Val; throwerror = true)
 
 A mixed precision LU factorization using RecursiveFactorization.jl that performs
 factorization in Float32 precision while maintaining Float64 interface. This combines
@@ -1286,6 +1639,7 @@ for additional performance gains.
   at the cost of numerical stability.
 - `thread = Val(true)`: Enable multi-threading. Set to `Val{false}` for single-threaded
   execution.
+- `throwerror = true`: Whether to throw an error if RecursiveFactorization.jl is not loaded.
 
 ## Performance Notes
 - Converts Float64 matrices to Float32 for factorization
@@ -1323,7 +1677,11 @@ end
     AlgebraicMultigridJL(args...; kwargs...)
 
 A wrapper for [AlgebraicMultigrid.jl](https://github.com/JuliaLinearAlgebra/AlgebraicMultigrid.jl)
-solvers.
+solvers. The AMG hierarchy is built with `SciMLBase.init(amg_alg, A, b; kwargs...)` on
+each fresh `A` and then used as a standalone iterative solver via `solve!`. It is meant
+for square sparse systems of the kind algebraic multigrid handles well, typically
+symmetric positive definite or M-matrix-like discretizations of elliptic PDEs; a
+non-square `A` fails an assertion at `init`.
 
 ## Positional Arguments
 
@@ -1333,6 +1691,11 @@ defaults to `AlgebraicMultigrid.RugeStubenAMG()`.
 ## Keyword Arguments
 
 All keyword arguments are forwarded to the AMG hierarchy constructor.
+
+Only `reltol` and `maxiters` from the cache are used (as `reltol` and `maxiter` of the
+AMG `solve!`); `abstol` and any `Pl`/`Pr` preconditioners are not used. The returned
+solution always reports `ReturnCode.Success`, so check the residual yourself if
+convergence matters.
 
 ## Example
 

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -266,15 +266,18 @@ end
 ## LU Factorizations
 
 """
-`LUFactorization(pivot=LinearAlgebra.RowMaximum())`
+    LUFactorization(; pivot = LinearAlgebra.RowMaximum(), reuse_symbolic = true,
+                    check_pattern = true, residualsafety = false)
 
 Julia's built in `lu`. Equivalent to calling `lu!(A)`
 
   - On dense matrices, this uses the current BLAS implementation of the user's computer,
     which by default is OpenBLAS but will use MKL if the user does `using MKL` in their
     system.
-  - On sparse matrices, this will use UMFPACK from SparseArrays. Note that this will not
-    cache the symbolic factorization.
+  - On sparse matrices, this will use UMFPACK from SparseArrays. With the default
+    `reuse_symbolic = true` the symbolic factorization is cached and reused across
+    refactorizations (via `lu!` on the cached factorization) whenever the sparsity pattern
+    is unchanged.
   - On CuMatrix, it will use a CUDA-accelerated LU from CuSolver.
   - On BandedMatrix and BlockBandedMatrix, it will use a banded LU.
 
@@ -284,10 +287,21 @@ triangular sweeps as `GenericLUFactorization`, which beat `getrs!`'s call and bl
 overhead at those sizes; larger vectors and matrix right-hand sides use `ldiv!`
 (LAPACK `getrs!`).
 
-## Positional Arguments
+## Keyword Arguments
 
-  - pivot: The choice of pivoting. Defaults to `LinearAlgebra.RowMaximum()`. The other choice is
-    `LinearAlgebra.NoPivot()`.
+  - `pivot`: The choice of pivoting. Defaults to `LinearAlgebra.RowMaximum()`. The other choice is
+    `LinearAlgebra.NoPivot()`. Only the keyword form changes the pivoting: the legacy
+    positional method `LUFactorization(pivot)` is kept for compatibility but ignores its
+    argument and always constructs the `RowMaximum()` algorithm.
+  - `reuse_symbolic`: for sparse matrices, reuse the cached UMFPACK symbolic factorization
+    across solves when the sparsity pattern is unchanged. Defaults to `true`.
+  - `check_pattern`: for sparse matrices, check whether the sparsity pattern changed before
+    reusing the symbolic factorization, recomputing it from scratch if it did. Set to
+    `false` to skip the check (this may error if the pattern does change). Defaults to
+    `true`.
+  - `residualsafety`: after each fresh factorization, compute the residual `A*u - b`
+    against a copy of the original `A` and return `ReturnCode.APosterioriSafetyFailure`
+    if its norm exceeds `abstol + reltol * norm(b)`. Defaults to `false`.
 """
 Base.@kwdef struct LUFactorization{P} <: AbstractDenseFactorization
     pivot::P = LinearAlgebra.RowMaximum()
@@ -300,7 +314,7 @@ end
 LUFactorization(pivot) = LUFactorization(; pivot = RowMaximum())
 
 """
-`GenericLUFactorization(pivot=LinearAlgebra.RowMaximum())`
+    GenericLUFactorization(pivot = LinearAlgebra.RowMaximum(); residualsafety = false)
 
 Julia's built in generic LU factorization. Equivalent to calling LinearAlgebra.generic_lufact!.
 Supports arbitrary number types. Has low overhead and is good for small matrices.
@@ -330,8 +344,14 @@ default algorithm instead.
 
 ## Positional Arguments
 
-  - pivot: The choice of pivoting. Defaults to `LinearAlgebra.RowMaximum()`. The other choice is
+  - `pivot`: The choice of pivoting. Defaults to `LinearAlgebra.RowMaximum()`. The other choice is
     `LinearAlgebra.NoPivot()`.
+
+## Keyword Arguments
+
+  - `residualsafety`: after each fresh factorization, compute the residual `A*u - b`
+    against a copy of the original `A` and return `ReturnCode.APosterioriSafetyFailure`
+    if its norm exceeds `abstol + reltol * norm(b)`. Defaults to `false`.
 """
 struct GenericLUFactorization{P} <: AbstractDenseFactorization
     pivot::P
@@ -932,16 +952,32 @@ end
 ## QRFactorization
 
 """
-`QRFactorization(pivot=LinearAlgebra.NoPivot(),blocksize=16)`
+    QRFactorization(inplace = true)
+    QRFactorization(pivot::LinearAlgebra.PivotingStrategy, inplace = true)
 
-Julia's built in `qr`. Equivalent to calling `qr!(A)`.
+Julia's built in `qr`. Equivalent to calling `qr!(A, pivot)` (or `qr(A, pivot)` when
+`inplace = false`).
 
   - On dense matrices, this uses the current BLAS implementation of the user's computer
     which by default is OpenBLAS but will use MKL if the user does `using MKL` in their
     system.
-  - On sparse matrices, this will use SPQR from SparseArrays
-  - On CuMatrix, it will use a CUDA-accelerated QR from CuSolver.
+  - On sparse matrices, this will use SPQR from SparseArrays (the pivoting strategy is
+    not passed through; SPQR chooses its own column ordering).
+  - On CuMatrix, it will use a CUDA-accelerated QR from CuSolver (again via the plain
+    `qr(A)` form).
   - On BandedMatrix and BlockBandedMatrix, it will use a banded QR.
+
+## Positional Arguments
+
+  - `pivot`: The choice of pivoting. Defaults to `LinearAlgebra.NoPivot()`; the other
+    choice is `LinearAlgebra.ColumnNorm()` for a rank-revealing column-pivoted QR.
+  - `inplace`: whether to factorize with `qr!`, overwriting `A`, rather than the
+    copying `qr`. Only affects mutable CPU matrices; `Symmetric` wrappers, sparse CSC,
+    GPU arrays and immutable matrices always use the out-of-place `qr`. Defaults to
+    `true`.
+
+The struct also carries a `blocksize` field (set to `16` by both constructors) that is
+not read by any solver path; it is kept for structural compatibility only.
 
 With the default `NoPivot()` this is not rank-revealing, so it cannot solve a
 rank-deficient (least-squares) system: it reports `ReturnCode.Failure` when a
@@ -1043,16 +1079,34 @@ end
 ## CholeskyFactorization
 
 """
-`CholeskyFactorization(; pivot = nothing, tol = 0.0, shift = 0.0, perm = nothing)`
+    CholeskyFactorization(; pivot = nothing, tol = 0.0, shift = 0.0, perm = nothing)
 
-Julia's built in `cholesky`. Equivalent to calling `cholesky!(A)`.
+Julia's built in `cholesky`. Equivalent to calling `cholesky!(A, pivot)` on dense
+matrices and `cholesky(A; shift, perm)` (CHOLMOD) on sparse CSC matrices; GPU arrays
+use `cholesky(A)`.
+
+The matrix must be symmetric (or Hermitian) positive definite. Failures such as an
+indefinite matrix are not thrown (the factorization runs with `check = false`) but are
+reported through the solution's `retcode` (`ReturnCode.Failure`). For such matrices
+this is roughly twice as fast as an LU factorization and uses half the storage, so it is
+the preferred direct method whenever positive definiteness is known; use
+`LUFactorization` for general matrices and `BunchKaufmanFactorization` or
+`LDLtFactorization` for symmetric indefinite ones.
 
 ## Keyword Arguments
 
-  - pivot: defaluts to NoPivot, can also be RowMaximum.
-  - tol: the tol argument in CHOLMOD. Only used for sparse matrices.
-  - shift: the shift argument in CHOLMOD. Only used for sparse matrices.
-  - perm: the perm argument in CHOLMOD. Only used for sparse matrices.
+  - `pivot`: the pivoting strategy for dense matrices. `nothing` (the default) means
+    `LinearAlgebra.NoPivot()`; `LinearAlgebra.RowMaximum()` selects the pivoted
+    (rank-revealing) Cholesky. Not used for sparse or GPU matrices.
+  - `tol`: accepted for backwards compatibility but currently not stored: the
+    constructor always sets the internal tolerance to `16`, which is passed as `tol` to
+    `cholesky!(A, RowMaximum(); tol)` on the dense pivoted path only. It is not
+    forwarded to the sparse CHOLMOD factorization.
+  - `shift`: the `shift` argument of CHOLMOD's `cholesky` (a multiple of the identity
+    added before factorizing). Only used for sparse matrices. Defaults to `0.0`.
+  - `perm`: the `perm` argument of CHOLMOD's `cholesky` (a user-supplied fill-reducing
+    permutation). Only used for sparse matrices. Defaults to `nothing` (CHOLMOD's own
+    ordering).
 """
 struct CholeskyFactorization{P, P2} <: AbstractDenseFactorization
     pivot::P
@@ -1177,12 +1231,29 @@ end
 ## SVDFactorization
 
 """
-    SVDFactorization(full=false, alg=nothing)
-Julia's built-in `svd`. Equivalent to `svd!(A)`.
+    SVDFactorization()
+    SVDFactorization(full::Bool, alg)
 
-- On dense matrices, this uses the current BLAS implementation.
-- When `alg = nothing`, the backend default SVD algorithm is used
-  (required for CUDA compatibility).
+Julia's built-in `svd`. Equivalent to `svd!(A; full, alg)` (or the copying `svd` on
+immutable matrices). Solving with the SVD is the most robust of the dense direct
+methods, handling rank-deficient and ill-conditioned (least-squares) systems by
+minimum-norm pseudo-inverse solves, but it is also the slowest; prefer LU or QR when
+the system is well-posed.
+
+  - On dense matrices, this uses the current BLAS/LAPACK implementation.
+  - When `alg = nothing`, the backend default SVD algorithm is used
+    (required for CUDA compatibility).
+
+Only the zero-argument and the two-positional-argument forms exist; there are no
+defaults for a single positional argument.
+
+## Positional Arguments
+
+  - `full`: whether to compute the full SVD (`U` and `V` square) rather than the thin
+    SVD. Passed to `svd!` as `full`. Defaults to `false`.
+  - `alg`: the LAPACK SVD algorithm, `LinearAlgebra.DivideAndConquer()` or
+    `LinearAlgebra.QRIteration()`, or `nothing` to let the backend choose. Defaults to
+    `nothing`.
 """
 struct SVDFactorization{A} <: AbstractDenseFactorization
     full::Bool
@@ -1814,14 +1885,14 @@ end
 A pure-Julia port of SuiteSparse's KLU sparse LU solver, provided by
 [PureKLU.jl](https://github.com/SciML/PureKLU.jl). It has no SuiteSparse binary
 dependency and supports generic element types in addition to `Float64`/`ComplexF64`.
-Loading PureKLU (`using PureKLU`) makes this the default sparse LU for "less
-structured" sparse matrices, replacing the SuiteSparse-backed [`KLUFactorization`](@ref)
-in the default polyalgorithm.
+PureKLU is a hard dependency of LinearSolve, so no extra `using` is required, and
+this is the default sparse LU for "less structured" sparse matrices in the default
+polyalgorithm; the SuiteSparse-backed `KLUFactorization` remains available when
+requested explicitly.
 
 !!! note
 
-    `PureKLUFactorization` is only available once the `PureKLU` package is loaded
-    (`using PureKLU`). It mirrors [`KLUFactorization`](@ref): by default the symbolic
+    `PureKLUFactorization` mirrors `KLUFactorization`: by default the symbolic
     factorization is cached. If the sparsity pattern of `A` may change between solves,
     set `reuse_symbolic = false`. To skip the pattern check entirely (which errors if the
     pattern unexpectedly changes), set `check_pattern = false`.
@@ -1912,8 +1983,9 @@ function init_cacheval(
 end
 
 """
-`SupernodalLUFactorization(; reuse_symbolic = true, check_pattern = true, ordering = :amd,
-                            matching = :auto, eps_pivot = 1e-8, threaded = false)`
+    SupernodalLUFactorization(; reuse_symbolic = true, check_pattern = true, ordering = :amd,
+                              matching = :auto, eps_pivot = 1e-8, threaded = false,
+                              dense_alg = nothing)
 
 A pure-Julia implementation of the supernodal left–right-looking sparse LU
 method of O. Schenk and K. Gärtner (FGCS 20(3), 2004; ETNA 23, 2006),
@@ -1997,9 +2069,9 @@ default polyalgorithm and the fallback when the default sparse LU
   - `reuse_symbolic`: reuse the cached symbolic factorization across solves when
     the sparsity pattern is unchanged. Defaults to `true`.
   - `ordering`: column ordering passed to `SparseColumnPivotedQR.scpqr`
-    (`:default`, `:amd`, `:natural`). LinearSolve loads AMD alongside the sparse
-    extension, so `:default` resolves to AMD ordering (1.5-2x faster factorization
-    than `:natural`). Defaults to `:default`.
+    (`:default`, `:amd`, `:natural`). LinearSolve imports AMD as a hard dependency,
+    so `:default` resolves to AMD ordering (1.5-2x faster factorization than
+    `:natural`). Defaults to `:default`.
 """
 Base.@kwdef struct SparseColumnPivotedQRFactorization <: AbstractSparseFactorization
     reuse_symbolic::Bool = true
@@ -2018,11 +2090,11 @@ end
 ## CHOLMODFactorization
 
 """
-`CHOLMODFactorization(; shift = 0.0, perm = nothing)`
+    CHOLMODFactorization(; shift = 0.0, perm = nothing)
 
 A wrapper of CHOLMOD's polyalgorithm, mixing Cholesky factorization and ldlt.
-Tries cholesky for performance and retries ldlt if conditioning causes Cholesky
-to fail.
+Tries `cholesky(A; check = false)` for performance and retries with
+`ldlt!(fact, A; check = false)` if conditioning causes Cholesky to fail.
 
 Only supports sparse matrices.
 
@@ -2034,8 +2106,14 @@ Only supports sparse matrices.
 
 ## Keyword Arguments
 
-  - shift: the shift argument in CHOLMOD.
-  - perm: the perm argument in CHOLMOD
+  - `shift`: intended as the `shift` argument of CHOLMOD's `cholesky`/`ldlt` (a
+    multiple of the identity added before factorizing). Defaults to `0.0`. Currently
+    stored on the algorithm but not forwarded: `solve!` calls CHOLMOD with its default
+    shift, so this keyword has no effect. Use `CholeskyFactorization(shift = ...)` or
+    `LDLtFactorization(shift, perm)` when a shift or ordering must be applied.
+  - `perm`: intended as the `perm` argument of CHOLMOD (a user-supplied fill-reducing
+    permutation). Defaults to `nothing`. Like `shift`, it is currently stored but not
+    forwarded to the factorization calls.
 """
 Base.@kwdef struct CHOLMODFactorization{T} <: AbstractSparseFactorization
     shift::Float64 = 0.0
@@ -2075,11 +2153,12 @@ end
 ## NormalCholeskyFactorization
 
 """
-`NormalCholeskyFactorization(pivot = RowMaximum())`
+    NormalCholeskyFactorization(; pivot = nothing)
 
-A fast factorization which uses a Cholesky factorization on A * A'. Can be much
-faster than LU factorization, but is not as numerically stable and thus should only
-be applied to well-conditioned matrices.
+A fast factorization which solves the normal equations `A' * A * u = A' * b` with a
+Cholesky factorization of `Symmetric(A' * A)`. Can be much faster than LU
+factorization, but squares the condition number of `A` and thus should only be
+applied to well-conditioned matrices.
 
 !!! warning
 
@@ -2088,9 +2167,12 @@ be applied to well-conditioned matrices.
     recommended that the user checks `A*u-b` is approximately zero, as this may be untrue
     even if `sol.retcode === ReturnCode.Success` due to numerical stability issues.
 
-## Positional Arguments
+## Keyword Arguments
 
-  - pivot: Defaults to RowMaximum(), but can be NoPivot()
+  - `pivot`: the pivoting strategy passed to `cholesky` for dense matrices. `nothing`
+    (the default) means `LinearAlgebra.NoPivot()`; `LinearAlgebra.RowMaximum()` selects
+    the pivoted Cholesky. Sparse, GPU and static matrices always use the unpivoted
+    `cholesky`.
 """
 struct NormalCholeskyFactorization{P} <: AbstractDenseFactorization
     pivot::P
@@ -2181,15 +2263,16 @@ end
 ## NormalBunchKaufmanFactorization
 
 """
-`NormalBunchKaufmanFactorization(rook = false)`
+    NormalBunchKaufmanFactorization(; rook = false)
 
-A fast factorization which uses a BunchKaufman factorization on A * A'. Can be much
-faster than LU factorization, but is not as numerically stable and thus should only
-be applied to well-conditioned matrices.
+A fast factorization which solves the normal equations `A' * A * u = A' * b` with a
+Bunch-Kaufman factorization of `Symmetric(A' * A)`. Can be much faster than LU
+factorization, but squares the condition number of `A` and thus should only be
+applied to well-conditioned matrices.
 
-## Positional Arguments
+## Keyword Arguments
 
-  - rook: whether to perform rook pivoting. Defaults to false.
+  - `rook`: whether to perform rook pivoting in `bunchkaufman`. Defaults to `false`.
 """
 struct NormalBunchKaufmanFactorization <: AbstractDenseFactorization
     rook::Bool
@@ -2265,9 +2348,13 @@ end
 ## SparspakFactorization is here since it's MIT licensed, not GPL
 
 """
-`SparspakFactorization(reuse_symbolic = true)`
+    SparspakFactorization(; reuse_symbolic = true, throwerror = true)
 
-This is the translation of the well-known sparse matrix software Sparspak
+A sparse LU factorization using the pure-Julia
+[Sparspak.jl](https://github.com/PetrKryslUCSD/Sparspak.jl) package (`sparspaklu`),
+made available through the `LinearSolveSparspakExt` extension.
+
+Sparspak.jl is the translation of the well-known sparse matrix software Sparspak
 (Waterloo Sparse Matrix Package), solving
 large sparse systems of linear algebraic equations. Sparspak is composed of the
 subroutines from the book "Computer Solution of Large Sparse Positive Definite
@@ -2279,6 +2366,27 @@ from the authors of the Fortran package. The package uses multiple
 dispatch to route around standard BLAS routines in the case e.g. of arbitrary-precision
 floating point numbers or ForwardDiff.Dual.
 This e.g. allows for Automatic Differentiation (AD) of a sparse-matrix solve.
+
+Use it for square sparse CSC systems whose element type is not supported by the
+SuiteSparse (UMFPACK/KLU) solvers, such as `BigFloat` or dual numbers, or as a
+non-GPL alternative to UMFPACK. It is not part of the default polyalgorithm (which
+uses the pure-Julia `PureKLUFactorization` for generic element types), and for
+`Float64`/`ComplexF64` matrices `PureKLUFactorization`, `SupernodalLUFactorization`
+and `UMFPACKFactorization` are usually faster.
+
+## Keyword Arguments
+
+  - `reuse_symbolic`: reuse the cached symbolic factorization (ordering) across
+    refactorizations by calling `sparspaklu!` on the cached object rather than
+    recomputing it with `sparspaklu`. Set to `false` if the sparsity pattern of `A`
+    changes between solves. Defaults to `true`.
+  - `throwerror`: whether to throw an error at construction time if Sparspak.jl is not
+    loaded. Defaults to `true`.
+
+!!! note
+
+    Using this solver requires that the Sparspak.jl package is loaded, i.e.
+    `using Sparspak`.
 """
 struct SparspakFactorization <: AbstractSparseFactorization
     reuse_symbolic::Bool
@@ -2294,35 +2402,49 @@ struct SparspakFactorization <: AbstractSparseFactorization
 end
 
 """
-`STRUMPACKFactorization(; use_initial_guess = false, options = String[], kwargs...)`
+    STRUMPACKFactorization(; use_initial_guess = false, options = String[],
+                           compression = nothing, rel_tol = nothing, abs_tol = nothing,
+                           max_rank = nothing, leaf_size = nothing, reordering = nothing,
+                           matching = nothing, throwerror = true)
 
 A sparse direct solver based on
 [STRUMPACK](https://github.com/pghysels/STRUMPACK) via the
 `LinearSolveSTRUMPACKExt` extension.
 
 This wrapper targets the single-node (`MT`) sparse interface and currently supports
-real sparse matrices (`AbstractSparseMatrixCSC{<:AbstractFloat}`), solving in
+square real sparse matrices (`AbstractSparseMatrixCSC{<:AbstractFloat}`), solving in
 `Float64` precision.
 
-Pass STRUMPACK runtime options through `options` to expose advanced functionality.
+## Keyword Arguments
+
+  - `use_initial_guess`: passed as the `use_initial_guess` flag of `STRUMPACK_solve`,
+    so that the current contents of `cache.u` are used as the starting guess for
+    STRUMPACK's iterative refinement / iterative solve. Defaults to `false`.
+  - `options`: STRUMPACK runtime options, given as a flat `Vector{String}` of
+    command-line style tokens where each flag is followed by its value, for example
+    `["--sp_rel_tol", "1e-6", "--sp_compression", "HSS"]`. The tokens are handed to
+    `STRUMPACK_init_mt` as `argv`, so any unexposed or version-specific knob can be set
+    this way. Defaults to `String[]`.
+  - `throwerror`: whether to throw an error at construction time if the STRUMPACK
+    extension (or its shared library) is not available. Defaults to `true`.
 
 Convenience keyword arguments are provided for common low-rank/compression tuning
-and are translated to STRUMPACK-style runtime options:
+and are appended to `options` as STRUMPACK-style runtime options (each defaults to
+`nothing`, meaning "not set"):
 - `compression` -> `--sp_compression`
-- `rel_tol` -> `--sp_rel_tol`
-- `abs_tol` -> `--sp_abs_tol`
-- `max_rank` -> `--sp_max_rank`
-- `leaf_size` -> `--sp_leaf_size`
+- `rel_tol` -> `--sp_rel_tol` (must be non-negative)
+- `abs_tol` -> `--sp_abs_tol` (must be non-negative)
+- `max_rank` -> `--sp_max_rank` (integer, at least 1)
+- `leaf_size` -> `--sp_leaf_size` (integer, at least 1)
 - `reordering` -> `--sp_reordering_method`
-- `matching` -> `--sp_enable_matching`
-
-Any unexposed or version-specific knobs can still be passed through `options`.
+- `matching` -> `--sp_enable_matching` (a `Bool`, written as `1`/`0`)
 
 !!! note
 
-    Using this solver requires:
-    1. `using SparseArrays` (to enable sparse matrix support), and
-    2. loading `STRUMPACK_jll` (for example `import STRUMPACK_jll`).
+    Using this solver requires loading `STRUMPACK_jll` (for example
+    `import STRUMPACK_jll`), which activates the `LinearSolveSTRUMPACKExt` extension.
+    LinearSolve's sparse matrix support is built in and no longer needs a separate
+    extension to be loaded.
 """
 struct STRUMPACKFactorization <: AbstractSparseFactorization
     use_initial_guess::Bool
@@ -2407,15 +2529,37 @@ end
 ## CliqueTreesFactorization is here since it's MIT licensed, not GPL
 
 """
-    CliqueTreesFactorization(
-        alg = nothing,
-        snd = nothing,
-        reuse_symbolic = true,
-    )
+    CliqueTreesFactorization(; alg = nothing, snd = nothing, reuse_symbolic = true,
+                             throwerror = true)
 
-The sparse Cholesky factorization algorithm implemented in CliqueTrees.jl.
-The implementation is pure-Julia and accepts arbitrary numeric types. It is
-somewhat slower than CHOLMOD.
+The sparse Cholesky factorization algorithm implemented in
+[CliqueTrees.jl](https://github.com/AlgebraicJulia/CliqueTrees.jl)
+(`CliqueTrees.Multifrontal.ChordalCholesky`), made available through the
+`LinearSolveCliqueTreesExt` extension. The implementation is pure-Julia and
+accepts arbitrary numeric types. It is somewhat slower than CHOLMOD.
+
+The matrix must be a sparse symmetric positive definite matrix. Use it as a
+CHOLMOD replacement when the element type is not `Float64`/`ComplexF64` (for example
+`BigFloat` or dual numbers), or when a SuiteSparse-free stack is wanted.
+
+## Keyword Arguments
+
+  - `alg`: the elimination (fill-reducing ordering) algorithm option of
+    `ChordalCholesky`, forwarded as its `alg` keyword when not `nothing`. Defaults to
+    `nothing` (CliqueTrees' default ordering).
+  - `snd`: the supernode partition option of `ChordalCholesky`, forwarded as its `snd`
+    keyword when not `nothing`. Defaults to `nothing` (CliqueTrees' default supernodes).
+  - `reuse_symbolic`: reuse the cached symbolic factorization (elimination tree and
+    supernodal structure) across refactorizations, only recomputing the numeric
+    factorization with `cholesky!`. Set to `false` to rebuild the symbolic analysis
+    on every fresh matrix, e.g. when the sparsity pattern changes. Defaults to `true`.
+  - `throwerror`: whether to throw an error at construction time if CliqueTrees.jl is
+    not loaded. Defaults to `true`.
+
+!!! note
+
+    Using this solver requires that the CliqueTrees.jl package is loaded, i.e.
+    `using CliqueTrees`.
 """
 struct CliqueTreesFactorization{A, S} <: AbstractSparseFactorization
     alg::A

--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -71,20 +71,73 @@ EnumX.@enumx WarmStart begin
 end
 
 """
-```julia
-KrylovJL(args...; KrylovAlg = Krylov.gmres!,
-    Pl = nothing, Pr = nothing,
-    gmres_restart = 0, window = 0,
-    warm_start = WarmStart.Auto,
-    kwargs...)
-```
+    KrylovJL(args...; KrylovAlg = Krylov.gmres!, gmres_restart = 0, window = 0,
+        warm_start = WarmStart.Auto, precs = nothing, kwargs...)
 
-A generic wrapper over the Krylov.jl krylov-subspace iterative solvers.
+A generic wrapper over the Krylov.jl Krylov-subspace iterative solvers. The chosen
+in-place solver is run through `Krylov.krylov_solve!` on a Krylov.jl workspace
+that `solve!` builds on the first solve, rebuilds whenever `A` has been replaced
+(`cache.A = newA` or `reinit!` with a new `A`), and otherwise reuses across
+solves of the same cache (for example when only `b` changes). Preconditioners,
+whether given as `Pl`/`Pr` to `init`/`solve` or built by `precs`, are handed to
+Krylov.jl as its `M` (left) and `N` (right) operators, for the methods that take
+them (see the last paragraph). The named constructors `KrylovJL_GMRES`,
+`KrylovJL_CG`, `KrylovJL_MINRES`, `KrylovJL_FGMRES`, `KrylovJL_BICGSTAB`,
+`KrylovJL_LSMR`, `KrylovJL_CRAIGMR`, and `KrylovJL_MINARES` fix `KrylovAlg` and
+forward everything else here.
 
-`warm_start` (a [`WarmStart`](@ref) value) selects the initial guess used when
-the same cache is solved repeatedly (GMRES and FGMRES only): `WarmStart.Auto`
-(default; cold start unless a caller resolves it), `WarmStart.None`,
-`WarmStart.Previous`, or the recommended `WarmStart.Hegedus`.
+## Positional Arguments
+
+  - `args...`: stored on the algorithm but not used by `solve!`.
+
+## Keyword Arguments
+
+  - `KrylovAlg`: the Krylov.jl in-place solver function to run. It must be one of
+    the `Krylov.<method>!` functions LinearSolve knows how to build a workspace
+    for: `cg!`, `cr!`, `cgs!`, `minres!`, `minres_qlp!`, `minares!`, `symmlq!`,
+    `cg_lanczos!`, `gmres!`, `fgmres!`, `dqgmres!`, `diom!`, `fom!`, `gpmr!`,
+    `bicgstab!`, `bilq!`, `bilqr!`, `qmr!`, `usymlq!`, `usymqr!`, `tricg!`,
+    `trimr!`, `trilqr!`, `cgls!`, `crls!`, `lsqr!`, `lslq!`, `lsmr!`, `cgne!`,
+    `crmr!`, `lnlq!`, `craig!`, or `craigmr!`. Any other value errors with
+    "Invalid Krylov method detected". Defaults to `Krylov.gmres!`.
+  - `gmres_restart`: Krylov subspace size for the GMRES-like methods (`gmres!`,
+    `fgmres!`, `dqgmres!`, `diom!`, `fom!`, `gpmr!`). `0` sizes the workspace with
+    `memory = min(20, size(A, 1))` and runs GMRES without restarting; a positive
+    value sets `memory = gmres_restart` and, for `gmres!` only, also passes
+    `restart = true` so that GMRES restarts every `gmres_restart` iterations. For
+    the other GMRES-like methods it only sizes the workspace (pass
+    `restart = true` in `kwargs` to make FGMRES restart). Ignored by every other
+    method. Defaults to `0`.
+  - `window`: the `window` argument of the Krylov.jl workspace constructor for
+    `minres!`, `symmlq!`, `lslq!`, `lsqr!`, and `lsmr!` (the number of iterations
+    used to estimate a lower bound on the error), forwarded when nonzero. Ignored
+    by every other method. Defaults to `0`.
+  - `warm_start`: a [`WarmStart`](@ref) value selecting the initial guess used when
+    the same cache is solved repeatedly (GMRES and FGMRES only): `WarmStart.Auto`
+    (cold start unless a caller resolves it), `WarmStart.None`,
+    `WarmStart.Previous`, or the recommended `WarmStart.Hegedus`. Defaults to
+    `WarmStart.Auto`.
+  - `precs`: a preconditioner builder, a function `(A, p) -> (Pl, Pr)`. It is
+    called at `init` (explicit `Pl`/`Pr` passed to `init`/`solve` take
+    precedence) and again in `solve!` whenever `A` or `p` has changed since the
+    preconditioners were last built (`reinit!` without `reuse_precs = true`), and
+    its result becomes `cache.Pl`/`cache.Pr`. `nothing` means no preconditioning
+    unless `Pl`/`Pr` are given to `init`/`solve`. Defaults to `nothing`.
+  - `kwargs...`: any remaining keywords are forwarded to `Krylov.krylov_solve!` on
+    every solve (for example `callback`, `reorthogonalization`, `timemax`, or
+    `restart`), on top of the `atol`/`rtol` tolerances, `itmax = maxiters`,
+    `verbose`, `ldiv = true`, and `history = true` that LinearSolve supplies. Two
+    exceptions are consumed at workspace construction instead of being
+    forwarded: `memory` overrides the subspace size derived from
+    `gmres_restart`, and `window` is dropped (use the `window` keyword above).
+
+Right preconditioning is only available for some methods. For `cg!`, `minres!`,
+`cgls!`, and `crls!` a non-identity `Pr` triggers the `no_right_preconditioning`
+verbosity message and is discarded, since Krylov.jl takes only a centered
+preconditioner `M` for them. `Pl` and `Pr` are passed through for the GMRES,
+FGMRES, BiCGSTAB, LSMR, LSQR, and LSLQ workspaces. For every other `KrylovAlg`
+(including `craigmr!` and `minares!`), `solve!` calls the Krylov solver without
+`M`/`N`, so any `Pl`/`Pr` are silently ignored.
 """
 struct KrylovJL{F, I, P, A, K} <: AbstractKrylovSubspaceMethod
     KrylovAlg::F
@@ -113,94 +166,161 @@ default_alias_A(::KrylovJL, ::Any, ::Any) = true
 default_alias_b(::KrylovJL, ::Any, ::Any) = true
 
 """
-```julia
-KrylovJL_CG(args...; kwargs...)
-```
+    KrylovJL_CG(args...; kwargs...)
 
-A generic CG implementation for Hermitian and positive definite linear systems
+Conjugate gradient for Hermitian positive definite linear systems, wrapping
+`Krylov.cg!` via `KrylovJL` (equivalent to
+`KrylovJL(args...; KrylovAlg = Krylov.cg!, kwargs...)`). All keyword arguments
+(`precs`, and any Krylov.jl solve keywords such as `callback`) are those of
+`KrylovJL`; `gmres_restart` and `window` have no effect here. Only left
+(centered) preconditioning is supported: a right preconditioner `Pr` triggers
+the `no_right_preconditioning` verbosity message and is discarded.
 """
 function KrylovJL_CG(args...; kwargs...)
     return KrylovJL(args...; KrylovAlg = Krylov.cg!, kwargs...)
 end
 
 """
-```julia
-KrylovJL_MINRES(args...; kwargs...)
-```
+    KrylovJL_MINRES(args...; window = 0, kwargs...)
 
-A generic MINRES implementation for Hermitian linear systems
+MINRES for Hermitian (possibly indefinite) linear systems, wrapping
+`Krylov.minres!` via `KrylovJL` (equivalent to
+`KrylovJL(args...; KrylovAlg = Krylov.minres!, kwargs...)`). Keyword arguments
+are those of `KrylovJL`. `window` sizes the error-estimation window of the
+MINRES workspace when nonzero (defaults to `0`, meaning Krylov.jl's default);
+`gmres_restart` has no effect here. Only left (centered) preconditioning is
+supported: a right preconditioner `Pr` triggers the `no_right_preconditioning`
+verbosity message and is discarded. Batched (matrix) right-hand sides are
+supported through Krylov.jl's block MINRES.
 """
 function KrylovJL_MINRES(args...; kwargs...)
     return KrylovJL(args...; KrylovAlg = Krylov.minres!, kwargs...)
 end
 
 """
-```julia
-KrylovJL_GMRES(args...; gmres_restart = 0, window = 0, warm_start = WarmStart.Auto, kwargs...)
-```
+    KrylovJL_GMRES(args...; gmres_restart = 0, warm_start = WarmStart.Auto,
+        precs = nothing, kwargs...)
 
-A generic GMRES implementation for square non-Hermitian linear systems
+GMRES for square non-Hermitian linear systems, wrapping `Krylov.gmres!` via
+`KrylovJL` (equivalent to `KrylovJL(args...; KrylovAlg = Krylov.gmres!, kwargs...)`).
+This is the general-purpose iterative choice, and the one the default
+polyalgorithm falls back to for operators without a matrix representation.
 
-`warm_start` (a [`WarmStart`](@ref) value) selects the initial guess used when
-the same cache is solved repeatedly; see [`KrylovJL`](@ref).
+## Keyword Arguments
+
+  - `gmres_restart`: `0` allocates a workspace with `memory = min(20, size(A, 1))`
+    and runs GMRES without restarting; a positive value sets the workspace memory
+    to `gmres_restart` and passes `restart = true`, so GMRES restarts every
+    `gmres_restart` iterations. Defaults to `0`.
+  - `warm_start`: a [`WarmStart`](@ref) value selecting the initial guess used
+    when the same cache is solved repeatedly; see `KrylovJL` and `WarmStart`.
+    Defaults to `WarmStart.Auto`.
+  - `precs`: a preconditioner builder `(A, p) -> (Pl, Pr)`; see `KrylovJL`.
+    Defaults to `nothing`.
+  - `kwargs...`: forwarded to `Krylov.krylov_solve!` as described for `KrylovJL`
+    (`memory` overrides the subspace size derived from `gmres_restart`).
+
+Both left and right preconditioners are supported. `window` is accepted but has
+no effect for GMRES. Batched (matrix) right-hand sides are supported through
+Krylov.jl's block GMRES.
 """
 function KrylovJL_GMRES(args...; kwargs...)
     return KrylovJL(args...; KrylovAlg = Krylov.gmres!, kwargs...)
 end
 
 """
-```julia
-KrylovJL_FGMRES(args...; gmres_restart = 0, window = 0, warm_start = WarmStart.Auto, kwargs...)
-```
+    KrylovJL_FGMRES(args...; gmres_restart = 0, warm_start = WarmStart.Auto,
+        precs = nothing, kwargs...)
 
-A generic FGMRES implementation for square non-Hermitian linear systems
+Flexible GMRES for square non-Hermitian linear systems, wrapping `Krylov.fgmres!`
+via `KrylovJL` (equivalent to
+`KrylovJL(args...; KrylovAlg = Krylov.fgmres!, kwargs...)`). Use it in place of
+`KrylovJL_GMRES` when the right preconditioner changes between iterations, for
+example when it is itself an iterative solve.
 
-`warm_start` (a [`WarmStart`](@ref) value) selects the initial guess used when
-the same cache is solved repeatedly; see [`KrylovJL`](@ref).
+## Keyword Arguments
+
+  - `gmres_restart`: `0` allocates a workspace with `memory = min(20, size(A, 1))`;
+    a positive value sets the workspace memory to `gmres_restart`. Unlike
+    `KrylovJL_GMRES`, no `restart` flag is passed for FGMRES, so this only sizes
+    the workspace; pass `restart = true` in `kwargs` to make FGMRES restart every
+    `gmres_restart` iterations. Defaults to `0`.
+  - `warm_start`: a [`WarmStart`](@ref) value selecting the initial guess used
+    when the same cache is solved repeatedly; see `KrylovJL` and `WarmStart`.
+    Defaults to `WarmStart.Auto`.
+  - `precs`: a preconditioner builder `(A, p) -> (Pl, Pr)`; see `KrylovJL`.
+    Defaults to `nothing`.
+  - `kwargs...`: forwarded to `Krylov.krylov_solve!` as described for `KrylovJL`
+    (`memory` overrides the subspace size derived from `gmres_restart`).
+
+Both left and right preconditioners are supported. `window` is accepted but has
+no effect for FGMRES.
 """
 function KrylovJL_FGMRES(args...; kwargs...)
     return KrylovJL(args...; KrylovAlg = Krylov.fgmres!, kwargs...)
 end
 
 """
-```julia
-KrylovJL_BICGSTAB(args...; kwargs...)
-```
+    KrylovJL_BICGSTAB(args...; kwargs...)
 
-A generic BICGSTAB implementation for square non-Hermitian linear systems
+BiCGSTAB for square non-Hermitian linear systems, wrapping `Krylov.bicgstab!` via
+`KrylovJL` (equivalent to
+`KrylovJL(args...; KrylovAlg = Krylov.bicgstab!, kwargs...)`). Its memory use
+does not grow with the iteration count, unlike unrestarted GMRES, at the cost of
+a less regular convergence history. All keyword arguments (`precs`, and any Krylov.jl solve
+keywords such as `callback`) are those of `KrylovJL`; `gmres_restart` and
+`window` have no effect here. Both left and right preconditioners are supported.
 """
 function KrylovJL_BICGSTAB(args...; kwargs...)
     return KrylovJL(args...; KrylovAlg = Krylov.bicgstab!, kwargs...)
 end
 
 """
-```julia
-KrylovJL_LSMR(args...; kwargs...)
-```
+    KrylovJL_LSMR(args...; window = 0, kwargs...)
 
-A generic LSMR implementation for least-squares problems
+LSMR for least-squares problems (rectangular or rank-deficient `A`, minimizing
+`‖b - A x‖`), wrapping `Krylov.lsmr!` via `KrylovJL` (equivalent to
+`KrylovJL(args...; KrylovAlg = Krylov.lsmr!, kwargs...)`). It is the default
+polyalgorithm's choice for tall systems whose `A` is an operator without a matrix
+representation. Keyword arguments are those of `KrylovJL`. `window` sizes the
+error-estimation window of the LSMR workspace when nonzero (defaults to `0`,
+meaning Krylov.jl's default); `gmres_restart` has no effect here. Both left and
+right preconditioners are passed through to Krylov.jl.
 """
 function KrylovJL_LSMR(args...; kwargs...)
     return KrylovJL(args...; KrylovAlg = Krylov.lsmr!, kwargs...)
 end
 
 """
-```julia
-KrylovJL_CRAIGMR(args...; kwargs...)
-```
+    KrylovJL_CRAIGMR(args...; kwargs...)
 
-A generic CRAIGMR implementation for least-norm problems
+CRAIGMR for least-norm problems (underdetermined `A`, returning the minimum-norm
+solution of `A x = b`), wrapping `Krylov.craigmr!` via `KrylovJL` (equivalent to
+`KrylovJL(args...; KrylovAlg = Krylov.craigmr!, kwargs...)`). It is the default
+polyalgorithm's choice for wide systems whose `A` is an operator without a matrix
+representation. Keyword arguments (`precs`, and any Krylov.jl solve keywords)
+are those of `KrylovJL`; `gmres_restart` and `window` have no effect here.
+Preconditioners are not passed through for this method:
+`solve!` calls `Krylov.craigmr!` without `M`/`N`, so any `Pl`/`Pr` supplied to
+`init`/`solve` or built by `precs` are silently ignored.
 """
 function KrylovJL_CRAIGMR(args...; kwargs...)
     return KrylovJL(args...; KrylovAlg = Krylov.craigmr!, kwargs...)
 end
 
 """
-```julia
-KrylovJL_MINARES(args...; kwargs...)
-```
+    KrylovJL_MINARES(args...; kwargs...)
 
-A generic MINARES implementation for Hermitian linear systems
+MINARES for Hermitian (possibly indefinite or singular) linear systems,
+wrapping `Krylov.minares!` via `KrylovJL` (equivalent to
+`KrylovJL(args...; KrylovAlg = Krylov.minares!, kwargs...)`). It minimizes the
+norm of `A r` rather than that of the residual `r`, and is an alternative to
+`KrylovJL_MINRES` for singular or nearly singular Hermitian systems. Keyword
+arguments (`precs`, and any Krylov.jl solve keywords) are those of `KrylovJL`;
+`gmres_restart` and `window` have no effect here. Preconditioners are not passed
+through for this method: `solve!` calls `Krylov.minares!` without `M`/`N`, so
+any `Pl`/`Pr` supplied to `init`/`solve` or built by `precs` are silently
+ignored.
 """
 function KrylovJL_MINARES(args...; kwargs...)
     return KrylovJL(args...; KrylovAlg = Krylov.minares!, kwargs...)

--- a/src/mkl.jl
+++ b/src/mkl.jl
@@ -1,10 +1,29 @@
 """
-```julia
-MKLLUFactorization()
-```
+    MKLLUFactorization(; residualsafety::Bool = false)
 
-A wrapper over Intel's Math Kernel Library (MKL). Direct calls to MKL in a way that pre-allocates workspace
-to avoid allocations and does not require libblastrampoline.
+A wrapper over Intel's Math Kernel Library (MKL). Direct calls to MKL's LU routines
+(`getrf!` and `getrs!`) in a way that pre-allocates workspace to avoid allocations and does
+not require libblastrampoline. Supports `Float32`, `Float64`, `ComplexF32`, and `ComplexF64`
+element types.
+
+Use this to guarantee MKL's LU is used regardless of the system BLAS configuration (no
+`using MKL` needed), or when benchmarking shows it beats `LUFactorization` on your hardware.
+Where MKL is loaded, the default algorithm choice already selects this method for larger
+dense BLAS-eltype matrices.
+
+## Keyword Arguments
+
+  - `residualsafety`: If `true`, every solve that (re)factorizes `A` is followed by a
+    residual check against a copy of the original matrix. If `‖A*x - b‖` exceeds
+    `abstol + reltol * ‖b‖` (the tolerances of the solve), the returned solution has
+    `retcode = ReturnCode.APosterioriSafetyFailure`. Defaults to `false`.
+
+!!! note
+
+    MKL is only loaded on x86_64/i686 hosts when the `LoadMKL_JLL` preference is `true`
+    (the default, except on AMD EPYC CPUs where it defaults to `false`) and MKL_jll is at
+    least version 2022.2. Otherwise `solve!` with this algorithm errors that the MKL binary
+    is missing.
 """
 struct MKLLUFactorization <: AbstractFactorization
     residualsafety::Bool

--- a/src/openblas.jl
+++ b/src/openblas.jl
@@ -1,11 +1,16 @@
 """
-```julia
-OpenBLASLUFactorization()
-```
+    OpenBLASLUFactorization(; residualsafety::Bool = false)
 
 A direct wrapper over OpenBLAS's LU factorization (`getrf!` and `getrs!`).
 This solver makes direct calls to OpenBLAS_jll without going through Julia's
 libblastrampoline, which can provide performance benefits in certain configurations.
+
+## Keyword Arguments
+
+  - `residualsafety`: If `true`, every solve that (re)factorizes `A` is followed by a
+    residual check against a copy of the original matrix. If `‖A*x - b‖` exceeds
+    `abstol + reltol * ‖b‖` (the tolerances of the solve), the returned solution has
+    `retcode = ReturnCode.APosterioriSafetyFailure`. Defaults to `false`.
 
 ## Performance Characteristics
 

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -222,8 +222,28 @@ end
 """
     show_algorithm_choices()
 
-Display what algorithm choices are actually made by the default solver for 
-representative matrix sizes. Shows current preferences and system information.
+Print a report of the dense default algorithm selection to `stdout` and return
+`nothing`. Takes no arguments. Use it to check whether autotune preferences are set and
+took effect, or to see which LU variant `solve(prob)` will pick on this machine.
+
+The report has three parts, followed by a short legend of the size categories:
+
+  - **Current Preferences**: the Preferences.jl entries `best_algorithm_<eltype>_<size>`
+    and `best_always_loaded_<eltype>_<size>` stored for LinearSolve (typically written to
+    `LocalPreferences.toml` by LinearSolveAutotune.jl) for the eltypes `Float32`,
+    `Float64`, `ComplexF32`, `ComplexF64` and the size categories `tiny` (n <= 20),
+    `small` (21-100), `medium` (101-300), `large` (301-1000), `big` (> 1000), or
+    "No autotune preferences currently set." if there are none.
+  - **Default Algorithm Choices**: a table of the algorithm `defaultalg` returns for a
+    dense random square matrix (with `OperatorAssumptions(true)`) of each eltype at one
+    representative size per category: 8, 50, 200, 500, and 1500. Sizes of 10 or less
+    always resolve to `GenericLUFactorization`.
+  - **System Information**: whether MKL and Apple Accelerate are available and whether
+    RecursiveFactorization.jl is enabled.
+
+Preferences are read into constants when LinearSolve is compiled, so a preference set
+in the current session shows up in the first section but only changes the second
+section (and actual solves) after Julia is restarted.
 """
 function show_algorithm_choices()
     println("="^60)

--- a/src/simplegmres.jl
+++ b/src/simplegmres.jl
@@ -19,6 +19,13 @@ specialized dispatches.
 
       + If this is set `≤ 0` and during runtime we get a Block Diagonal Matrix, then we will
         check if the specialized dispatch can be used.
+  - `warm_start::Bool = false`: If `true`, the initial residual is formed as `b - A*Δx` from
+    the cache's internal `Δx` buffer instead of as `b`, and `Δx` is folded into the returned
+    solution (following the Krylov.jl `warm_start` convention). Note that in the current
+    implementation nothing copies the problem's `u0` into `Δx`: with `restart = true` the
+    buffer is uninitialized, and with `restart = false` it has length zero (so the first
+    `solve!` throws a `DimensionMismatch`). This option therefore does not seed the
+    iteration from `u0`. Leave it at the default `false`.
 
 !!! warning
 

--- a/src/solve_function.jl
+++ b/src/solve_function.jl
@@ -60,29 +60,36 @@ function SciMLBase.solve!(
 end
 
 """
-    DirectLdiv!{cache}() <: AbstractSolveFunction
+    DirectLdiv!(::Val{cache} = Val(true))
 
 A simple linear solver that directly applies the left-division operator (`\\`)
 to solve the linear system. This algorithm calls `ldiv!(u, A, b)` which computes
-`u = A \\ b` in-place.
+`u = A \\ b` in-place. It is the default algorithm for operators that already know how
+to solve with themselves: `Factorization` objects, `SciMLOperators` with `has_ldiv!`,
+and (on Julia 1.11 and later) square `Tridiagonal` and `Bidiagonal` matrices.
 
-## Type Parameter
+## Positional Arguments
 
-- `cache::Bool`: Whether to cache a copy of the matrix for use with ldiv!.
-  When `true`, a copy of the matrix is stored during `init` and used during `solve!`,
-  preventing mutation of `cache.A`. Default is `true` for matrix types where `ldiv!`
-  mutates the input (e.g., `Tridiagonal`, `SymTridiagonal`).
+  - `::Val{cache}`: `Val(true)` or `Val(false)`, stored as the type parameter
+    `DirectLdiv!{cache}`. Defaults to `Val(true)` for every matrix type. With
+    `Val(true)`, `init` stores a copy of `A` for the matrix types whose `ldiv!`
+    mutates its input, currently `Tridiagonal` and `SymTridiagonal`, and each
+    `solve!` refreshes that copy from `cache.A` and factorizes the copy, so `cache.A`
+    is preserved. For every other `A`, `Val(true)` and `Val(false)` behave the same:
+    `ldiv!(u, A, b)` is called on `cache.A` directly with no copy. With `Val(false)`,
+    `Tridiagonal`/`SymTridiagonal` are also passed straight to `ldiv!`, which
+    overwrites `cache.A` with its LU factors.
 
 ## Usage
 
 ```julia
-# Default: automatically caches for matrix types that need it
+# Default: copies A for the matrix types whose ldiv! mutates it
 alg = DirectLdiv!()
 sol = solve(prob, alg)
 
-# Explicit caching control
-alg = DirectLdiv!(Val(true))   # Always cache
-alg = DirectLdiv!(Val(false))  # Never cache (may mutate A)
+# Explicit control of the copy
+alg = DirectLdiv!(Val(true))   # copy for Tridiagonal/SymTridiagonal
+alg = DirectLdiv!(Val(false))  # never copy (ldiv! may mutate A)
 ```
 
 ## Notes
@@ -93,7 +100,9 @@ alg = DirectLdiv!(Val(false))  # Never cache (may mutate A)
 - No preconditioners or advanced numerical techniques are applied
 - Best used for small to medium problems or when `A` has special structure
 - For `Tridiagonal` and `SymTridiagonal`, `ldiv!` performs in-place LU factorization
-  which mutates the matrix. Use `cache=true` (default) to preserve `cache.A`.
+  which mutates the matrix. Keep the default `Val(true)` to preserve `cache.A`.
+- Only the `Val(...)` positional argument selects the mode; there is no `cache`
+  keyword argument.
 """
 struct DirectLdiv!{cache} <: AbstractSolveFunction
     function DirectLdiv!(::Val{cache} = Val(true)) where {cache}

--- a/src/verbosity.jl
+++ b/src/verbosity.jl
@@ -162,24 +162,52 @@ diagnostic messages, warnings, and errors during linear system solution.
 
 # Constructors
 
+    LinearVerbosity()
     LinearVerbosity(preset::AbstractVerbosityPreset)
 
-Create a `LinearVerbosity` using a preset configuration:
+Create a `LinearVerbosity` using a preset configuration (`LinearVerbosity()` is the
+`Standard` preset):
 - `SciMLLogging.None()`: All messages disabled
 - `SciMLLogging.Minimal()`: Only critical errors and fatal issues
 - `SciMLLogging.Standard()`: Balanced verbosity (default)
 - `SciMLLogging.Detailed()`: Comprehensive debugging information
 - `SciMLLogging.All()`: Maximum verbosity
 
-    LinearVerbosity(; error_control=nothing, performance=nothing, numerical=nothing, kwargs...)
+    LinearVerbosity(; preset = nothing, error_control = nothing, performance = nothing,
+                    numerical = nothing, kwargs...)
 
-Create a `LinearVerbosity` with group-level or individual field control.
+Create a `LinearVerbosity` with group-level or individual field control. `preset` is the
+`SciMLLogging.AbstractVerbosityPreset` supplying the values of everything not set
+explicitly; `nothing` (default) means `Standard()`. `error_control`, `performance`, and
+`numerical` set every toggle of the corresponding group to one message level, and the
+remaining `kwargs` set individual toggles by name (`default_lu_fallback = ...`,
+`KrylovJL_verbosity = ...`, and so on). Precedence is individual toggle, then group,
+then preset. Toggle values are message levels such as `Silent()`, `InfoLevel()`,
+`WarnLevel()`, `ErrorLevel()`, or `MessageLevel(n)`; unknown toggle names throw an
+`ArgumentError`.
+
+# Usage
+
+The object is passed as the `verbose` keyword of `init`/`solve`, whose default is
+`LinearVerbosity()`. That keyword also accepts a bare preset (`verbose =
+SciMLLogging.None()`, wrapped as `LinearVerbosity(preset)`) or a `Bool` (`true` is
+`LinearVerbosity()`, `false` is `LinearVerbosity(SciMLLogging.None())`).
+
+The preset and message-level types live in SciMLLogging.jl and are not re-exported by
+LinearSolve, so `using SciMLLogging` is needed to name them as in the examples below
+(`LinearSolve.SciMLLogging.Standard()` also works without adding the dependency).
 
 # Examples
 
 ```julia
+using LinearSolve, SciMLLogging
+
 # Use a preset
 verbose = LinearVerbosity(SciMLLogging.Standard())
+sol = solve(prob; verbose)
+
+# Start from a preset and override one toggle
+verbose = LinearVerbosity(preset = SciMLLogging.None(), max_iters = SciMLLogging.WarnLevel())
 
 # Set entire groups
 verbose = LinearVerbosity(


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #378. #1225 already made the docs build strict (`checkdocs = :exports`, no `warnonly`); this PR does the docstring improvement the issue is titled for.

Every exported LinearSolve docstring was audited against its definition and extension implementation and each defect independently re-verified before editing: documented constructor signatures that do not exist (`QRFactorization`, `SVDFactorization`, `FastQRFactorization`, `NormalCholeskyFactorization`, `NormalBunchKaufmanFactorization`), `Pl`/`Pr` documented as constructor keywords on nine iterative wrappers that take `precs`, defaults and behaviors stated the opposite of the code (`LUFactorization` symbolic caching, `CholeskyFactorization` `tol`, `CHOLMODFactorization` `shift`/`perm`, `DirectLdiv!` cache default, `KrylovKitJL`'s stale Krylov.jl default, `MetalLUFactorization` allocation claim, `PureKLUFactorization` loading claim), live keywords missing from the docs (`residualsafety`, `throwerror`, `reuse_symbolic`, `check_pattern`, `cache_analysis`, `warm_start`, `use_initial_guess`, the `iparm`/`dparm` tuple format), and one-line docstrings on the `KrylovJL_*` and Ginkgo constructors that named neither the wrapped solver nor the accepted keywords. The two supernodal panel hook docstrings gain the operation and backend semantics at the generic-function definitions #1225 moved them to.

Docstring text only, no code changes; where a keyword is currently inert or a positional argument is discarded, the docstring states the present behavior. Also: the code sketch left as a triple-quoted string on the generated `DefaultLinearSolver` `solve!` becomes a comment, and the `LinearProblem`/`EigenvalueProblem` pages summarize constructors, keywords and targets with a link to the SciMLBase problem-interface page that exists (the two SciMLBase URLs previously linked, and ignored by linkcheck, are not pages).

Validated by the strict docs build with doctests and linkcheck from the branch, and Runic on every touched file.
