### PR TITLE
Release LinearSolve 5.17.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearSolve"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "5.17.1"
+version = "5.17.2"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Bumps `LinearSolve` 5.17.1 -> 5.17.2 (patch).

Source files changed since 5.17.1:
- `ext/LinearSolveConjugateGradientsExt.jl`

Commits:
- Widen ConjugateGradients maxIter to Int64 (32-bit) (#1288)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
