### PR TITLE
Document BLISLUFactorization and export it like its peers

### DIFF
--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -19,7 +19,8 @@ For efficiency, `RFLUFactorization` is the fastest for dense LU-factorizations u
 point, `MKLLUFactorization` is usually faster on most hardware. Note that on Mac computers
 that `AppleAccelerateLUFactorization` is generally always the fastest. `OpenBLASLUFactorization` 
 provides direct OpenBLAS calls without going through libblastrampoline and can be faster than 
-`LUFactorization` in some configurations. `LUFactorization` will use your base system BLAS which 
+`LUFactorization` in some configurations, and `BLISLUFactorization` does the same for
+[BLIS](https://github.com/flame/blis), the library AMD's AOCL-BLAS is derived from. `LUFactorization` will use your base system BLAS which 
 can be fast or slow depending on the hardware configuration. `SimpleLUFactorization` will be fast 
 only on very small matrices but can cut down on compile times.
 
@@ -433,6 +434,17 @@ MKL32MixedLUFactorization
 ```@docs
 OpenBLASLUFactorization
 OpenBLAS32MixedLUFactorization
+```
+
+### BLIS
+
+!!! note
+
+    Using this solver requires both JLLs that back the extension, i.e.
+    `using blis_jll, LAPACK_jll`
+
+```@docs
+BLISLUFactorization
 ```
 
 ### AppleAccelerate.jl

--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -818,6 +818,7 @@ export MUMPSFactorization
 export SuperLUDISTFactorization
 export MKLLUFactorization
 export OpenBLASLUFactorization
+export BLISLUFactorization
 export OpenBLAS32MixedLUFactorization
 export MKL32MixedLUFactorization
 export AppleAccelerateLUFactorization

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -1483,26 +1483,43 @@ struct MetalOffload32MixedLUFactorization <: AbstractFactorization
 end
 
 """
-    BLISLUFactorization()
+    BLISLUFactorization(; throwerror = true, residualsafety = false)
 
-An LU factorization implementation using the BLIS (BLAS-like Library Instantiation Software)
-framework. BLIS provides high-performance dense linear algebra kernels optimized for various
-CPU architectures.
+An LU factorization for dense matrices that calls [BLIS](https://github.com/flame/blis)
+directly for its BLAS kernels, with the factorization and back-solve themselves coming
+from LAPACK's `getrf`/`getrs`. Like `OpenBLASLUFactorization`, it bypasses
+libblastrampoline and calls a fixed library, so the solve does not depend on which BLAS
+the running session happens to have forwarded.
 
-## Requirements
-Using this solver requires that blis_jll is available and the BLIS extension is loaded.
-The solver will be automatically available when conditions are met.
+Supports `Float32`, `Float64`, `ComplexF32` and `ComplexF64` dense matrices, and reuses
+the factorization across repeated `solve!` calls on the same cache.
 
-## Performance Notes
-- Optimized for modern CPU architectures with BLIS-specific optimizations
-- May provide better performance than standard BLAS on certain processors
-- Best suited for dense matrices with Float32, Float64, ComplexF32, or ComplexF64 elements
+!!! note
+
+    Using this solver requires both JLLs that back the extension to be loaded:
+    `using blis_jll, LAPACK_jll`.
+
+## Keyword Arguments
+
+  - `throwerror`: whether the constructor errors when the BLIS extension is not loaded.
+    Defaults to `true`; pass `false` to construct the algorithm anyway, which is what the
+    default algorithm machinery does when it probes for availability.
+  - `residualsafety`: whether to compute the a posteriori residual after the solve and
+    return `ReturnCode.APosterioriSafetyFailure` when it exceeds the tolerances. Defaults
+    to `false`.
 
 ## Example
+
 ```julia
-alg = BLISLUFactorization()
-sol = solve(prob, alg)
+using LinearSolve, blis_jll, LAPACK_jll
+
+A = rand(100, 100) + 100I
+b = rand(100)
+sol = solve(LinearProblem(A, b), BLISLUFactorization())
 ```
+
+`LinearSolveAutotune` can also select BLIS for the default algorithm on hardware where it
+benchmarks fastest, in which case `solve(prob)` uses it without naming it explicitly.
 """
 struct BLISLUFactorization <: AbstractFactorization
     residualsafety::Bool


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

`BLISLUFactorization` is fully implemented but invisible: 387 lines in `ext/LinearSolveBLISExt.jl`, a `DefaultAlgorithmChoice` entry, `useblis` dispatch in `src/default.jl`, an autotune preference in `src/preferences.jl`, inclusion in the `LinearSolveAutotune` benchmark set, and coverage in nine test files. Yet `grep -ri blis docs/src/` matched only `docs/src/assets/Manifest.toml`, so it appears nowhere in the manual.

- It was also the only vendor BLAS LU not exported. `MKLLUFactorization`, `OpenBLASLUFactorization`, `AppleAccelerateLUFactorization`, `MetalLUFactorization`, `RFLUFactorization` and `ButterflyFactorization` all are, so this exports it too. That makes its own docstring example correct: `BLISLUFactorization()` as written did not resolve, since the name needed a `LinearSolve.` prefix.
- The docstring documented no keywords, though the constructor is `BLISLUFactorization(; throwerror = true, residualsafety = false)` and both are live. This is the same defect class as #1232, which missed it precisely because that audit covered exported names. Both are now documented.
- It also claimed the solver "will be automatically available when conditions are met", which understates the requirement: the extension triggers on `blis_jll` **and** `LAPACK_jll`, so `using blis_jll` alone is not enough. Verified: with only LinearSolve loaded the extension is absent, and it loads once both JLLs are.
- Corrected what it actually does. It is not a BLIS reimplementation of LU: the factorization and back-solve are LAPACK `getrf`/`getrs`, with BLIS supplying the BLAS kernels, which is why the extension needs `LAPACK_jll` at all.
- Documented in `docs/src/solvers/solvers.md` next to MKL and OpenBLAS, and mentioned in the dense recommendation prose where users actually pick an LU, since a `@docs` entry alone is easy to miss.

Verified rather than assumed: the documented example runs verbatim (residual 1.7e-16), and `Float32`, `Float64`, `ComplexF32`, `ComplexF64` plus cache reuse across a new right hand side all solve correctly on this machine with blis_jll available. Strict docs build passes with the new export under `checkdocs = :exports`. Runic clean.

No tests added: this documents and exports existing behaviour, and the nine files listed above already cover the solver itself.

AI Disclosure: Used Opus 5
