### PR TITLE
Fix LinearSolveAutotune PrettyTables v3 output

### DIFF
--- a/lib/LinearSolveAutotune/src/LinearSolveAutotune.jl
+++ b/lib/LinearSolveAutotune/src/LinearSolveAutotune.jl
@@ -393,7 +393,9 @@ function autotune_setup(;
                         return v
                     end
                 end,
-            ]
+            ],
+            fit_table_in_display_horizontally = false,
+            fit_table_in_display_vertically = false
         )
     else
         @warn "No successful benchmark results!"

--- a/lib/LinearSolveAutotune/src/LinearSolveAutotune.jl
+++ b/lib/LinearSolveAutotune/src/LinearSolveAutotune.jl
@@ -384,15 +384,16 @@ function autotune_setup(;
         println("="^60)
         pretty_table(
             full_summary,
-            header = ["Algorithm", "Avg GFLOPs", "Max GFLOPs", "Success", "Total"],
-            formatters = (v, i, j) -> begin
-                if j in [2, 3] && isa(v, Float64)
-                    return isnan(v) ? "NaN" : @sprintf("%.2f", v)
-                else
-                    return v
-                end
-            end,
-            crop = :none
+            column_labels = ["Algorithm", "Avg GFLOPs", "Max GFLOPs", "Success", "Total"],
+            formatters = [
+                (v, i, j) -> begin
+                    if j in [2, 3] && isa(v, Float64)
+                        return isnan(v) ? "NaN" : @sprintf("%.2f", v)
+                    else
+                        return v
+                    end
+                end,
+            ]
         )
     else
         @warn "No successful benchmark results!"

--- a/lib/LinearSolveAutotune/test/autotune_tests.jl
+++ b/lib/LinearSolveAutotune/test/autotune_tests.jl
@@ -433,17 +433,25 @@ if isempty(VERSION.prerelease)
             LinearSolveAutotune.clear_algorithm_preferences()
 
             # Run a minimal autotune that sets preferences
-            result = LinearSolveAutotune.autotune_setup(
-                sizes = [:tiny],
-                set_preferences = true,  # KEY: Must be true to test preference setting
-                samples = 1,
-                seconds = 0.1,
-                eltypes = (Float64,),
-                collect_solve_path_data = false,
-                collect_supernodal_panel_data = false
-            )
+            result, summary_output = mktemp() do _, io
+                result = redirect_stdout(io) do
+                    LinearSolveAutotune.autotune_setup(
+                        sizes = [:tiny],
+                        set_preferences = true,  # KEY: Must be true to test preference setting
+                        samples = 1,
+                        seconds = 0.1,
+                        eltypes = (Float64,),
+                        collect_solve_path_data = false,
+                        collect_supernodal_panel_data = false
+                    )
+                end
+                flush(io)
+                seekstart(io)
+                return result, read(io, String)
+            end
 
             @test isa(result, AutotuneResults)
+            @test contains(summary_output, "Algorithm")
 
             # Check if any preferences were set
             prefs_after_autotune = LinearSolveAutotune.get_algorithm_preferences()


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

The LinearSolveAutotune summary still used PrettyTables v2 keywords after the package compat moved to PrettyTables 3. The lower-bound environment resolves PrettyTables 3.0.5, where `formatters` must be a vector and `header` / `crop` are no longer the v3 API, so both integration tests errored after completing their benchmarks.

This uses the PrettyTables v3 `column_labels` keyword and a formatter vector. It also maps the old `crop = :none` behavior to the v3 horizontal and vertical display-fit controls so the complete benchmark summary remains visible. The integration test now verifies that the rendered summary contains its `Algorithm` column label.

## Regression evidence

The adjacent-commit bisect used the last successful downgrade commit as good and the compat change as bad:

```text
$ git bisect start 1fddd293ccd2649454b11c9a84490c0ae7da67b5 1d99a9ec684a771304e0deaac60e51c17478e13b
1fddd293ccd2649454b11c9a84490c0ae7da67b5 is the first bad commit
```

That commit changes `PrettyTables = "2.4"` to `PrettyTables = "3"`. Its parent downgrade job passed, while its own LinearSolveAutotune downgrade job failed:

- Passing parent: https://github.com/SciML/LinearSolve.jl/actions/runs/32932888679/job/98078988590
- First bad commit: https://github.com/SciML/LinearSolve.jl/commit/1fddd293ccd2649454b11c9a84490c0ae7da67b5
- Failing job: https://github.com/SciML/LinearSolve.jl/actions/runs/32967619980/job/98243450901

I reproduced the failure on a clean checkout of current `main` at `5dcf04d2` with the downgrade action's generated Julia 1.10.12 / PrettyTables 3.0.5 environment. With the regression assertion applied but without the source fix:

```text
$ LINEARSOLVE_TEST_GROUP=Core julia +1.10.12 --project=lib/LinearSolveAutotune -e 'using Pkg; Pkg.test()'
TypeError: in keyword argument formatters, expected Union{Nothing, Vector}, got a value of type LinearSolveAutotune.var"#96#105"
Test Summary:             | Pass  Error  Total     Time
LinearSolveAutotune Tests |  151      2    153  3m58.6s
ERROR: Package LinearSolveAutotune errored during testing
```

With this fix and the identical downgraded environment:

```text
$ LINEARSOLVE_TEST_GROUP=Core julia +1.10.12 --project=lib/LinearSolveAutotune -e 'using Pkg; Pkg.test()'
Test Summary:             | Pass  Total     Time
LinearSolveAutotune Tests |  175    175  5m13.8s
Testing LinearSolveAutotune tests passed
```

## Additional verification

Current dependencies (Julia 1.11.9, PrettyTables 3.4.8):

```text
$ LINEARSOLVE_TEST_GROUP=Core julia +1.11.9 --project=lib/LinearSolveAutotune -e 'using Pkg; Pkg.test()'
Test Summary:             | Pass  Total     Time
LinearSolveAutotune Tests |  175    175  6m08.1s
Testing LinearSolveAutotune tests passed

$ LINEARSOLVE_TEST_GROUP=QA julia +1.11.9 --project=lib/LinearSolveAutotune -e 'using Pkg; Pkg.test()'
Test Summary:             | Pass  Total     Time
Code quality (Aqua + JET) |   21     21  6m58.8s
Testing LinearSolveAutotune tests passed
```

The following local checks also exited successfully with no output:

```text
julia +1.11.9 --project=../.runic-env -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff lib/LinearSolveAutotune/src/LinearSolveAutotune.jl lib/LinearSolveAutotune/test/autotune_tests.jl
typos lib/LinearSolveAutotune/src/LinearSolveAutotune.jl lib/LinearSolveAutotune/test/autotune_tests.jl
git diff --check
```

I did not run GPU tests because this checkout has no GPU. I did not run the documentation build because this changes neither documentation nor public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
