### PR TITLE
Fix LHLCache unbound constructor parameters

### DIFF
--- a/src/lhl.jl
+++ b/src/lhl.jl
@@ -104,8 +104,10 @@ not-yet-reduced state widens it.
 mutable struct LHLCache{WS, JT}
     ws::WS
     jac::Union{Nothing, JT}
+    LHLCache{WS, JT}(ws, jac) where {WS, JT} = new{WS, JT}(ws, jac)
 end
 
+LHLCache(ws::WS, jac::JT) where {WS, JT} = LHLCache{WS, JT}(ws, jac)
 LHLCache(ws, ::Type{JT}) where {JT} = LHLCache{typeof(ws), JT}(ws, nothing)
 
 function init_cacheval(


### PR DESCRIPTION
## What changed and why

Define the `LHLCache` inner and outer constructors explicitly so every constructor type parameter is bound by an argument. The generated constructor for the `Union{Nothing, JT}` field exposed `JT` only through a union and Aqua therefore rejected the method; the explicit outer constructor preserves type inference when a Jacobian value is supplied, while the existing `LHLCache(ws, ::Type{JT})` path still constructs the initial `nothing` state.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## Failing before

On clean `main` at `5dcf04d29038b5e4e4938157e9834fd8ddcf5f7a`, the full Julia 1.11.9 QA group reported:

```text
Unbound type parameters detected:
LinearSolve.LHLCache(ws::WS, jac::Union{Nothing, JT}) where {WS, JT}
Quality Assurance | Pass 47 Fail 2 Error 1 Total 50 Time 6m37.8s
```

An adjacent-history check with Aqua 0.8.16 on Julia 1.10.12 passed at parent commit `a449aab53f03a0aba833a502df409bf86b08de8f` and failed after `47cdfb2eb81757346bb06cd8a3053a9736d15291`, which introduced this cache.

## Passing after

The focused Aqua check on Julia 1.11.9 reports:

```text
LinearSolve source: /home/crackauc/sandbox/tmp_20260825_180339_53321/linearsolve-lhlcache-qa-main/src/LinearSolve.jl
Aqua unbound-argument check: pass
```

The final three-fix stack was then validated with:

```sh
GROUP=QA julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
GROUP=Core julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
julia +1.12 --project=/home/crackauc/.julia/environments/runic -m Runic --check src/LinearSolve.jl src/blocked_lufact.jl src/lhl.jl
typos src/LinearSolve.jl src/blocked_lufact.jl src/lhl.jl
git diff --check origin/main...HEAD
```

Results:

```text
Quality Assurance | 50 pass, total 50, 9m41.3s
Testing LinearSolve tests passed

Core examples:
Re-solve | 143 pass, total 143
SupernodalLU internals | 91 pass, total 91
Default Alg Tests | 133 pass, total 133
Adjoint Sensitivity | 138 pass, total 138
ForwardDiff Overloads | 147 pass, total 147
SpecializingFactorizations | 18 pass, total 18
Testing LinearSolve tests passed
```

The full Core command exited 0 after 36m10s. Runic, typos, and `git diff --check` exited 0 with no output. Documentation was not built because this changes neither public API nor documentation.

## Review notes

This is the first of three focused QA fixes. The later branches are stacked separately so this constructor change can be reviewed and merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
