### PR TITLE
Allow matrix-backed operator Jacobians in LHL defaults

### DIFF
--- a/docs/src/tutorials/shifted_systems.md
+++ b/docs/src/tutorials/shifted_systems.md
@@ -189,9 +189,9 @@ uc ≈ (J - LA.I / γc) \ bc
 ## When it is chosen automatically
 
 Wrapping a matrix in a `WOperator` is itself the statement that the shift will move while
-`J` stays put, so `defaultalg` treats it as one: for a `WOperator` with a dense Jacobian, a
-scalar multiple of `I` as the mass matrix, and `n ≥ LinearSolve.LHL_DEFAULT_MIN_SIZE`, no
-algorithm argument is needed.
+`J` stays put, so `defaultalg` treats it as one: for a `WOperator` with a dense matrix or
+matrix-backed operator as its Jacobian, a scalar multiple of `I` as the mass matrix, and
+`n ≥ LinearSolve.LHL_DEFAULT_MIN_SIZE`, no algorithm argument is needed.
 
 ```@example shifted
 LS.defaultalg(W, b, LS.OperatorAssumptions(true))

--- a/src/default.jl
+++ b/src/default.jl
@@ -1,4 +1,6 @@
 needs_concrete_A(alg::DefaultLinearSolver) = true
+# Jacobian staleness belongs to the wrapper, so copying it would disconnect the signal.
+default_alias_A(::DefaultLinearSolver, ::WOperator, ::Any) = true
 
 # Every algorithm the default can dispatch to either ignores the tolerances
 # (the factorizations) or reads `cache.abstol`/`cache.reltol` at solve time (the
@@ -233,11 +235,11 @@ const LHL_DEFAULT_MIN_SIZE = 32
 # but left uninitialized the solve fails, and if it is initialized but never selected the
 # buffers are wasted. Both ask here.
 function _lhl_defaultable(A::WOperator, assump::OperatorAssumptions)
-    # A `MatrixOperator` is updated in place while its identity and `jac_stale` remain
-    # unchanged, so the reduction cannot detect that its contents moved.
     (assump.issq && _lhl_scalar_massmatrix(A.mass_matrix)) || return false
-    A.J isa DenseMatrix && return size(A, 1) >= LHL_DEFAULT_MIN_SIZE
-    return issparsematrixcsc(A.J)
+    (A.J isa AbstractMatrix || A.J isa MatrixOperator) || return false
+    J = _lhl_jacobian(A)
+    J isa DenseMatrix && return size(A, 1) >= LHL_DEFAULT_MIN_SIZE
+    return issparsematrixcsc(J)
 end
 _lhl_defaultable(A, assump) = false
 

--- a/src/lhl.jl
+++ b/src/lhl.jl
@@ -19,9 +19,9 @@ fixed for many steps.
 
 Give it the system matrix unassembled, as a `SciMLOperators.WOperator` — the split
 `J - M/γ` an implicit solver already builds — and move the shift with
-[`update_gamma!`](@ref).  A `WOperator` whose Jacobian is a dense matrix is also what
-`defaultalg` selects this algorithm for, at sizes where the reduction pays.  The mass
-matrix must be a multiple of `I`.
+[`update_gamma!`](@ref).  A `WOperator` whose Jacobian is a dense matrix or matrix-backed
+operator is also what `defaultalg` selects this algorithm for, at sizes where the
+reduction pays.  The mass matrix must be a multiple of `I`.
 
 Handed an ordinary matrix `A`, it solves `Ax = b` as `Z H⁻¹ Z⁻¹ b`; that works, but it is
 strictly worse than an LU and the algorithm has no reason to be chosen.

--- a/test/Core/lhl.jl
+++ b/test/Core/lhl.jl
@@ -393,11 +393,7 @@ end
     end
 end
 
-@testset "an operator Jacobian is never claimed by the reduction" begin
-    # `update_coefficients!` moves a `MatrixOperator`'s numbers in place, leaving both the
-    # object identity and `jac_stale` untouched. Nothing tells the reduction it went
-    # stale, so the split form must not be claimed at all for an operator `J` — it would
-    # answer with the previous Jacobian and raise nothing.
+@testset "a dense operator Jacobian uses LHL by default" begin
     n = 40
     γ = 0.1
     A = randn(MersenneTwister(21), n, n)
@@ -406,16 +402,18 @@ end
     W = WOperator{true}(I, γ, Aop, zeros(n))
     assump = LinearSolve.OperatorAssumptions(true)
 
-    @test !LinearSolve._lhl_defaultable(W, assump)
-    @test LinearSolve.defaultalg(W, b, assump) !=
+    @test LinearSolve._lhl_defaultable(W, assump)
+    @test LinearSolve.defaultalg(W, b, assump) ==
         LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.LHLFactorization)
 
     cache = init(LinearProblem(W, b))
+    @test cache.A === W
+    @test cache.cacheval.LHLFactorization !== nothing
     @test solve!(cache).u ≈ (A - I / γ) \ b rtol = 1.0e-6
 
     Anew = randn(MersenneTwister(23), n, n)
     copyto!(Aop.A, Anew)
-    cache.isfresh = true
+    mark_jacobian_updated!(W)
     @test solve!(cache).u ≈ (Anew - I / γ) \ b rtol = 1.0e-6
 end
 


### PR DESCRIPTION
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

Now that OrdinaryDiffEq marks a `WOperator` stale when an operator-backed Jacobian moves in place, LinearSolve can remove the consumer-side exclusion added in https://github.com/SciML/LinearSolve.jl/pull/1215. The LHL default predicate now inspects the matrix backing a `MatrixOperator`, while matrix-free operators still fall through to Krylov.

`DefaultLinearSolver` also aliases `WOperator` inputs. The staleness flag belongs to the wrapper, so copying the wrapper at `init` disconnected the producer's `mark_jacobian_updated!` call from the wrapper observed by the LHL cache even though both wrappers shared the same matrix data.

The regression covers default selection, LHL cache initialization, wrapper identity, the first solve, and a marked in-place Jacobian update. The LHL docstring and shifted-systems tutorial describe the expanded default.

## Failing before / passing after

Test-only state on unmodified `main`:

```console
$ julia +1.10 --project -e 'using Pkg; Pkg.instantiate(); include("test/Core/lhl.jl")'
a dense operator Jacobian uses LHL by default: Test Failed
  LinearSolve._lhl_defaultable(W, assump)
  false

a dense operator Jacobian uses LHL by default: Test Failed
  defaultalg(...) == DefaultLinearSolver(LHLFactorization)
  KrylovJL_GMRES == LHLFactorization

a dense operator Jacobian uses LHL by default: Test Failed
  cache.cacheval.LHLFactorization !== nothing
  nothing !== nothing

Test Summary:                                 | Pass  Fail  Total
 a dense operator Jacobian uses LHL by default |    2     3      5
ERROR: Some tests did not pass: 2 passed, 3 failed
```

Widening the predicate alone exposed the second half of the bug: the default selected LHL, but the copied wrapper did not receive the staleness signal, so the updated-J assertion failed with the old solution (`4 passed, 1 failed`). After preserving `WOperator` identity:

```console
Test Summary:                                 | Pass  Total  Time
a dense operator Jacobian uses LHL by default |    6      6  2.6s
Test Summary:     | Pass  Total     Time
LHL Factorization |  204    204  1m05.0s
```

## Verification

```console
$ GROUP=Core julia +1.10 --project -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
LHL Factorization |  204    204  1m05.0s
Testing LinearSolve tests passed

$ JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=QA julia +1.10 --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Broken  Total
JET Tests     |   20      23     43
Test Summary: | Pass  Total
Allocation QA |   55     55
Test Summary:              | Pass  Total
SupernodalLU Allocation QA |    6      6
Test Summary:     | Pass  Total
Quality Assurance |   48     48
Testing LinearSolve tests passed

$ JULIA_CONDAPKG_BACKEND=Null JULIA_PYTHONCALL_EXE="$PWD/.docs-venv/bin/python" julia +1.12 --project=docs docs/make.jl
[ Info: Doctest: running doctests.
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.

$ julia -m Runic --check src/default.jl src/lhl.jl test/Core/lhl.jl
$ git diff -- src/default.jl src/lhl.jl test/Core/lhl.jl docs/src/tutorials/shifted_systems.md | typos -
$ git diff --check
```

The first standard QA invocation spent its full one-hour budget in automatic Reactant extension precompilation before any QA assertion ran. Disabling only automatic precompilation allowed the unchanged QA group to execute and pass. The docs environment likewise needed a temporary Python environment for its already-declared PyAMG dependency after the machine-local Pixi environment failed to load Python's `encodings` module; the actual Documenter build then completed.

## CI

At commit `f8276dd69e3a616abfc5fa2875fe698688ad1f18`, 60 checks passed and one generated matrix entry was skipped. The sole failure was ModelingToolkit's downstream `All` suite:

```console
MethodError: no method matching create_array(::Type{CasADi.MX}, ::Nothing, ::Val{1}, ...)
ERROR: Some tests did not pass: 114 passed, 0 failed, 12 errored, 1 broken.
```

The identical CasADi failure occurs on unmodified upstream `main` at `85b24a13f17cf6c0813a34c3f906f7cac92c527c`, so this branch did not introduce it. A clean local checkout reproduced the same first Optimization error with LinearSolve 5.15.0, ModelingToolkit 11.40.1, CasADi 1.3.0, and SymbolicUtils 4.46.1 (`1 passed, 1 errored`).

Commit-level boundary testing identified CasADi `54f83b489d1d99afd53a7571d94e5e66d03bb1c7` as good and `b041ed63a5beb49f24620cd97de0e35c514c3115` as the first bad commit. CasADi PR 42 already restores the removed SymbolicUtils `create_array` integration. With its merge commit `a879b555aab7ea46ab24409c49025d7b99f15f35`, the actual previously failing ModelingToolkit `add_solve_constraints!` path returned `Opti` and passed. A later full-file local run hit an unrelated pip-CasADi/Julia-Ipopt ABI symbol error, so the entire file was not verified locally with the fix.

No duplicate issue was opened. CasADi's draft 1.3.1 release PR is the existing delivery path and currently has eight passing checks.

- PR CI failure: https://github.com/SciML/LinearSolve.jl/actions/runs/33292439860/job/99206322545
- Matching upstream-main failure: https://github.com/SciML/LinearSolve.jl/actions/runs/33282762136/job/99180607405

## Not verified

- Real CUDA, AMDGPU, or Metal execution locally; the CI GPU job passed.
- `GROUP=Everything` locally; CI ran the declared version, platform, sublibrary, and downstream matrix, with only the pre-existing ModelingToolkit failure documented above.
- An end-to-end OrdinaryDiffEq solve against this branch; the producer-side staleness regression is in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4354.

## Reviewer decision

This default is safe only when the producer honors the `WOperator` staleness contract. OrdinaryDiffEq `master` now does, but older OrdinaryDiffEq releases do not, and LinearSolve cannot express a compat bound on a downstream package. Release sequencing or an explicit capability signal may be preferable to immediately shipping the widened default.

Aliasing all `WOperator` inputs in `DefaultLinearSolver` is intentional because its eligible branches are operator algorithms (LHL or Krylov) that need the live operator. Please push back if copying a `WOperator` is expected public behavior for another default-solver path.

## Links

- OrdinaryDiffEq issue: https://github.com/SciML/OrdinaryDiffEq.jl/issues/4303
- Producer-side staleness fix: https://github.com/SciML/OrdinaryDiffEq.jl/pull/4354
- Original LHL default and consumer-side exclusion: https://github.com/SciML/LinearSolve.jl/pull/1215
- CasADi regression commit: https://github.com/SciML/CasADi.jl/commit/b041ed63a5beb49f24620cd97de0e35c514c3115
- CasADi fix PR: https://github.com/SciML/CasADi.jl/pull/42
- CasADi 1.3.1 release PR: https://github.com/SciML/CasADi.jl/pull/44

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a0507d-8515-73c0-841a-d7231caf221a).