### PR TITLE
Release LinearSolve 5.16.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.15.1"
+version = "5.16.0"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Bumps `LinearSolve` 5.15.1 -> 5.16.0 (minor).

Source files changed since 5.15.1:
- `ext/LinearSolveCUDAExt.jl`
- `ext/LinearSolvePETScExt.jl`
- `ext/LinearSolveSLATEExt.jl`
- `src/LinearSolve.jl`
- `src/adjoint_factorization.jl`
- `src/common.jl`
- `src/slate.jl`

Commits:
- Reject a CUSPARSE matrix used as a preconditioner with a message naming kp_ilu0 (#1276)
- Add SLATE dense LU solver wrapper (#1051)
- Document slate_isavailable so the public API QA check passes (#1279)
- Use bulk CSR preallocation for PETSc MPI matrices (#1280)

adds SLATEFactorization,slate_isavailable

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
