### PR TITLE
Guard the BLIS JET test on the extension, not on the name being defined

### DIFF
--- a/test/qa/jet.jl
+++ b/test/qa/jet.jl
@@ -1,6 +1,12 @@
 using LinearSolve, ForwardDiff, ForwardDiff, RecursiveFactorization, LinearAlgebra, SparseArrays, Test
 using JET
 
+# Loaded for the extension module, matching test/qa/allocations.jl: without both
+# JLLs the BLIS extension never loads and BLISLUFactorization() throws.
+if Sys.islinux()
+    import LAPACK_jll, blis_jll
+end
+
 # Dense problem setup
 A = rand(4, 4)
 b = rand(4)
@@ -121,7 +127,9 @@ end
     if Sys.isapple() && @isdefined(MetalLUFactorization)
         JET.@test_opt solve(prob, MetalLUFactorization()) broken = true
     end
-    if @isdefined(BLISLUFactorization)
+    # BLISLUFactorization is exported unconditionally, so @isdefined does not
+    # tell us whether it can be constructed; the extension has to be loaded.
+    if Base.get_extension(LinearSolve, :LinearSolveBLISExt) !== nothing
         JET.@test_opt solve(prob, BLISLUFactorization()) broken = true
     end
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes the QA break I introduced in #1243. QA is red on `main` right now; it passed on `d74dcc0e` and failed on `f19ef2f5`, which is that merge.

- #1243 exported `BLISLUFactorization`. `test/qa/jet.jl:124` guarded its testset with `@isdefined(BLISLUFactorization)`, which was `false` while the name was unexported, so that branch had never run. Exporting made it unconditionally `true`, the branch woke up, and `BLISLUFactorization()` threw `BLISLUFactorization requires that the BLIS extension is loaded and blis_jll is available`.
- Root cause is that `jet.jl` never loads the JLLs. `test/qa/qa.jl:13` and `test/qa/allocations.jl:4` both load `LAPACK_jll` and `blis_jll`; `jet.jl` does not, so the extension is absent and the constructor errors. The `broken = true` marker does not help, since the exception is raised while evaluating the expression rather than by the JET check.
- `@isdefined` cannot be the guard for any exported extension algorithm, because it is true whether or not the extension is loaded. This switches to `Base.get_extension(LinearSolve, :LinearSolveBLISExt) !== nothing`, which is the condition that actually matters and is already the idiom at `jet.jl:201` for the ForwardDiff extension.
- The JLL import is Linux-guarded exactly as `test/qa/allocations.jl:3-5` does it.
- This makes the test live rather than restoring it to dead: with the extension loaded the JET check runs and reports Broken as annotated, so it now covers BLIS for real.

Verified locally in `test/qa`: reproduced the failure first (extension absent, constructor throws), then with the fix the BLIS testset reports 1 Broken, 0 Fail, 0 Error, and the whole of `jet.jl` passes.

`MKLLUFactorization` and `AppleAccelerateLUFactorization` use the same `@isdefined` guard but are unaffected: their constructors do not error when the backing library is missing, which is why QA was green with those branches live all along.

AI Disclosure: Used Opus 5
