### PR TITLE
Fix default algorithm QA regressions

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -21,7 +21,7 @@ using LinearAlgebra: LinearAlgebra, BlasInt, LU, Adjoint, BLAS, Bidiagonal, Bunc
 using SciMLBase: SciMLBase, LinearAliasSpecifier,
     init, solve!, reinit!, solve, ReturnCode, LinearProblem
 using SciMLOperators: SciMLOperators, AbstractSciMLOperator, IdentityOperator,
-    MatrixOperator, WOperator, jacobian_stale, mark_jacobian_updated!,
+    MatrixOperator, WOperator, jacobian_stale,
     mark_jacobian_current!,
     has_ldiv!, issquare
 using SciMLStructures: SciMLStructures

--- a/src/default.jl
+++ b/src/default.jl
@@ -252,6 +252,12 @@ function defaultalg(A::WOperator, b, assump::OperatorAssumptions{Bool})
     return @invoke defaultalg(A::SciMLOperators.AbstractSciMLOperator, b, assump)
 end
 
+function defaultalg(
+        A::WOperator, b::GPUArraysCore.AnyGPUArray, assump::OperatorAssumptions{Bool}
+    )
+    return @invoke defaultalg(A::WOperator, b::Any, assump::OperatorAssumptions{Bool})
+end
+
 _lhl_scalar_massmatrix(::UniformScaling) = true
 _lhl_scalar_massmatrix(::Number) = true
 _lhl_scalar_massmatrix(::Any) = false

--- a/test/Core/forwarddiff_gpu.jl
+++ b/test/Core/forwarddiff_gpu.jl
@@ -2,6 +2,7 @@ using LinearSolve
 using ForwardDiff
 using JLArrays
 using LinearAlgebra
+using SciMLOperators: WOperator
 using Test
 
 # JLArray is a CPU-backed AbstractGPUArray, so it exercises the GPU contract
@@ -19,6 +20,12 @@ using Test
 # that genuinely honors the GPU contract here, which is what this file proves.
 
 const N_PARTIALS = 3
+
+@testset "WOperator with a GPU right-hand side" begin
+    W = WOperator{true}(I, 0.1, Matrix{Float64}(I, 2, 2), zeros(2))
+    alg = LinearSolve.defaultalg(W, JLArray(ones(2)), LinearSolve.OperatorAssumptions(true))
+    @test alg.alg === LinearSolve.DefaultAlgorithmChoice.KrylovJL_GMRES
+end
 
 function dual_problem(n, p)
     A = [

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -140,7 +140,7 @@ linearsolve_internal_accesses = (
     :_SPARSE_LU_FALLBACK_ALGORITHMS, :_SPARSE_ONLY_ALGORITHMS,
     :__is_extension_loaded, :__nonstructural_zeros, :_adjoint_factorization_solve,
     :_adjoint_krylov_solve, :_adjoint_precs, :_adjoint_solve, :_can_reuse_cache_factorization,
-    :_check_residual_safety,
+    :_check_matrix_support, :_check_residual_safety,
     :_custom_adjoint_factorization_solve, :_custom_cache_factorization,
     :_custom_can_reuse_adjoint_factorization, Symbol("_direct_lu_factorize!"),
     Symbol("_direct_lu_solve!"), Symbol("_fast_sym_givens!"), :_init_cacheval,
@@ -182,7 +182,7 @@ external_internal_accesses = (
     :rocBLAS, :rocSOLVER, Symbol("trsv!"), Symbol("geqrf!"), Symbol("getrs!"),
     Symbol("ormqr!"),
     # CUDSS / cuSOLVER
-    :cuSPARSE, :CUDACore,
+    :cuSPARSE, :CUDACore, Symbol("csrlsvqr!"),
     # EnzymeCore (+ .EnzymeRules)
     :EnzymeRules, :augmented_primal, :forward, :inactive_type, :reverse,
     # ForwardDiff


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The QA group on `main` was red from a `WOperator`/GPU right-hand-side dispatch ambiguity, an unused `mark_jacobian_updated!` import, and two newly introduced extension-internal qualified accesses. This adds the missing intersection method, removes the stale import, and records the extension-only `_check_matrix_support` and `csrlsvqr!` accesses in the existing strict ExplicitImports inventories.

The regression test uses `JLArray`, a CPU-backed GPU array, to cover the ambiguous dispatch without requiring GPU hardware.

## Verification

### Failing before

At [`6166a400bd393af4653ea752033a6ab792517408`](https://github.com/SciML/LinearSolve.jl/commit/6166a400bd393af4653ea752033a6ab792517408), the new regression case failed:

```julia
julia +release --project=.tmp-gpu-rhs-before -e 'using LinearSolve, JLArrays, LinearAlgebra; using SciMLOperators: WOperator; W = WOperator{true}(I, 0.1, Matrix{Float64}(I, 2, 2), zeros(2)); alg = LinearSolve.defaultalg(W, JLArray(ones(2)), LinearSolve.OperatorAssumptions(true)); @assert alg.alg === LinearSolve.DefaultAlgorithmChoice.KrylovJL_GMRES'
```

```text
ERROR: MethodError: defaultalg(::WOperator{...}, ::JLArray{Float64, 1}, ::OperatorAssumptions{Bool}) is ambiguous.

Candidates:
  defaultalg(A::WOperator, b, assump::OperatorAssumptions{Bool})
  defaultalg(A::SciMLOperators.AbstractSciMLOperator, b::GPUArraysCore.AnyGPUArray, assump::OperatorAssumptions{Bool})
```

The clean base QA run also reproduced all three defects:

```sh
GROUP=QA julia +release --project -e 'using Pkg; Pkg.test()'
```

```text
Quality Assurance | 46 pass, 1 fail, 2 errors, 49 total
```

The first bad commits were bisected to:

- [`47cdfb2eb81757346bb06cd8a3053a9736d15291`](https://github.com/SciML/LinearSolve.jl/commit/47cdfb2eb81757346bb06cd8a3053a9736d15291): ambiguity and stale import
- [`012c5e9e21a60111c9364e49356de8f603b2376e`](https://github.com/SciML/LinearSolve.jl/commit/012c5e9e21a60111c9364e49356de8f603b2376e): `csrlsvqr!` qualified access
- [`3d64d7f3accf2416c1f930478029ae9cc20086b3`](https://github.com/SciML/LinearSolve.jl/commit/3d64d7f3accf2416c1f930478029ae9cc20086b3): `_check_matrix_support` qualified access

### Passing after

The same regression case now reports:

```text
PASS: WOperator + GPU RHS selected KrylovJL_GMRES
```

```sh
GROUP=Core julia +release --project -e 'using Pkg; Pkg.test()'
```

```text
ForwardDiff GPU Arrays | 16 pass, 16 total, 1m13.2s
Testing LinearSolve tests passed
```

```sh
GROUP=QA julia +release --project -e 'using Pkg; Pkg.test()'
```

```text
Quality Assurance | 49 pass, 49 total, 3m32.5s
Testing LinearSolve tests passed
```

```sh
julia +release -m Runic --check src/LinearSolve.jl src/default.jl test/Core/forwarddiff_gpu.jl test/qa/qa.jl
git diff | typos -
```

Both exited successfully with no output.

## Not verified

- No physical GPU was available; the dispatch regression is covered with `JLArray`.
- Julia LTS and prerelease channels were not run locally.
- The docs build was not run because this changes no docstring, rendered documentation, or public API declaration.

## Review focus

The two ExplicitImports entries are narrow name-based inventories, not disabled checks. `_check_matrix_support` is LinearSolve's extension hook, while `csrlsvqr!` is the cuSOLVER entry point used by its own tests but is neither exported nor declared public upstream.
