### PR TITLE
Document slate_isavailable

### DIFF
--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -445,6 +445,7 @@ for something else will not redirect an explicit choice.
 
 ```@docs
 SLATEFactorization
+slate_isavailable
 ```
 
 ### CliqueTrees.jl

--- a/src/slate.jl
+++ b/src/slate.jl
@@ -91,6 +91,15 @@ function _load_libslate(libpath = nothing)
     return nothing
 end
 
+"""
+    slate_isavailable(; libpath = nothing)
+
+Return `true` when a SLATE LAPACK API library can be loaded and provides the
+`slate_dgesv` entry point required by [`SLATEFactorization`](@ref).
+
+The optional `libpath` and environment-variable lookup follow the same rules as
+[`SLATEFactorization`](@ref).
+"""
 function slate_isavailable(; libpath = nothing)
     lib = _load_libslate(libpath)
     lib === nothing && return false


### PR DESCRIPTION
## What changed and why

Document the public `slate_isavailable` helper and add it to the rendered SLATE solver documentation. The helper was made public without either entry, causing both public-API documentation checks on `main` to fail.

> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before the fix on `main`:

```console
$ GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Fail  Total      Time
Quality Assurance |   48     2     50  13m20.2s
...
public API has docstrings: Evaluated: isempty([:slate_isavailable])
public API is rendered in docs: Evaluated: isempty([:slate_isavailable])
```

Passing after the fix:

```console
$ GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
Quality Assurance |   50     50  5m42.8s
Testing LinearSolve tests passed
```

Documentation build:

```console
$ PIXI_CACHE_DIR=/home/crackauc/sandbox/tmp_20260831_204216_89854/linearsolve-pixi-cache julia --project=docs docs/make.jl
[ Info: Doctest: running doctests.
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
```

Formatting and spelling:

```console
$ julia -m Runic --check src/slate.jl
$ typos --force-exclude src/slate.jl docs/src/solvers/solvers.md
$ git diff --check
```

All three exited successfully with no output.

## Not verified

This documentation-only change was not exercised against GPU, downstream, Julia pre-release, or package Core lanes. The docs build emitted the existing CKTSO redirect and generated-page-size warnings; neither was introduced by this change.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol). Session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d
