### PR TITLE
Export InvPreconditioner

### DIFF
--- a/src/LinearSolve.jl
+++ b/src/LinearSolve.jl
@@ -803,7 +803,7 @@ export LUFactorization, SVDFactorization, QRFactorization, GenericFactorization,
 
 export LHLFactorization, update_gamma!
 
-export LinearSolveFunction, DirectLdiv!, show_algorithm_choices
+export LinearSolveFunction, DirectLdiv!, show_algorithm_choices, InvPreconditioner
 
 export KrylovJL, KrylovJL_CG, KrylovJL_MINRES, KrylovJL_GMRES,
     KrylovJL_BICGSTAB, KrylovJL_LSMR, KrylovJL_CRAIGMR, KrylovJL_FGMRES, WarmStart,

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -882,8 +882,6 @@ end
     end
 
     @testset "Preconditioners" begin
-        @test Base.isexported(LinearSolve, :InvPreconditioner)
-
         @testset "Vector Diagonal Preconditioner" begin
             x = rand(n, n)
             y = rand(n, n)

--- a/test/Core/basictests.jl
+++ b/test/Core/basictests.jl
@@ -882,6 +882,8 @@ end
     end
 
     @testset "Preconditioners" begin
+        @test Base.isexported(LinearSolve, :InvPreconditioner)
+
         @testset "Vector Diagonal Preconditioner" begin
             x = rand(n, n)
             y = rand(n, n)


### PR DESCRIPTION
## What changed and why

`InvPreconditioner` already has a docstring and rendered manual entries, but it is not exported and therefore is not public API. Export it so downstream packages can use the inverse-preconditioner wrapper without reaching into LinearSolve internals. This unblocks the requested cleanup in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4391#issuecomment-5449978491.

This public API addition should be included in a LinearSolve 5.15.0 or later minor release. The version is not changed here because LinearSolve performs version bumps in dedicated release PRs.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before / passing after

On exact parent `50563b88`, the focused public-API assertion failed:

```console
$ julia +1.11 --project -e 'using LinearSolve, Test; @test Base.isexported(LinearSolve, :InvPreconditioner)'
Test Failed at none:1
  Expression: Base.isexported(LinearSolve, :InvPreconditioner)

ERROR: There was an error during testing
```

With this change, the same command exits 0. It also exits 0 on Julia 1.10.11.
The two-line committed assertion was removed by @ChrisRackauckas during review at https://github.com/SciML/LinearSolve.jl/pull/1272#discussion_r3888018736; the commands above are the retained fail-before/pass-after evidence.

## Verification

Julia 1.11.9:

```console
$ GROUP=Core julia +1.11 --project -e 'using Pkg; Pkg.test()'
Test Summary:              | Pass  Total  Time
SpecializingFactorizations |   18     18  3.7s
Testing LinearSolve tests passed

$ GROUP=QA julia +1.11 --project -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
Quality Assurance |   50     50  6m24.1s
Testing LinearSolve tests passed
```

```console
$ JULIA_DEPOT_PATH=<clean-isolated-depot> julia +1.11 --project=docs docs/make.jl
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
# exit 0

$ julia +1.12 -m Runic --check src/LinearSolve.jl test/Core/basictests.jl
# exit 0

$ typos src/LinearSolve.jl test/Core/basictests.jl
# exit 0

$ git diff --check
# exit 0
```

The isolated depot was necessary because this host's global CondaPkg Pixi cache contains zero-byte Python files left by the 2026-08-22 disk-full incident. Clean `upstream/main` and this branch both build the docs successfully with the isolated depot; this is local cache corruption, not a repository failure.

## Not verified

GPU-specific groups and optional solver backend groups were not run locally. No dependency is added or changed.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a04fab-48db-7e03-9f47-20c69464527f)
