### PR TITLE
Avoid duplicate matrix copy in one-shot solves

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -993,7 +993,12 @@ function SciMLBase.solve(
         prob::LinearProblem, alg::SciMLLinearSolveAlgorithm,
         args...; kwargs...
     )
-    return solve!(init(prob, alg, args...; kwargs...))
+    cache = init(prob, alg, args...; kwargs...)
+    # A non-aliased init owns a private copy, and a one-shot cache is never returned.
+    if cache isa LinearCache && cache.A isa Matrix && !cache.alias_A && cache.A !== prob.A
+        setfield!(cache, :alias_A, true)
+    end
+    return solve!(cache)
 end
 
 """

--- a/test/qa/allocations.jl
+++ b/test/qa/allocations.jl
@@ -4,6 +4,25 @@ if Sys.islinux()
     import LAPACK_jll, blis_jll
 end
 
+function one_shot_lu_allocations(A, b)
+    solve(LinearProblem(A, b), LUFactorization())
+    GC.gc()
+    return @allocated solve(LinearProblem(A, b), LUFactorization())
+end
+
+@testset "One-shot LU reuses its private matrix copy" begin
+    n = 128
+    A = rand(n, n) + n * I
+    A_original = copy(A)
+    b = rand(n)
+
+    alloc = one_shot_lu_allocations(A, b)
+    sol = solve(LinearProblem(A, b), LUFactorization())
+    @test sol.u ≈ A_original \ b
+    @test A == A_original
+    @test alloc <= sizeof(A) + 8192
+end
+
 @check_allocs function allocation_checked_direct_lu_refactor_solve!(
         cache, Awork, A, alg
     )


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

A one-shot dense solve previously copied `A` into its non-aliased cache during `init`, then copied that private matrix again when LU factorization ran. This marks only a one-shot cache-owned `Matrix` as safe to overwrite, allowing LU to factor that private copy in place while preserving the caller matrix. Explicitly initialized reusable caches and non-`Matrix` structured inputs retain their existing aliasing behavior.

For a 500×500 `Float64` LU solve, observed allocations fell from 4,012,760 bytes to 2,012,704 bytes, eliminating approximately one matrix-sized allocation. Timing on the shared machine was noisy, so this PR makes no wall-time claim.

## Bug-regression evidence

With the allocation test present and the implementation reverted:

```text
Test Failed: Evaluated: 265952 <= 139264
Allocation QA | 65 passed, 1 failed, 66 total
```

With the implementation applied:

```text
Allocation QA              | 67 passed, 67 total
SupernodalLU Allocation QA |  8 passed,  8 total
Quality Assurance          | 50 passed, 50 total
Testing LinearSolve tests passed
```

The added test also checks solution correctness and verifies that the input matrix remains unchanged.

## Verification

```text
GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Allocation QA              | 67 passed, 67 total
SupernodalLU Allocation QA |  8 passed,  8 total
Quality Assurance          | 50 passed, 50 total
Testing LinearSolve tests passed

GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
BandedMatrices             | 103 passed, 103 total
SpecializingFactorizations |  18 passed,  18 total
Testing LinearSolve tests passed

julia +1.12 --project=@runic -m Runic --check src/common.jl test/qa/allocations.jl
exit 0

git diff --unified=0 upstream/main...HEAD | awk <changed-lines filter> | typos -
exit 0

git diff --check upstream/main...HEAD
exit 0
```

Focused supported-version allocation checks:

```text
Julia 1.10: alloc=134656 ceiling=139264 unchanged=true
Julia 1.12: alloc=134792 ceiling=139264 unchanged=true
```

After the full Core run, the branch was rebased over an upstream-only PETSc MPI commit. The focused allocation check and full QA group above were rerun after that rebase; the performance diff itself was unchanged.

## CI status

The PR matrix completed with 62 successful checks, one expected skipped check, and one failed ModelingToolkit downstream check. The failure is pre-existing on `main`: the current-base workflow produced the same missing `Interpolations` dependency and `create_array(::Type{CasADi.MX}, ...)` errors in https://github.com/SciML/LinearSolve.jl/actions/runs/33956224688/job/101279952909. The corresponding PR job is https://github.com/SciML/LinearSolve.jl/actions/runs/33958343027/job/101285635920. The downstream regression is tracked in https://github.com/SciML/CasADi.jl/issues/46.

## Not verified

- Hardware GPU backends and allowed-to-fail jobs were not run.
- The docs build was not run because this changes neither documentation nor public API.
- The upstream PETSc MPI test group was not run locally; this PR does not modify that upstream-only change.

## Review note

The optimization deliberately applies only when `init` produced a distinct private `Matrix`. Applying the same rule to arbitrary mutable matrix types exposed incompatible structured-matrix `lu!` dispatch, so those types remain on their existing path.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a059b1-11bd-77c2-93d2-6d4be342787a)
