### PR TITLE
Release LinearSolve 5.17.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.17.0"
+version = "5.17.1"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Bumps `LinearSolve` 5.17.0 -> 5.17.1 (patch).

Source files changed since 5.17.0:
- `ext/LinearSolveBLISExt.jl`
- `src/LinearSolve.jl`

Commits:
- Disable BLIS extension on i686 (no blis_jll product) (#1287)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
