### PR TITLE
Fix BLIS JET test gate after algorithm export

### DIFF
--- a/test/qa/jet.jl
+++ b/test/qa/jet.jl
@@ -121,7 +121,9 @@ end
     if Sys.isapple() && @isdefined(MetalLUFactorization)
         JET.@test_opt solve(prob, MetalLUFactorization()) broken = true
     end
-    if @isdefined(BLISLUFactorization)
+    blis_ext = Base.get_extension(LinearSolve, :LinearSolveBLISExt)
+    @test isnothing(blis_ext)
+    if !isnothing(blis_ext)
         JET.@test_opt solve(prob, BLISLUFactorization()) broken = true
     end
 end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`BLISLUFactorization` became exported in https://github.com/SciML/LinearSolve.jl/commit/f19ef2f575db2b327af5b828af232ebd2e8940a6. That made the QA test's `@isdefined(BLISLUFactorization)` gate true before `LinearSolveBLISExt` was loaded, so constructing the algorithm threw instead of skipping the extension-specific JET check.

Gate that check on `Base.get_extension(LinearSolve, :LinearSolveBLISExt)` and assert the intended QA setup leaves the extension unloaded.

## Failing before

On clean `upstream/main` at `f19ef2f575db2b327af5b828af232ebd2e8940a6`:

```console
$ GROUP=QA julia +release --project -e 'using Pkg; Pkg.test()'
JET Tests for Extension Factorizations: Error During Test at test/qa/jet.jl:125
  Expression: JET.@test_opt solve(prob, BLISLUFactorization())
  BLISLUFactorization requires that the BLIS extension is loaded and blis_jll is available
Test Summary: | Pass  Error  Broken  Total
JET Tests     |   34      1       8     43
ERROR: LoadError: Some tests did not pass: 34 passed, 0 failed, 1 errored, 8 broken.
```

An executable boundary check also showed:

```console
# f19ef2f575db2b327af5b828af232ebd2e8940a6
defined=true extension=nothing
ERROR: BLISLUFactorization requires that the BLIS extension is loaded and blis_jll is available

# parent d74dcc0e
defined=false extension=nothing
```

This identifies https://github.com/SciML/LinearSolve.jl/commit/f19ef2f575db2b327af5b828af232ebd2e8940a6 as the first bad commit.

## Passing after

```console
$ GROUP=QA julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Broken  Total
JET Tests     |   35       8     43
Test Summary: | Pass  Total
Allocation QA |   64     64
Test Summary:              | Pass  Total
SupernodalLU Allocation QA |    8      8
Test Summary:     | Pass  Total
Quality Assurance |   49     49
Testing LinearSolve tests passed

$ GROUP=Core julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary:          | Pass  Total
ForwardDiff GPU Arrays |   16     16
Test Summary:       | Pass  Total
Algorithm Interface |  141    141
Test Summary:   | Pass  Broken  Total
Mixed Precision |   16       2     18
Test Summary:              | Pass  Total
SpecializingFactorizations |   18     18
Testing LinearSolve tests passed

$ julia +release -m Runic --check test/qa/jet.jl
# exit 0

$ git diff -- test/qa/jet.jl | typos -
# exit 0

$ git diff --check
# exit 0
```

## Not verified

No hardware-specific GPU group or downstream group was run. Documentation was not built because this changes only an internal QA test and no public API or documentation.
