### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,61 @@
+using LinearSolve, BenchmarkTools
+using LinearAlgebra, SparseArrays, StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+# =============================================================================
+# Dense linear solves
+# =============================================================================
+
+SUITE["dense"] = BenchmarkGroup()
+
+A = rand(rng, 300, 300)
+A += 300I  # diagonal dominance for Krylov convergence
+b = rand(rng, 300)
+prob = LinearProblem(A, b)
+
+SUITE["dense"]["default"] = @benchmarkable solve($prob)
+SUITE["dense"]["LUFactorization"] = @benchmarkable solve($prob, LUFactorization())
+SUITE["dense"]["QRFactorization"] = @benchmarkable solve($prob, QRFactorization())
+SUITE["dense"]["KrylovJL_GMRES"] = @benchmarkable solve(
+    $prob, KrylovJL_GMRES()
+)
+SUITE["dense"]["SimpleGMRES"] = @benchmarkable solve(
+    $prob, SimpleGMRES(; blocksize = 30)
+)
+
+# =============================================================================
+# Factorization reuse (init + solve! with changing RHS)
+# =============================================================================
+
+SUITE["reuse"] = BenchmarkGroup()
+
+cache = init(prob, LUFactorization())
+b2 = rand(rng, 300)
+
+SUITE["reuse"]["init"] = @benchmarkable init($prob, LUFactorization())
+SUITE["reuse"]["solve!"] = @benchmarkable solve!($cache)
+SUITE["reuse"]["resolve_new_b"] = @benchmarkable begin
+    c = deepcopy($cache)
+    c.b = $b2
+    solve!(c)
+end
+
+# =============================================================================
+# Sparse linear solves
+# =============================================================================
+
+SUITE["sparse"] = BenchmarkGroup()
+
+As = sprand(rng, 2000, 2000, 0.005)
+As = As + As' + 2000I  # symmetric positive definite-ish
+bs = rand(rng, 2000)
+prob_sparse = LinearProblem(As, bs)
+
+SUITE["sparse"]["default"] = @benchmarkable solve($prob_sparse)
+SUITE["sparse"]["LUFactorization"] = @benchmarkable solve($prob_sparse, LUFactorization())
+SUITE["sparse"]["KrylovJL_CG"] = @benchmarkable solve($prob_sparse, KrylovJL_CG())
+SUITE["sparse"]["KrylovJL_GMRES"] = @benchmarkable solve(
+    $prob_sparse, KrylovJL_GMRES()
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~82s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~82s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md