### PR TITLE
Keep a GPU WOperator off the host-only LHL reduction

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -252,10 +252,18 @@ function defaultalg(A::WOperator, b, assump::OperatorAssumptions{Bool})
     return @invoke defaultalg(A::SciMLOperators.AbstractSciMLOperator, b, assump)
 end
 
+# Routed to the operator default rather than to the `WOperator` method above, because
+# that one can answer `LHLFactorization`. The reduction behind it lives in
+# LHLFactorization.jl and runs on the host, while a GPU array still satisfies
+# `DenseMatrix` (`CuArray <: DenseArray`), so `_lhl_defaultable` would accept a device
+# Jacobian and the solve would then die on scalar indexing.
 function defaultalg(
         A::WOperator, b::GPUArraysCore.AnyGPUArray, assump::OperatorAssumptions{Bool}
     )
-    return @invoke defaultalg(A::WOperator, b::Any, assump::OperatorAssumptions{Bool})
+    return @invoke defaultalg(
+        A::SciMLOperators.AbstractSciMLOperator, b::GPUArraysCore.AnyGPUArray,
+        assump::OperatorAssumptions{Bool}
+    )
 end
 
 _lhl_scalar_massmatrix(::UniformScaling) = true

--- a/test/GPU/cuda.jl
+++ b/test/GPU/cuda.jl
@@ -179,3 +179,29 @@ if Base.find_package("CUSOLVERRF") !== nothing
         include("cusolverrf.jl")
     end
 end
+
+# A `WOperator` with a device Jacobian used to default to `LHLFactorization`, whose
+# reduction runs on the host: `CuArray <: DenseArray`, so `A.J isa DenseMatrix` holds on
+# the GPU and `_lhl_defaultable` accepted it. The solve then died on scalar indexing.
+@testset "WOperator on the GPU does not default to LHLFactorization" begin
+    n = 64
+    γ = 0.1
+    J = CUDACore.adapt(CuArray, rand(n, n) + n * I)
+    b_gpu = CUDACore.adapt(CuArray, rand(n))
+    W = LinearSolve.WOperator{true}(I, γ, J, similar(b_gpu))
+
+    @test LinearSolve.defaultalg(W, b_gpu, OperatorAssumptions(true)).alg !==
+        LinearSolve.DefaultAlgorithmChoice.LHLFactorization
+
+    sol = solve(LinearProblem(W, b_gpu))
+    @test SciMLBase.successful_retcode(sol)
+    ref = Array(J - I / γ) \ Array(b_gpu)
+    @test Array(sol.u) ≈ ref rtol = 1.0e-6
+
+    # A host `WOperator` of the same shape still takes the LHL path.
+    Jc = rand(n, n) + n * I
+    bc = rand(n)
+    Wc = LinearSolve.WOperator{true}(I, γ, Jc, similar(bc))
+    @test LinearSolve.defaultalg(Wc, bc, OperatorAssumptions(true)).alg ===
+        LinearSolve.DefaultAlgorithmChoice.LHLFactorization
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Follows #1240, which resolved the `defaultalg` ambiguity between `WOperator` and a GPU right hand side by forwarding to the `WOperator` method. That method can answer `LHLFactorization`, whose reduction lives in LHLFactorization.jl and runs on the host.

- A GPU array still satisfies `DenseMatrix`, since `CuArray <: DenseArray`, so `_lhl_defaultable` accepts a device Jacobian at any `n` from `LHL_DEFAULT_MIN_SIZE` up. The default picked a host factorization for a device operator and the solve failed.
- This forwards to the operator default instead. A host `WOperator` is untouched and still reaches `LHLFactorization`.

Measured on a T4, on `main`:

```
GPU  WOperator default = LHLFactorization
J isa DenseMatrix on GPU: true
SOLVE: FAILED  Scalar indexing is disallowed.
```

and with this change:

```
GPU  WOperator default = KrylovJL_GMRES
host WOperator default = LHLFactorization
SOLVE: ok  retcode=Success  relerr=1.26e-9
```

The test in `test/GPU/cuda.jl` covers the algorithm choice, that the solve now succeeds and agrees with the dense answer, and that a host `WOperator` still takes the LHL path.

This PR originally carried the three QA fixes on `main`. #1240 landed the same three while it was open, so those are dropped and only the GPU routing remains.
