### PR TITLE
Release 5.13.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.13.1"
+version = "5.13.2"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Unreleased **source** changes have accumulated on the default branch since the last registered version.

This is a **patch** bump: the exported public surface is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R