### PR TITLE
Use imported one-based indexing check

### DIFF
--- a/src/blocked_lufact.jl
+++ b/src/blocked_lufact.jl
@@ -717,7 +717,7 @@ function _blocked_generic_lufact!(
         ipiv::AbstractVector{<:Integer}, pack::Union{Nothing, Vector{T}};
         check::Bool = true, allowsingular::Bool = false
     ) where {T <: Union{Float32, Float64}}
-    Base.require_one_based_indexing(A, ipiv)
+    require_one_based_indexing(A, ipiv)
     if check && !all(isfinite, A)
         throw(ArgumentError("matrix contains Infs or NaNs"))
     end

--- a/src/lhl.jl
+++ b/src/lhl.jl
@@ -104,8 +104,10 @@ not-yet-reduced state widens it.
 mutable struct LHLCache{WS, JT}
     ws::WS
     jac::Union{Nothing, JT}
+    LHLCache{WS, JT}(ws, jac) where {WS, JT} = new{WS, JT}(ws, jac)
 end
 
+LHLCache(ws::WS, jac::JT) where {WS, JT} = LHLCache{WS, JT}(ws, jac)
 LHLCache(ws, ::Type{JT}) where {JT} = LHLCache{typeof(ws), JT}(ws, nothing)
 
 function init_cacheval(


### PR DESCRIPTION
## What changed and why

Call the already-imported `require_one_based_indexing` binding instead of qualifying it through `Base`. LinearSolve already explicitly imports this Base internal and documents that irreducible exception in its QA allowlist, so the unqualified call is consistent with that declaration and needs no new qualified-access ignore.

This draft is stacked on https://github.com/SciML/LinearSolve.jl/pull/1260 and should be reviewed after that prerequisite. Please ignore it until it has been reviewed by @ChrisRackauckas.

## Failing before

On clean `main` at `5dcf04d29038b5e4e4938157e9834fd8ddcf5f7a`, the Julia 1.11.9 QA group reports:

```text
require_one_based_indexing is not public in Base but accessed as Base.require_one_based_indexing
Quality Assurance | Pass 47 Fail 2 Error 1 Total 50 Time 6m37.8s
```

The qualified call was introduced by `6bbb233daa4bd647fa289b96b4a3d9ff6fe0b7e0`; strict qualified-access QA was enabled later by `48c1a7e34fa95fc2f6450cea80226f0e7330ad68`.

## Passing after

The final three-fix stack was validated with:

```sh
GROUP=QA julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
GROUP=Core julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
julia +1.12 --project=/home/crackauc/.julia/environments/runic -m Runic --check src/LinearSolve.jl src/blocked_lufact.jl src/lhl.jl
typos src/LinearSolve.jl src/blocked_lufact.jl src/lhl.jl
git diff --check origin/main...HEAD
```

Results:

```text
Quality Assurance | 50 pass, total 50, 9m41.3s
Testing LinearSolve tests passed

Core examples:
Re-solve | 143 pass, total 143
SupernodalLU internals | 91 pass, total 91
Default Alg Tests | 133 pass, total 133
Adjoint Sensitivity | 138 pass, total 138
ForwardDiff Overloads | 147 pass, total 147
SpecializingFactorizations | 18 pass, total 18
Testing LinearSolve tests passed
```

The full Core command exited 0 after 36m10s. Runic, typos, and `git diff --check` exited 0 with no output. Documentation was not built because this changes neither public API nor documentation.

## Review notes

The PR contains the prerequisite commit because it is stacked; the new change for this PR is the one-line `src/blocked_lufact.jl` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
