### PR TITLE
Forward preconditioners through the default Krylov workspace

### DIFF
--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -680,41 +680,41 @@ function SciMLBase.solve!(cache::LinearCache, alg::KrylovJL; kwargs...)
         ldiv = true, history = true, filtered_kwargs...,
     )
 
-    if cache.cacheval isa Krylov.CgWorkspace
+    if cacheval isa Krylov.CgWorkspace
         N !== I &&
             @SciMLMessage(
             "$(alg.KrylovAlg) doesn't support right preconditioning.",
             verbose, :no_right_preconditioning
         )
         Krylov.krylov_solve!(args...; M, kwargs...)
-    elseif cache.cacheval isa Krylov.GmresWorkspace
+    elseif cacheval isa Krylov.GmresWorkspace
         Krylov.krylov_solve!(args...; M, N, restart = alg.gmres_restart > 0, kwargs...)
-    elseif cache.cacheval isa Krylov.FgmresWorkspace
+    elseif cacheval isa Krylov.FgmresWorkspace
         Krylov.krylov_solve!(args...; M, N, kwargs...)
-    elseif cache.cacheval isa Krylov.BicgstabWorkspace
+    elseif cacheval isa Krylov.BicgstabWorkspace
         Krylov.krylov_solve!(args...; M, N, kwargs...)
-    elseif cache.cacheval isa Krylov.MinresWorkspace
+    elseif cacheval isa Krylov.MinresWorkspace
         N !== I &&
             @SciMLMessage(
             "$(alg.KrylovAlg) doesn't support right preconditioning.",
             verbose, :no_right_preconditioning
         )
         Krylov.krylov_solve!(args...; M, kwargs...)
-    elseif cache.cacheval isa Krylov.BlockGmresWorkspace
+    elseif cacheval isa Krylov.BlockGmresWorkspace
         Krylov.krylov_solve!(args...; M, N, restart = alg.gmres_restart > 0, kwargs...)
-    elseif cache.cacheval isa Krylov.BlockMinresWorkspace
+    elseif cacheval isa Krylov.BlockMinresWorkspace
         N !== I &&
             @SciMLMessage(
             "$(alg.KrylovAlg) doesn't support right preconditioning.",
             verbose, :no_right_preconditioning
         )
         Krylov.krylov_solve!(args...; M, kwargs...)
-    elseif cache.cacheval isa Krylov.LsmrWorkspace ||
-            cache.cacheval isa Krylov.LsqrWorkspace ||
-            cache.cacheval isa Krylov.LslqWorkspace
+    elseif cacheval isa Krylov.LsmrWorkspace ||
+            cacheval isa Krylov.LsqrWorkspace ||
+            cacheval isa Krylov.LslqWorkspace
         Krylov.krylov_solve!(args...; M, N, kwargs...)
-    elseif cache.cacheval isa Krylov.CglsWorkspace ||
-            cache.cacheval isa Krylov.CrlsWorkspace
+    elseif cacheval isa Krylov.CglsWorkspace ||
+            cacheval isa Krylov.CrlsWorkspace
         N !== I &&
             @SciMLMessage(
             "$(alg.KrylovAlg) doesn't support right preconditioning.",

--- a/test/Core/default_algs.jl
+++ b/test/Core/default_algs.jl
@@ -1,6 +1,15 @@
 using LinearSolve, RecursiveFactorization, LinearAlgebra, SparseArrays, Test
 using SciMLOperators: FunctionOperator, MatrixOperator, WOperator, has_concretization
 
+struct CountingIdentityPreconditioner
+    calls::Base.RefValue{Int}
+end
+
+function LinearAlgebra.ldiv!(y, P::CountingIdentityPreconditioner, x)
+    P.calls[] += 1
+    return copyto!(y, x)
+end
+
 @test LinearSolve.defaultalg(nothing, zeros(3)).alg === LinearSolve.DefaultAlgorithmChoice.GenericLUFactorization
 prob = LinearProblem(rand(3, 3), rand(3))
 solve(prob)
@@ -709,4 +718,21 @@ end
     @test LinearSolve.defaultalg(Wdense, bw, OperatorAssumptions(true)).alg ===
         LinearSolve.DefaultAlgorithmChoice.LHLFactorization
     @test solve(LinearProblem(Wdense, bw)).u ≈ ref rtol = 1.0e-8
+end
+
+@testset "default matrix-free solver uses supplied preconditioners" begin
+    n = 4
+    Jm = rand(n, n) + n * I
+    b = rand(n)
+    fj(v, u, p, t) = Jm * v
+    fj(w, v, u, p, t) = mul!(w, Jm, v)
+    Jfree = FunctionOperator(fj, zeros(n), zeros(n); islinear = true)
+    Wfree = WOperator{true}(I, 0.1, Jfree, zeros(n))
+    Pl = CountingIdentityPreconditioner(Ref(0))
+    Pr = CountingIdentityPreconditioner(Ref(0))
+
+    solve(LinearProblem(Wfree, b), nothing; Pl, Pr)
+
+    @test Pl.calls[] > 0
+    @test Pr.calls[] > 0
 end


### PR DESCRIPTION
## What changed and why

When `DefaultLinearSolver` selects a Krylov method, `solve!` unwraps the selected inner Krylov workspace into the local `cacheval`. The subsequent workspace dispatch incorrectly tested the outer `cache.cacheval`, so none of the typed branches matched and the fallback called `Krylov.krylov_solve!` without `M` or `N`. Supplied left and right preconditioners were silently ignored even though the solve could report success.

This changes those dispatch tests to use the selected `cacheval` and adds a matrix-free `WOperator` regression test that counts both preconditioner applications. It complements the matrix-free `WOperator` routing fixed in https://github.com/SciML/LinearSolve.jl/pull/1255: that PR lets the problem reach the default iterative solver; this PR ensures the selected solver receives its preconditioners.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before / passing after

I ran the same standalone regression on the exact unfixed parent and on this change. The linear solve itself succeeds before the fix, which is why this was silent, but neither preconditioner is called:

```console
# unfixed parent, exact test from this PR
retcode=Success Pl_calls=0 Pr_calls=0
ERROR: AssertionError: Pl.calls[] > 0
```

With this change:

```console
# d57aecff5011f13a29dd61143fee9b35234e97be
retcode=Success Pl_calls=5 Pr_calls=5
# exit 0
```

The reduced KenCarp4 `SplitODEProblem` MWE using this rebased branch plus the companion OrdinaryDiffEq change now completes with the default linear solver:

```console
mode=default elapsed=21.145805456 retcode=Success accepted=24 nf=446 nsolve=467
```

Without the two fixes, the original matrix-free GMRES path remained inside `Krylov.gmres!` beyond 3,600 seconds.

## Verification

Julia 1.11.9:

```console
$ GROUP=Core julia +1.11.9 --project -e 'using Pkg; Pkg.test()'
Default Alg Tests | 133 pass, total 133
SpecializingFactorizations | 18 pass, total 18
Testing LinearSolve tests passed
```

The full Core group passed. Runic 1.7.0, `typos`, and `git diff --check` also exited 0 after rebasing onto LinearSolve 5.14.0.

Clean `main` currently has three unrelated QA failures. They were reproduced and bisected separately, and the complete current-main stack including those three repairs and this change passed:

```console
$ GROUP=QA julia +1.11.9 --project -e 'using Pkg; Pkg.test()'
JET Tests | 25 pass, 18 broken, total 43
Allocation QA | 55 pass, total 55
SupernodalLU Allocation QA | 6 pass, total 6
Quality Assurance | 50 pass, total 50, 9m19.5s
Testing LinearSolve tests passed
```

The focused clean-main repairs are:

- https://github.com/SciML/LinearSolve.jl/pull/1260
- https://github.com/SciML/LinearSolve.jl/pull/1261
- https://github.com/SciML/LinearSolve.jl/pull/1262

The hosted downstream ModelingToolkit resolver failure common to all branches is addressed by https://github.com/SciML/ModelingToolkit.jl/pull/5031.

## Not verified

GPU-specific test groups were not run; this changes generic Krylov workspace dispatch and the regression is CPU matrix-free. No public API or documentation changed, so the docs build was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
