### PR TITLE
Use bulk CSR preallocation for PETSc MPI matrices

### DIFF
--- a/ext/LinearSolvePETScExt.jl
+++ b/ext/LinearSolvePETScExt.jl
@@ -305,7 +305,7 @@ function _to_petsc_mat_mpi_csc(petsclib, A::SparseMatrixCSC, pcache)
     pcache.rstart = rstart
     pcache.rend = rend
 
-    _assemble_local_rows_csr!(petsclib, mat, A, rstart, rend)
+    _assemble_local_rows_csr!(petsclib, mat, A, rstart, rend, comm)
     PETSc.assemble!(mat)
     return mat
 end
@@ -314,7 +314,7 @@ end
 # A is a SparseMatrixCSC with 1-indexed Julia rows [1, m].
 # rstart, rend are 0-indexed PETSc row indices defining which rows this rank owns.
 # rstart <= rowindex < rend (0-indexed).
-function _assemble_local_rows_csr!(petsclib, mat, A::SparseMatrixCSC, rstart, rend)
+function _assemble_local_rows_csr!(petsclib, mat, A::SparseMatrixCSC, rstart, rend, comm)
     PetscInt = PETSc.inttype(petsclib)
     PetscScalar = PETSc.scalartype(petsclib)
 
@@ -365,20 +365,14 @@ function _assemble_local_rows_csr!(petsclib, mat, A::SparseMatrixCSC, rstart, re
         end
     end
 
-    for local_i in 1:local_m
-        row_nnz = local_rowptr[local_i + 1] - local_rowptr[local_i]
-        if row_nnz > 0
-            row_petsc = rstart + local_i - 1
-            row_range = (local_rowptr[local_i] + 1):local_rowptr[local_i + 1]
-            cols = local_colind[row_range]
-            vals = local_vals[row_range]
-            LibPETSc.MatSetValues(
-                petsclib, mat,
-                PetscInt(1), [row_petsc],
-                PetscInt(row_nnz), cols,
-                vals, LibPETSc.INSERT_VALUES
-            )
-        end
+    if MPI.Comm_size(comm) == 1
+        LibPETSc.MatSeqAIJSetPreallocationCSR(
+            petsclib, mat, local_rowptr, local_colind, local_vals
+        )
+    else
+        LibPETSc.MatMPIAIJSetPreallocationCSR(
+            petsclib, mat, local_rowptr, local_colind, local_vals
+        )
     end
 
     return nothing

--- a/test/LinearSolvePETSc/petsctests_mpi.jl
+++ b/test/LinearSolvePETSc/petsctests_mpi.jl
@@ -76,6 +76,12 @@ end
 
         owned_rows = pcache.rend - pcache.rstart
         @test MPI.Allreduce(owned_rows, +, MPI.COMM_WORLD) == n
+
+        info = Ref{PETSc.LibPETSc.MatInfo}()
+        PETSc.LibPETSc.MatGetInfo(
+            petsclib, pcache.petsc_A, PETSc.LibPETSc.MAT_LOCAL, info
+        )
+        @test info[].mallocs == 0
         PETScExt.cleanup_petsc_cache!(cache)
     end
 


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed and why

The replicated `SparseMatrixCSC` MPI path created an unpreallocated AIJ matrix and then called `MatSetValues` once per owned row. PETSc consequently performed one dynamic matrix allocation per row, and assembly scaled superlinearly: on the benchmark host a 40,000-row solve took 72.79 seconds and a 1,000,000-row matrix was still assembling after 85 minutes.

This passes the local CSR arrays to PETSc's bulk CSR preallocation APIs instead. A size-one communicator uses `MatSeqAIJSetPreallocationCSR`; larger communicators use `MatMPIAIJSetPreallocationCSR`. The change adds no dependency and changes no public API.

The row-wise implementation first appeared in https://github.com/SciML/LinearSolve.jl/pull/969 (commit `2573724e92ae2495b2888e2099d0432de111c0c9`).

## Test discrimination

The regression test checks PETSc's matrix-allocation counter after building the existing replicated-CSC cache. I ran the exact new test against clean `main` from an isolated worktree:

```text
$ julia +1.12.3 --project=.validation/before-env -e 'include("test/LinearSolvePETSc/petsctests_mpi.jl")'
cache sentinels and ownership range: Test Failed
  Expression: (info[]).mallocs == 0
   Evaluated: 12.0 == 0
Test Summary:                                 | Pass  Fail  Total
SparseMatrixCSC: multi-rank assembly plumbing |   26     1     27
```

I then ran the same file with this change:

```text
$ julia +1.12.3 --project=.validation/repro-env -e 'include("test/LinearSolvePETSc/petsctests_mpi.jl")'
Test Summary:                                 | Pass  Total
SparseMatrixCSC: multi-rank assembly plumbing |   27     27
# all testsets in the file: 261 passed / 261 total
```

The standalone 2,500-row probe reported `mallocs=2500.0` before and `mallocs=0.0` after.

## Performance verification

I ran the same 2-D Laplacian solve before and after on Julia 1.12.3. The first 100-row case includes compilation; the larger cases are warm:

```text
                         clean main       this PR
10,000 rows / 49,600 nnz    4.17449 s      0.017431 s
40,000 rows / 199,200 nnz  72.78556 s      0.215372 s
residual at 40,000 rows      9.984e-9       9.984e-9
```

The two-rank 40,000-row run completed in 0.197914 seconds with residual `9.984e-9`.

I also ran SciMLBenchmarks' exact million-unknown worker:

```text
$ julia +1.12.3 --project=.validation/repro-env \
    ../linearsolvedistributed-combined-validation/benchmarks/LinearSolveDistributed/run_solve.jl \
    1000000 cg gamg
1,1000000,4996000,cg,gamg,4.991113304,6.269221372956215e-9,17,Success
```

The complete command took 65.30 seconds and 1.96 GB maximum RSS, including compilation, a warm-up solve, three timed samples, and the final reporting solve. Isolating just matrix/KSP construction took 1.896 seconds and reported zero dynamic PETSc allocations.

## Other verification

```text
$ julia +1.12.3 --project=.validation/repro-env -e 'include("test/LinearSolvePETSc/petsctests.jl")'
109 passed / 109 total

$ mpiexec -n 2 julia +1.12.3 --project=.validation/repro-env \
    -e 'include("test/LinearSolvePETSc/petsctests_mpi.jl")'
exit 0

$ julia +1.12.3 -m Runic --check ext/LinearSolvePETScExt.jl test/LinearSolvePETSc/petsctests_mpi.jl
exit 0

$ typos ext/LinearSolvePETScExt.jl test/LinearSolvePETSc/petsctests_mpi.jl
exit 0
```

```text
$ GROUP=QA julia +1.10.12 --project=. -e 'using Pkg; Pkg.test()'
JET Tests     | 20 passed, 23 broken, 43 total
Allocation QA | 55 passed / 55 total
SupernodalLU Allocation QA | 6 passed / 6 total
Quality Assurance | 48 passed / 48 total
Testing LinearSolve tests passed
```

This QA run used a temporary `AMD = "=0.5.3"` constraint that is not part of the diff.

The temporary AMD constraint was necessary because clean `main` currently resolves AMD 0.5.4, while SparseColumnPivotedQR still accesses the removed `AMD.SS_Int`; unmodified clean `main` therefore fails during LinearSolve precompilation on both Julia 1.10.12 and 1.12.3. That independent clean-main failure is not changed in this behavior PR.

No documentation build was run because this changes neither documentation nor public API. GPU and downstream-package tests were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://chatgpt.com/codex/tasks/01a03a17-ad6f-7131-82fc-d0fd57ea6512
