### PR TITLE
Isolate LHLFactorization dependency binding for JET

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -8,8 +8,19 @@ import PrecompileTools
 using ArrayInterface: ArrayInterface
 # Explicit names, not the module: LinearSolve defines its own `LHLFactorization` (the
 # algorithm object) and `using LHLFactorization` would shadow it.
-using LHLFactorization: LHLWorkspace, lhl_reduce!, lhl_shift!, lhl_ldiv!, lhl_refine!,
-    lhl_ldivH!, lhl_refineH!, lhl, lhl!, lhl_isreduced
+module LHLFactorizationBindings
+    using LHLFactorization: LHLWorkspace, lhl_reduce!, lhl_shift!, lhl_ldiv!, lhl_refine!,
+        lhl_ldivH!, lhl_refineH!, lhl, lhl!, lhl_isreduced
+    const bindings = (
+        LHLWorkspace, lhl_reduce!, lhl_shift!, lhl_ldiv!, lhl_refine!,
+        lhl_ldivH!, lhl_refineH!, lhl, lhl!, lhl_isreduced,
+    )
+end
+const (
+    LHLWorkspace, lhl_reduce!, lhl_shift!, lhl_ldiv!, lhl_refine!, lhl_ldivH!,
+    lhl_refineH!, lhl, lhl!, lhl_isreduced,
+) =
+    LHLFactorizationBindings.bindings
 using Base: Bool, convert, copyto!, adjoint, transpose, /, \, require_one_based_indexing
 using LinearAlgebra: LinearAlgebra, BlasInt, LU, Adjoint, BLAS, Bidiagonal, BunchKaufman,
     ColumnNorm, cond, Diagonal, Factorization, Hermitian, I, LAPACK, NoPivot,

--- a/src/blocked_lufact.jl
+++ b/src/blocked_lufact.jl
@@ -717,7 +717,7 @@ function _blocked_generic_lufact!(
         ipiv::AbstractVector{<:Integer}, pack::Union{Nothing, Vector{T}};
         check::Bool = true, allowsingular::Bool = false
     ) where {T <: Union{Float32, Float64}}
-    Base.require_one_based_indexing(A, ipiv)
+    require_one_based_indexing(A, ipiv)
     if check && !all(isfinite, A)
         throw(ArgumentError("matrix contains Infs or NaNs"))
     end

--- a/src/lhl.jl
+++ b/src/lhl.jl
@@ -104,8 +104,10 @@ not-yet-reduced state widens it.
 mutable struct LHLCache{WS, JT}
     ws::WS
     jac::Union{Nothing, JT}
+    LHLCache{WS, JT}(ws, jac) where {WS, JT} = new{WS, JT}(ws, jac)
 end
 
+LHLCache(ws::WS, jac::JT) where {WS, JT} = LHLCache{WS, JT}(ws, jac)
 LHLCache(ws, ::Type{JT}) where {JT} = LHLCache{typeof(ws), JT}(ws, nothing)
 
 function init_cacheval(


### PR DESCRIPTION
> Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

Import the dependency's ten LHL implementation names inside a private binding module, then copy only those bindings into the `LinearSolve` module. JET's package analysis treats importing the dependency module name `LHLFactorization` into LinearSolve as an invalid redefinition because LinearSolve already defines the public algorithm type with that name. Isolating the dependency module name removes the collision without exporting new names or suppressing a report.

This draft is stacked on https://github.com/SciML/LinearSolve.jl/pull/1261, which is itself stacked on https://github.com/SciML/LinearSolve.jl/pull/1260. It should be reviewed after both prerequisites.

## Failing before

On clean `main` at `5dcf04d29038b5e4e4938157e9834fd8ddcf5f7a`, `JET.report_package(LinearSolve)` reports seven errors beginning with:

```text
invalid redefinition of constant LinearSolve.LHLFactorization
```

The full Julia 1.11.9 QA result was:

```text
Quality Assurance | Pass 47 Fail 2 Error 1 Total 50 Time 6m37.8s
```

An adjacent-history check reports zero package-analysis errors at parent commit `a449aab53f03a0aba833a502df409bf86b08de8f` and seven after `47cdfb2eb81757346bb06cd8a3053a9736d15291`, which added the dependency import and the algorithm type with the same name.

## Passing after

The focused Julia 1.11.9 check reports:

```text
stale imports: nothing
JET reports: 0
```

After rebasing the stack onto current `main` commit `43044f5e`, I ran:

```sh
GROUP=QA julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
GROUP=Core julia +1.11.9 --project=. -e 'using Pkg; Pkg.test()'
julia +1.12 --project=/home/crackauc/.julia/environments/runic -m Runic --check src/LinearSolve.jl src/blocked_lufact.jl src/lhl.jl
typos src/LinearSolve.jl src/blocked_lufact.jl src/lhl.jl
git diff --check origin/main...HEAD
```

Results:

```text
JET Tests | 25 pass, 18 broken, total 43, 1m49.8s
Allocation QA | 55 pass, total 55, 1m19.7s
SupernodalLU Allocation QA | 6 pass, total 6, 11.8s
Quality Assurance | 50 pass, total 50, 8m22.5s
Testing LinearSolve tests passed

Core examples:
Re-solve | 143 pass, total 143
SupernodalLU internals | 91 pass, total 91
Default Alg Tests | 133 pass, total 133
Adjoint Sensitivity | 138 pass, total 138
ForwardDiff Overloads | 147 pass, total 147
SpecializingFactorizations | 18 pass, total 18
Testing LinearSolve tests passed
```

Runic, typos, and `git diff --check` exited 0 with no output. Documentation was not built because the helper module and copied bindings are internal and this changes no public API or documentation.

## Review notes

An import alias did not eliminate the JET collision. The private binding module is intentionally narrow: it prevents the dependency module name from entering LinearSolve while leaving the existing internal call sites unchanged. The PR contains both prerequisite commits because it is stacked; the new change for this PR is the `src/LinearSolve.jl` binding isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
