### PR TITLE
Fix the QA break from the shared adjoint route

### DIFF
--- a/ext/LinearSolveMooncakeExt.jl
+++ b/ext/LinearSolveMooncakeExt.jl
@@ -3,7 +3,7 @@ module LinearSolveMooncakeExt
 using Mooncake: Mooncake, @from_chainrules, MinimalCtx, ReverseMode, NoRData,
     @is_primitive, primal, zero_fcodual, CoDual, rdata, fdata
 using LinearSolve: LinearSolve, SciMLLinearSolveAlgorithm, init, solve!, LinearProblem,
-    LinearCache, AbstractKrylovSubspaceMethod, DefaultLinearSolver, LinearSolveAdjoint,
+    LinearCache, LinearSolveAdjoint,
     OperatorAssumptions, defaultalg, solve
 using SciMLBase: SciMLBase
 

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -139,7 +139,7 @@ linearsolve_internal_accesses = (
     :PrecompileTools, :SciMLLinearSolveAlgorithm, :SupernodalLU,
     :_SPARSE_LU_FALLBACK_ALGORITHMS, :_SPARSE_ONLY_ALGORITHMS,
     :__is_extension_loaded, :__nonstructural_zeros, :_adjoint_factorization_solve,
-    :_adjoint_krylov_solve, :_adjoint_precs, :_can_reuse_cache_factorization,
+    :_adjoint_krylov_solve, :_adjoint_precs, :_adjoint_solve, :_can_reuse_cache_factorization,
     :_check_residual_safety,
     :_custom_adjoint_factorization_solve, :_custom_cache_factorization,
     :_custom_can_reuse_adjoint_factorization, Symbol("_direct_lu_factorize!"),


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

QA is failing on main, from two things #1222 left behind. Both are mine.

- `_adjoint_solve` was never added to the qualified-access inventory in `test/qa/qa.jl`, the way `_adjoint_precs` was in #1212.
- Routing the Mooncake rule through `_adjoint_solve` removed the last bare-name uses of `AbstractKrylovSubspaceMethod` and `DefaultLinearSolver`, so those imports are now stale. The remaining use site in that file qualifies them, so the imports come out rather than the uses changing. ChainRulesCore still uses both bare and is untouched.

Worth landing ahead of the other open PRs, since a red QA on main shows up on all of them.

QA passes with this.
