### PR TITLE
Reformat four files that drifted from Runic

### DIFF
--- a/ext/LinearSolveForwardDiffExt.jl
+++ b/ext/LinearSolveForwardDiffExt.jl
@@ -858,9 +858,9 @@ function partials_to_list(partial_matrix::SparseMatrixCSC)
     V = ForwardDiff.valtype(T) # use type for concrete array below in empty-nz case (e.g. all-zero Jacobian at init)
     return [
         SparseMatrixCSC(
-                m, n, partial_matrix.colptr, partial_matrix.rowval,
-                V[nz[i][k] for i in eachindex(nz)]
-            ) for k in 1:p
+            m, n, partial_matrix.colptr, partial_matrix.rowval,
+            V[nz[i][k] for i in eachindex(nz)]
+        ) for k in 1:p
     ]
 end
 

--- a/test/Core/forwarddiff_gpu.jl
+++ b/test/Core/forwarddiff_gpu.jl
@@ -30,8 +30,8 @@ end
 function dual_problem(n, p)
     A = [
         ForwardDiff.Dual{Nothing}(
-                float(i == j ? 10 + i : 0.3 * (i + j)), ntuple(k -> 0.1k + 0.01 * (i + j), p)
-            ) for i in 1:n, j in 1:n
+            float(i == j ? 10 + i : 0.3 * (i + j)), ntuple(k -> 0.1k + 0.01 * (i + j), p)
+        ) for i in 1:n, j in 1:n
     ]
     b = [ForwardDiff.Dual{Nothing}(float(i), ntuple(k -> 0.05k + 0.1i, p)) for i in 1:n]
     return A, b
@@ -42,9 +42,9 @@ value_error(got, ref) = maximum(abs, ForwardDiff.value.(got) .- ForwardDiff.valu
 function partials_error(got, ref)
     return maximum(
         maximum(
-                abs,
-                collect(ForwardDiff.partials(x)) .- collect(ForwardDiff.partials(y))
-            ) for (x, y) in zip(got, ref)
+            abs,
+            collect(ForwardDiff.partials(x)) .- collect(ForwardDiff.partials(y))
+        ) for (x, y) in zip(got, ref)
     )
 end
 

--- a/test/Core/forwarddiff_overloads.jl
+++ b/test/Core/forwarddiff_overloads.jl
@@ -303,8 +303,8 @@ prob = LinearProblem(sparse(plain_A), b)
     for nchunk in (1, 2, 3)
         bd = [
             ForwardDiff.Dual{Nothing, Float64, nchunk}(
-                    Float64(i), ForwardDiff.Partials(ntuple(k -> sin(i + k), nchunk))
-                ) for i in 1:5
+                Float64(i), ForwardDiff.Partials(ntuple(k -> sin(i + k), nchunk))
+            ) for i in 1:5
         ]
         cache = LinearSolve.__init(LinearProblem(Asp, bd), PureKLUFactorization())
         @test eltype(cache.A) == Float64                 # A not promoted
@@ -313,9 +313,9 @@ prob = LinearProblem(sparse(plain_A), b)
         @test isapprox(ForwardDiff.value.(u), ForwardDiff.value.(uref); rtol = 1.0e-10)
         @test all(
             isapprox(
-                    ForwardDiff.partials(u[i], j), ForwardDiff.partials(uref[i], j);
-                    rtol = 1.0e-8, atol = 1.0e-12
-                ) for i in 1:5, j in 1:nchunk
+                ForwardDiff.partials(u[i], j), ForwardDiff.partials(uref[i], j);
+                rtol = 1.0e-8, atol = 1.0e-12
+            ) for i in 1:5, j in 1:nchunk
         )
     end
 
@@ -863,9 +863,9 @@ end
     p = 3
     A = [
         ForwardDiff.Dual{Nothing}(
-                float(i == j ? 10 + i : 0.3 * (i + j)),
-                ntuple(k -> 0.1k + 0.01 * (i + j), p)
-            ) for i in 1:n, j in 1:n
+            float(i == j ? 10 + i : 0.3 * (i + j)),
+            ntuple(k -> 0.1k + 0.01 * (i + j), p)
+        ) for i in 1:n, j in 1:n
     ]
     b = [ForwardDiff.Dual{Nothing}(float(i), ntuple(k -> 0.05k + 0.1i, p)) for i in 1:n]
     reference = solve(LinearProblem(A, b), LUFactorization()).u

--- a/test/qa/allocations.jl
+++ b/test/qa/allocations.jl
@@ -112,8 +112,8 @@ const DUAL_XP_LINSOLVE_RHS! = getproperty(
 function dual_linear_problem(n, p)
     A = [
         ForwardDiff.Dual{Nothing}(
-                float(i == j ? 10 + i : 0.3 * (i + j)), ntuple(k -> 0.1k + 0.01 * (i + j), p)
-            ) for i in 1:n, j in 1:n
+            float(i == j ? 10 + i : 0.3 * (i + j)), ntuple(k -> 0.1k + 0.01 * (i + j), p)
+        ) for i in 1:n, j in 1:n
     ]
     b = [ForwardDiff.Dual{Nothing}(float(i), ntuple(k -> 0.05k + 0.1i, p)) for i in 1:n]
     return A, b


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

The Runic check is failing on main, so every open PR shows a red format check. Four files drifted, indentation only, `git diff -w` comes back empty. Reformatted them and the whole tree is clean again.

No tests, since nothing but whitespace changed.

AI Disclosure: Used Opus 5
