### PR TITLE
Stop cg_lanczos! resolving to the shifted workspace

### DIFF
--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -373,8 +373,6 @@ function get_KrylovJL_solver(KrylovAlg)
         Krylov.CrmrWorkspace
     elseif (KrylovAlg === Krylov.cg!)
         Krylov.CgWorkspace
-    elseif (KrylovAlg === Krylov.cg_lanczos!)
-        Krylov.CgLanczosShiftWorkspace
     elseif (KrylovAlg === Krylov.cgls!)
         Krylov.CglsWorkspace
     elseif (KrylovAlg === Krylov.cg_lanczos!)

--- a/test/Core/nonsquare.jl
+++ b/test/Core/nonsquare.jl
@@ -345,3 +345,33 @@ end
         end
     end
 end
+
+# `get_KrylovJL_solver` matched `cg_lanczos!` twice. The first branch handed back the
+# *shifted* workspace, so the documented `KrylovAlg = Krylov.cg_lanczos!` threw a
+# `MethodError` out of the workspace constructor, and the second branch, the correct
+# one, was unreachable. See SciML/LinearSolve.jl#554.
+@testset "documented KrylovAlg values map to their own workspace" begin
+    for (f, W) in (
+            (Krylov.cg!, Krylov.CgWorkspace),
+            (Krylov.cg_lanczos!, Krylov.CgLanczosWorkspace),
+            (Krylov.cgls!, Krylov.CglsWorkspace),
+            (Krylov.minres!, Krylov.MinresWorkspace),
+            (Krylov.gmres!, Krylov.GmresWorkspace),
+        )
+        @test LinearSolve.get_KrylovJL_solver(f) === W
+    end
+
+    # The shifted variants need a `shifts` argument that this wrapper never passes, and
+    # the docstring does not list them, so they stay unmapped rather than advertised.
+    @test_throws ErrorException LinearSolve.get_KrylovJL_solver(Krylov.cg_lanczos_shift!)
+
+    # `cg_lanczos!` wants a symmetric positive definite system.
+    Random.seed!(554)
+    nl = 24
+    Xl = rand(nl, nl)
+    Al = Xl' * Xl + nl * I
+    bl = rand(nl)
+    sol = solve(LinearProblem(Al, bl), KrylovJL(KrylovAlg = Krylov.cg_lanczos!))
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u ≈ Al \ bl rtol = 1.0e-6
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

`get_KrylovJL_solver` matched `cg_lanczos!` twice. The first branch returned the shifted workspace and won, so the correct branch below it was dead code. Since `cg_lanczos!` is listed in the `KrylovJL` docstring, `KrylovJL(KrylovAlg = Krylov.cg_lanczos!)` threw a `MethodError` from the workspace constructor. Dropping the stray branch fixes it.

The shifted variants stay unmapped on purpose: they take a `shifts` argument this wrapper never passes, and they are not in the documented list.

Spotted in #554, which is otherwise superseded now that block GMRES and MINRES are reached by passing a matrix `b` to `KrylovJL_GMRES`/`KrylovJL_MINRES`.

AI Disclosure: Used Opus 5
