### PR TITLE
Define defaultalg_symbol before the generated factorization solve!

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -693,12 +693,6 @@ end
     )
 end
 
-function defaultalg_symbol(::Type{T}) where {T}
-    return Base.typename(SciMLBase.parameterless_type(T)).name
-end
-defaultalg_symbol(::Type{<:GenericFactorization{typeof(ldlt!)}}) = :LDLtFactorization
-
-defaultalg_symbol(::Type{<:QRFactorization{ColumnNorm}}) = :QRFactorizationPivoted
 
 const _SPARSE_ONLY_ALGORITHMS = Symbol.(
     (

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -1,51 +1,3 @@
-@generated function SciMLBase.solve!(
-        cache::LinearCache, alg::AbstractFactorization;
-        kwargs...
-    )
-    return quote
-        A = convert(AbstractMatrix, cache.A)
-        check_safety = _get_residualsafety(alg) && cache.isfresh
-        # Back up A before in-place LU when:
-        #   - residualsafety is enabled (for residual check using original A), OR
-        #   - the default solver has safetyfallback (for restoring A after LU failure)
-        needs_backup = check_safety ||
-            (cache.alg isa DefaultLinearSolver && cache.alg.safetyfallback && cache.isfresh)
-        A_original = needs_backup ? _copy_A_for_safety(cache) : A
-
-        if cache.isfresh
-            fact = do_factorization(alg, cache.A, cache.b, cache.u)
-            cache.cacheval = fact
-
-            # If factorization was not successful, return failure. Don't reset `isfresh`
-            if _notsuccessful(fact)
-                @SciMLMessage(
-                    "Solver failed", cache.verbose,
-                    :solver_failure
-                )
-                return SciMLBase.build_linear_solution(
-                    alg, cache.u, nothing, nothing; retcode = ReturnCode.Failure
-                )
-            end
-
-            cache.isfresh = false
-        end
-
-        y = _ldiv!(
-            cache.u, @get_cacheval(cache, $(Meta.quot(defaultalg_symbol(alg)))),
-            cache.b
-        )
-
-        if check_safety
-            failed = _check_residual_safety(cache, alg, A_original, y)
-            failed !== nothing && return failed
-        end
-
-        return SciMLBase.build_linear_solution(
-            alg, y, nothing, nothing; retcode = ReturnCode.Success
-        )
-    end
-end
-
 macro get_cacheval(cache, algsym)
     return quote
         if $(esc(cache)).alg isa DefaultLinearSolver
@@ -2696,6 +2648,65 @@ for alg in vcat(
             alg, A.A, b, u, Pl, Pr,
             maxiters::Int, abstol, reltol, verbose::Union{LinearVerbosity, Bool},
             assumptions::OperatorAssumptions
+        )
+    end
+end
+
+# The generated `solve!` below calls `defaultalg_symbol` while it runs, so these methods
+# must be defined first. They dispatch on types defined above, so this is the earliest
+# they can sit. See https://github.com/SciML/LinearSolve.jl/issues/1282.
+
+function defaultalg_symbol(::Type{T}) where {T}
+    return Base.typename(SciMLBase.parameterless_type(T)).name
+end
+defaultalg_symbol(::Type{<:GenericFactorization{typeof(ldlt!)}}) = :LDLtFactorization
+
+defaultalg_symbol(::Type{<:QRFactorization{ColumnNorm}}) = :QRFactorizationPivoted
+
+@generated function SciMLBase.solve!(
+        cache::LinearCache, alg::AbstractFactorization;
+        kwargs...
+    )
+    return quote
+        A = convert(AbstractMatrix, cache.A)
+        check_safety = _get_residualsafety(alg) && cache.isfresh
+        # Back up A before in-place LU when:
+        #   - residualsafety is enabled (for residual check using original A), OR
+        #   - the default solver has safetyfallback (for restoring A after LU failure)
+        needs_backup = check_safety ||
+            (cache.alg isa DefaultLinearSolver && cache.alg.safetyfallback && cache.isfresh)
+        A_original = needs_backup ? _copy_A_for_safety(cache) : A
+
+        if cache.isfresh
+            fact = do_factorization(alg, cache.A, cache.b, cache.u)
+            cache.cacheval = fact
+
+            # If factorization was not successful, return failure. Don't reset `isfresh`
+            if _notsuccessful(fact)
+                @SciMLMessage(
+                    "Solver failed", cache.verbose,
+                    :solver_failure
+                )
+                return SciMLBase.build_linear_solution(
+                    alg, cache.u, nothing, nothing; retcode = ReturnCode.Failure
+                )
+            end
+
+            cache.isfresh = false
+        end
+
+        y = _ldiv!(
+            cache.u, @get_cacheval(cache, $(Meta.quot(defaultalg_symbol(alg)))),
+            cache.b
+        )
+
+        if check_safety
+            failed = _check_residual_safety(cache, alg, A_original, y)
+            failed !== nothing && return failed
+        end
+
+        return SciMLBase.build_linear_solution(
+            alg, y, nothing, nothing; retcode = ReturnCode.Success
         )
     end
 end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -283,3 +283,12 @@ run_qa(
 )
 
 run_api_docs(LinearSolve.KLU)
+
+# The generated `solve!` calls `defaultalg_symbol` at generation time, so the methods
+# must not sit in a file included after `factorization.jl`. Reproducing the failure
+# itself needs `--compiled-modules=no`, which is too slow for the suite.
+# See https://github.com/SciML/LinearSolve.jl/issues/1282.
+@testset "defaultalg_symbol is defined before the generated solve! (#1282)" begin
+    files = unique(basename(string(m.file)) for m in methods(LinearSolve.defaultalg_symbol))
+    @test files == ["factorization.jl"]
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #1282. The generated `solve!` for `AbstractFactorization` calls `defaultalg_symbol` while the generator runs, but those methods lived in `default.jl`, which is included after `factorization.jl`. Precompilation hid it; under `--compiled-modules=no` the call fails with a world-age error. The methods dispatch on `GenericFactorization` and `QRFactorization`, so they cannot move earlier than those types, and the generated method moves after them instead.

Reproduced on Julia 1.12.6 with the reporter's script and confirmed fixed. The normal precompiled path is unchanged: the default solver, the explicit factorizations, LDLt through `GenericFactorization`, and the sparse default all still give the same answers.

The QA test checks that the methods stay in `factorization.jl` rather than a file included later. Reproducing the real failure needs a subprocess with `--compiled-modules=no`, which takes about two and a half minutes, and `--compiled-modules=existing` does not catch it, so the invariant is what is asserted instead.

AI Disclosure: Used Opus 5
