### PR TITLE
Solve a non-square GPU system instead of throwing

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -1054,7 +1054,13 @@ function do_factorization(alg::QRFactorization, A, b, u)
         # `alg.pivot` so the return type is determined by the static
         # `QRFactorization{P}` parameter (otherwise this branch returns
         # `Union{QRCompactWY, QRPivoted}` depending on `alg.inplace`).
-        if A isa GPUArraysCore.AnyGPUArray || is_cusparse(A) || issparsematrixcsc(A)
+        if A isa GPUArraysCore.AnyGPUArray && !is_cusparse(A) && is_underdetermined(A)
+            # A GPU `qr` factors a wide matrix happily, but solving with the result
+            # builds `UpperTriangular(R)` on an `R` that is not square and throws.
+            # Going through `Aᵀ` turns it back into a triangular solve and gives the
+            # minimum-norm solution, which is what dense `\` returns on the CPU.
+            fact = MinNormQR(qr(copy(transpose(A))))
+        elseif A isa GPUArraysCore.AnyGPUArray || is_cusparse(A) || issparsematrixcsc(A)
             fact = qr(A)
         elseif alg.inplace
             if A isa Symmetric
@@ -1076,7 +1082,13 @@ function init_cacheval(
         maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
         assumptions::OperatorAssumptions
     )
-    return ArrayInterface.qr_instance(convert(AbstractMatrix, A), alg.pivot)
+    A_ = convert(AbstractMatrix, A)
+    # Matches the wide GPU branch of `do_factorization`: the slot has to be typed for
+    # what will be stored in it, not for a plain `QR`.
+    if A_ isa GPUArraysCore.AnyGPUArray && !is_cusparse(A_) && is_underdetermined(A_)
+        return MinNormQR(qr(copy(transpose(A_))))
+    end
+    return ArrayInterface.qr_instance(A_, alg.pivot)
 end
 
 function init_cacheval(
@@ -1192,6 +1204,12 @@ function init_cacheval(
         alg::CholeskyFactorization, A::GPUArraysCore.AnyGPUArray, b, u, Pl,
         Pr, maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
     )
+    # `cholesky` needs a square matrix. The default solver initializes every slot it
+    # holds, this one included, before it knows which it will use, so a non-square `A`
+    # would fail here rather than reaching the least-squares algorithm that will actually
+    # serve it. Leave the slot empty instead.
+    # See https://github.com/SciML/NonlinearSolve.jl/issues/746
+    assumptions.issq || return nothing
     return cholesky(A; check = false)
 end
 

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -1204,12 +1204,12 @@ function init_cacheval(
         alg::CholeskyFactorization, A::GPUArraysCore.AnyGPUArray, b, u, Pl,
         Pr, maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool}, assumptions::OperatorAssumptions
     )
-    # `cholesky` needs a square matrix. The default solver initializes every slot it
-    # holds, this one included, before it knows which it will use, so a non-square `A`
-    # would fail here rather than reaching the least-squares algorithm that will actually
-    # serve it. Leave the slot empty instead.
+    # `cholesky` needs a square matrix, and the default solver initializes this slot for
+    # every `A` before it knows which algorithm it will use. Instance an empty
+    # factorization for a non-square `A`, rather than returning `nothing`, so the return
+    # type does not depend on the runtime value of `assumptions.issq`.
     # See https://github.com/SciML/NonlinearSolve.jl/issues/746
-    assumptions.issq || return nothing
+    assumptions.issq || return cholesky(similar(A, 0, 0); check = false)
     return cholesky(A; check = false)
 end
 

--- a/src/sparsearrays.jl
+++ b/src/sparsearrays.jl
@@ -1133,6 +1133,13 @@ function LinearSolve.init_cacheval(
         nothing
     elseif LinearSolve.is_cusparse_csr(A) && !LinearSolve.cudss_loaded(A)
         nothing
+    elseif A isa LinearSolve.GPUArraysCore.AnyGPUArray && !assumptions.issq
+        # A non-square GPU `A` cannot be instanced here: `cholesky_instance` needs a
+        # square matrix, and the default solver reaches this slot for every `A` before
+        # it knows which algorithm it will use. Sparse CPU input is deliberately not
+        # covered by this branch, since `cholesky_instance` handles a non-square sparse
+        # `A` and `solve!` stores a real factorization into the slot afterwards.
+        nothing
     else
         ArrayInterface.cholesky_instance(convert(AbstractMatrix, A))
     end

--- a/src/sparsearrays.jl
+++ b/src/sparsearrays.jl
@@ -1134,12 +1134,12 @@ function LinearSolve.init_cacheval(
     elseif LinearSolve.is_cusparse_csr(A) && !LinearSolve.cudss_loaded(A)
         nothing
     elseif A isa LinearSolve.GPUArraysCore.AnyGPUArray && !assumptions.issq
-        # A non-square GPU `A` cannot be instanced here: `cholesky_instance` needs a
-        # square matrix, and the default solver reaches this slot for every `A` before
-        # it knows which algorithm it will use. Sparse CPU input is deliberately not
-        # covered by this branch, since `cholesky_instance` handles a non-square sparse
-        # `A` and `solve!` stores a real factorization into the slot afterwards.
-        nothing
+        # `cholesky_instance` needs a square matrix, and the default solver reaches this
+        # slot for every `A` before it knows which algorithm it will use. A 0x0 is square,
+        # so instance that instead of returning `nothing`. Sparse CPU input is left alone:
+        # `cholesky_instance` handles a non-square sparse `A` and `solve!` stores a real
+        # factorization into the slot afterwards.
+        ArrayInterface.cholesky_instance(convert(AbstractMatrix, similar(A, 0, 0)))
     else
         ArrayInterface.cholesky_instance(convert(AbstractMatrix, A))
     end

--- a/test/GPU/cuda.jl
+++ b/test/GPU/cuda.jl
@@ -245,7 +245,7 @@ end
 
         @test LinearSolve.defaultalg(A, b, OperatorAssumptions(false)).alg ===
             LinearSolve.DefaultAlgorithmChoice.QRFactorization
-        @test solve(LinearProblem(A, b), QRFactorization()).u ≈ ref rtol = 1.0e-4
+        @test Array(solve(LinearProblem(A, b), QRFactorization()).u) ≈ ref rtol = 1.0e-4
     end
 
     # The wide solve has to be the minimum-norm one, which is what dense `\` gives on

--- a/test/GPU/cuda.jl
+++ b/test/GPU/cuda.jl
@@ -219,3 +219,39 @@ end
     @test LinearSolve.defaultalg(Wc, bc, OperatorAssumptions(true)).alg ===
         LinearSolve.DefaultAlgorithmChoice.LHLFactorization
 end
+
+# Two separate failures kept a non-square GPU `A` from solving at all.
+#
+# `_init_default_cacheval` builds a cacheval for every algorithm slot before it knows
+# which one it will use, and two of those slots called `cholesky` on `A` itself, so
+# `init` threw `DimensionMismatch` before any algorithm ran. Then for a wide `A`, the
+# QR solve itself threw: a GPU `qr` factors a wide matrix, but solving with the result
+# builds `UpperTriangular(R)` on a non-square `R`.
+# See https://github.com/SciML/NonlinearSolve.jl/issues/746 and #857.
+@testset "Non-square GPU matrices" begin
+    tall = CUDACore.adapt(CuArray, Float32[1 2; 3 4; 5 6; 7 8])
+    btall = CUDACore.adapt(CuArray, Float32[1, 2, 3, 4])
+    wide = CUDACore.adapt(CuArray, Float32[1 2 3 4; 5 6 7 8])
+    bwide = CUDACore.adapt(CuArray, Float32[1, 2])
+
+    @testset "$name" for (name, A, b) in (("tall", tall, btall), ("wide", wide, bwide))
+        ref = Array(A) \ Array(b)
+
+        # `init` is where every slot gets built, and where this used to throw.
+        cache = init(LinearProblem(A, b))
+        sol = solve!(cache)
+        @test SciMLBase.successful_retcode(sol)
+        @test Array(sol.u) ≈ ref rtol = 1.0e-4
+
+        @test LinearSolve.defaultalg(A, b, OperatorAssumptions(false)).alg ===
+            LinearSolve.DefaultAlgorithmChoice.QRFactorization
+        @test solve(LinearProblem(A, b), QRFactorization()).u ≈ ref rtol = 1.0e-4
+    end
+
+    # The wide solve has to be the minimum-norm one, which is what dense `\` gives on
+    # the CPU. Agreeing on the residual alone would not distinguish it from any other
+    # point on the solution manifold.
+    xwide = Array(solve(LinearProblem(wide, bwide)).u)
+    @test norm(xwide) ≈ norm(Array(wide) \ Array(bwide)) rtol = 1.0e-4
+    @test Array(wide) * xwide ≈ Array(bwide) rtol = 1.0e-4
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Revives #857, which is on another fork and conflicts. Solving a non-square GPU system threw `DimensionMismatch`, in two places:

- The default solver initializes every algorithm slot up front, and the `CholeskyFactorization` and `NormalCholeskyFactorization` slots both call `cholesky` on `A` itself. Both now skip a non-square `A`.
- A wide `A` then failed in the QR solve, since a GPU `qr` factors it but `ldiv!` builds `UpperTriangular` on a non-square `R`. Wide GPU input now goes through the existing `MinNormQR`, as the banded extensions already do, which also gives the minimum-norm solution.

Checked on a T4: tall, wide and square all solve, and the wide case matches LAPACK's `‖x‖`. #857's guard alone is no longer enough, since the `NormalCholeskyFactorization` slot moved to `sparsearrays.jl` and fails first.

AI Disclosure: Used Opus 5
