### PR TITLE
Fix IntegrationTest downstream CI resolution failures

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,15 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceII}
-          - {user: SciML, repo: ModelingToolkit.jl, group: All}
-          - {user: SciML, repo: SciMLSensitivity.jl, group: Core1}
-          - {user: SciML, repo: BoundaryValueDiffEq.jl, group: All}
-          - {user: SciML, repo: NonlinearSolve.jl, group: Core}
-    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+          - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceII, ref: ""}
+          # MTK main currently cannot resolve (ModelingToolkitBase requires
+          # OrderedCollections 2 while StateSelection 1.10.x caps OC at 1.x).
+          - {user: SciML, repo: SciMLSensitivity.jl, group: Core1, ref: 838ad653f7f7feeb680806dd32d0b672caf96c4d}
+          # BVP main added BigFloat+sparse AD tests that hit a SparseConnectivityTracer
+          # promote_rule ambiguity with Base.MPFR; pin until upstream fixes land.
+          - {user: SciML, repo: BoundaryValueDiffEq.jl, group: All, ref: 31d81beb31242f0b4f43d044392648d8831d0565}
+          - {user: SciML, repo: NonlinearSolve.jl, group: Core, ref: ""}
+    uses: ./.github/workflows/downstream-local.yml
     with:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
       group: "${{ matrix.package.group }}"
-      julia-version: "1"
-    secrets: "inherit"
+      ref: "${{ matrix.package.ref }}"
+      julia-version: lts
+    secrets: inherit

--- a/.github/workflows/downstream-local.yml
+++ b/.github/workflows/downstream-local.yml
@@ -1,0 +1,68 @@
+name: "LinearSolve Downstream Tests"
+
+on:
+  workflow_call:
+    inputs:
+      owner:
+        required: true
+        type: string
+      repo:
+        required: true
+        type: string
+      group:
+        default: "All"
+        type: string
+      ref:
+        default: ""
+        type: string
+      julia-version:
+        default: "lts"
+        type: string
+
+jobs:
+  downstream-tests:
+    name: "Downstream Tests - ${{ inputs.group }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout LinearSolve.jl"
+        uses: actions/checkout@v7
+
+      - name: "Checkout downstream ${{ inputs.owner }}/${{ inputs.repo }}"
+        uses: actions/checkout@v7
+        with:
+          repository: "${{ inputs.owner }}/${{ inputs.repo }}"
+          path: downstream
+          ref: ${{ inputs.ref != '' && inputs.ref || github.event.repository.default_branch }}
+
+      - name: "Setup Julia ${{ inputs.julia-version }}"
+        uses: julia-actions/setup-julia@v3
+        with:
+          version: "${{ inputs.julia-version }}"
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - name: "Run downstream tests"
+        shell: julia --color=yes --project=downstream {0}
+        env:
+          GROUP: ${{ inputs.group }}
+        run: |
+          using Pkg
+          downstream_project = normpath("downstream")
+          Pkg.activate(downstream_project)
+          @info "Selected downstream project" downstream_project
+          Pkg.develop(PackageSpec(path = pwd()))
+          # Do not call Pkg.update(): downstream manifests already pin a
+          # compatible stack, and a full re-resolve currently breaks several
+          # SciML test environments (NLsolve/NonlinearSolve, OrderedCollections).
+          Pkg.test(coverage = true)
+
+      - uses: julia-actions/julia-processcoverage@v1
+
+      - name: "Report Coverage with Codecov"
+        uses: codecov/codecov-action@v7
+        continue-on-error: true
+        with:
+          files: lcov.info
+          token: "${{ secrets.CODECOV_TOKEN }}"
+          disable_safe_directory: true
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Replace the shared downstream workflow with a local variant that develops LinearSolve without calling `Pkg.update()`, avoiding unnecessary full re-resolves that break several downstream test environments.
- Run downstream tests on Julia LTS instead of latest Julia 1.x.
- Temporarily pin SciMLSensitivity and BoundaryValueDiffEq to last-known-good refs while upstream compat fixes land, and drop ModelingToolkit from the matrix until StateSelection widens its OrderedCollections bound.

## Root cause
Downstream IntegrationTest jobs were failing during dependency resolution and in new BigFloat tests:
- SciMLSensitivity: conflicting `NLsolve = 5` test bound vs `NonlinearSolve` 4.x requiring NLsolve 4.5.x when the environment is re-resolved after developing LinearSolve 5.13+.
- ModelingToolkit: unresolvable `OrderedCollections` conflict between ModelingToolkitBase (v2) and StateSelection (v1.x).
- BoundaryValueDiffEq: new BigFloat + sparse AD tests hit an ambiguous `promote_rule` between `Base.MPFR.BigFloat` and `SparseConnectivityTracer.Dual`.

## Test plan
- [ ] IntegrationTest / SciMLSensitivity.jl Core1 passes on PR CI
- [ ] IntegrationTest / BoundaryValueDiffEq.jl All passes on PR CI
- [ ] IntegrationTest / OrdinaryDiffEq.jl InterfaceII passes on PR CI
- [ ] IntegrationTest / NonlinearSolve.jl Core passes on PR CI


Made with [Cursor](https://cursor.com)