### PR TITLE
Document slate_isavailable so the public API QA check passes

### DIFF
--- a/docs/src/solvers/solvers.md
+++ b/docs/src/solvers/solvers.md
@@ -445,6 +445,7 @@ for something else will not redirect an explicit choice.
 
 ```@docs
 SLATEFactorization
+slate_isavailable
 ```
 
 ### CliqueTrees.jl

--- a/src/slate.jl
+++ b/src/slate.jl
@@ -91,6 +91,16 @@ function _load_libslate(libpath = nothing)
     return nothing
 end
 
+"""
+    slate_isavailable(; libpath = nothing) -> Bool
+
+Whether a usable SLATE LAPACK API library can be loaded, so
+[`SLATEFactorization`](@ref) will work.
+
+Loading `SLATE_jll` is enough on the platforms it builds for. A local build is used
+instead when `libpath` is given or `ENV["SLATE_LAPACK_LIB"]` is set, either of which
+takes precedence over the JLL.
+"""
 function slate_isavailable(; libpath = nothing)
     lib = _load_libslate(libpath)
     lib === nothing && return false


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

`slate_isavailable` is exported but has no docstring and is not in an `@docs` block, so QA fails on main with `isempty(undocumented)` and `isempty(unrendered)` both evaluating to `[:slate_isavailable]`. This adds the docstring and renders it next to `SLATEFactorization`.

No tests, since this is a docstring and a docs entry. The QA group is what checks it.

AI Disclosure: Used Opus 5
