### PR TITLE
Document the AMGCL wrapper

### DIFF
--- a/docs/src/basics/Preconditioners.md
+++ b/docs/src/basics/Preconditioners.md
@@ -134,6 +134,19 @@ The following preconditioners match the interface of LinearSolve.jl.
     
       + `AlgebraicMultigrid.ruge_stuben(A)`
       + `AlgebraicMultigrid.smoothed_aggregation(A)`
+  - [AMGCLWrap.jl](https://github.com/j-fu/AMGCLWrap.jl): algebraic multigrid and
+    relaxation (incomplete LU, SPAI, ...) preconditioners backed by the
+    [AMGCL](https://github.com/ddemidov/amgcl) C++ library (CPU, multithreaded via
+    OpenMP). Requires `A` as a `SparseMatrixCSC` or a `SparseMatrixCSR`.
+    `AMGPreconBuilder()` and `RLXPreconBuilder()` plug directly into the `precs`
+    interface, and `AMGPrecon(A)` / `RLXPrecon(A)` construct the preconditioners
+    directly. On a 2-D finite-difference Laplacian with ten thousand unknowns,
+    the AMG preconditioner takes `KrylovJL_CG` from 297 iterations to 10:
+
+    ```julia
+    using LinearSolve, AMGCLWrap
+    sol = solve(prob, KrylovJL_CG(precs = AMGPreconBuilder()))
+    ```
   - [PyAMG via LinearSolvePyAMG.jl](https://github.com/SciML/LinearSolve.jl/tree/main/lib/LinearSolvePyAMG):
     Implementations of the algebraic multigrid method backed by the Python
     [PyAMG](https://github.com/pyamg/pyamg) library via PythonCall.jl.

--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -521,6 +521,50 @@ CUSOLVERRFFactorization
 AlgebraicMultigridJL
 ```
 
+### AMGCLWrap.jl
+
+!!! note
+
+    Using these solvers requires adding the package AMGCLWrap.jl, i.e.
+    `using AMGCLWrap`
+
+[AMGCLWrap.jl](https://github.com/j-fu/AMGCLWrap.jl) wraps
+[AMGCL](https://github.com/ddemidov/amgcl), a header-only C++ algebraic multigrid
+library, through a pre-instantiated C API shipped as a binary package. It runs on
+the CPU (multithreaded via OpenMP) and requires `A` as a `SparseMatrixCSC` or a
+`SparseMatrixCSR`. Loading AMGCLWrap provides two LinearSolve algorithms:
+
+  - `AMGSolverAlgorithm(; blocksize = 1, param = nothing, coarsening, relax, solver)`:
+    an algebraic-multigrid-preconditioned Krylov solver (BiCGStab by default).
+  - `RLXSolverAlgorithm(; blocksize = 1, param = nothing, precond, solver)`: a
+    single-level relaxation-preconditioned Krylov solver (incomplete LU by default).
+
+Options are given either through typed keyword arguments (e.g.
+`coarsening = AMGCLWrap.RugeStubenCoarsening()`) or as a JSON-style named tuple
+via `param`; see the
+[AMGCLWrap solver documentation](https://j-fu.github.io/AMGCLWrap.jl/stable/solvers/)
+for the full parameter space.
+
+```julia
+using LinearSolve, AMGCLWrap, SparseArrays, LinearAlgebra
+
+n = 100  # 2-D finite-difference Laplacian, N = n^2 unknowns
+lap1d = spdiagm(-1 => -ones(n - 1), 0 => 2 * ones(n), 1 => -ones(n - 1))
+A = kron(I(n), lap1d) + kron(lap1d, I(n))
+b = rand(size(A, 1))
+prob = LinearProblem(A, b)
+
+sol = solve(prob, AMGSolverAlgorithm())
+
+sol = solve(prob,
+    RLXSolverAlgorithm(param = (solver = (type = "bicgstab", tol = 1.0e-10),
+        precond = (type = "ilu0",))))
+```
+
+AMGCLWrap also provides AMG and relaxation preconditioners for LinearSolve's own
+Krylov methods through the `precs` interface; see the
+[Preconditioners](@ref prec) page.
+
 ### ConjugateGradients.jl
 
 !!! note


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #108. The wrapper the issue asked for has existed since 2024: AMGCLWrap.jl carries a LinearSolve extension providing `AMGSolverAlgorithm` and `RLXSolverAlgorithm`, plus `AMGPreconBuilder`/`RLXPreconBuilder` for the `precs` interface, with LinearSolve v5 in its compat. What remained, per the issue thread, was the note in the LinearSolve docs with a usage example.

This adds an AMGCLWrap.jl section to the solver catalog (both algorithms, both parameter forms, a runnable example) and an entry in the preconditioner list (`precs` builders and direct constructors). Every code snippet was executed verbatim against this branch before committing; on the example's 2-D finite-difference Laplacian with ten thousand unknowns, the AMG preconditioner takes `KrylovJL_CG` from 297 iterations to 10.

Docs only, so no tests are added on the LinearSolve side; the algorithms themselves are tested in AMGCLWrap.jl's suite against LinearSolve.

AI Disclosure: Used Opus 5