### PR TITLE
Use JuliaC package for trim test on Julia 1.13

### DIFF
--- a/test/Trim/Project.toml
+++ b/test/Trim/Project.toml
@@ -3,6 +3,7 @@ uuid = "e59a8f5e-4b8c-4d8e-9c8e-8e8e8e8e8e8e"
 version = "0.1.0"
 
 [deps]
+JuliaC = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 RecursiveFactorization = "f2c3362d-daeb-58d1-803e-2bc74f2840b4"
@@ -22,6 +23,7 @@ JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 test = ["JET"]
 
 [compat]
+JuliaC = "0.3"
 LinearSolve = "5"
 RecursiveFactorization = "0.2"
 SafeTestsets = "0.1, 1"

--- a/test/Trim/runtests.jl
+++ b/test/Trim/runtests.jl
@@ -51,7 +51,11 @@ end
             "juliac.jl"
         )
     )
-    @test isfile(JULIAC)
+    # Julia 1.13 removed `juliac.jl` from the distribution; juliac now lives
+    # in the JuliaC package (a test dep of this project).
+    JULIAC_CMD = isfile(JULIAC) ? `$(JULIAC)` :
+        Cmd(["-e", "using JuliaC; JuliaC.main(ARGS)", "--"])
+    @test isfile(JULIAC) || VERSION ≥ v"1.13-"
 
     using LinearSolve
     # Build list of tests to run, conditionally including MKL
@@ -65,7 +69,23 @@ end
 
     for (mainfile, expectedtopass) in test_files
         binpath = tempname()
-        cmd = `$(Base.julia_cmd()) --project=. --depwarn=error $(JULIAC) --experimental --trim=unsafe-warn --output-exe $(binpath) $(mainfile)`
+        # JuliaC requires `--output-exe` to be a bare name, so run from the
+        # output directory and pass absolute paths for project and entry file.
+        # The project can't be this directory nor the active env: SciMLTesting's
+        # `activate_group_env` sandboxes the env (instantiated TOMLs, no `src/`),
+        # while this repo dir has the sources but no Manifest. JuliaC copies the
+        # project dir for its buildscript, so assemble one that has both —
+        # sources from here, instantiated Project/Manifest from the active env.
+        project_dir = mktempdir()
+        for f in readdir(@__DIR__)
+            f in ("Project.toml", "Manifest.toml") ||
+                cp(joinpath(@__DIR__, f), joinpath(project_dir, f))
+        end
+        active_env = dirname(Base.active_project())
+        cp(joinpath(active_env, "Project.toml"), joinpath(project_dir, "Project.toml"))
+        manifest = joinpath(active_env, "Manifest.toml")
+        isfile(manifest) && cp(manifest, joinpath(project_dir, "Manifest.toml"))
+        cmd = `$(Base.julia_cmd()) --project=$(project_dir) --depwarn=error $(JULIAC_CMD) --experimental --trim=unsafe-warn --output-exe $(basename(binpath)) $(joinpath(@__DIR__, mainfile))`
 
         # since we are calling Julia from Julia, we first need to clean some
         # environment variables
@@ -75,7 +95,7 @@ end
         # We could just check for success, but then failures are hard to debug.
         # Instead we use `_execute` to also capture `stdout` and `stderr`.
         # @test success(setenv(cmd, clean_env))
-        trimcall = _execute(setenv(cmd, clean_env; dir = @__DIR__))
+        trimcall = _execute(setenv(cmd, clean_env; dir = dirname(binpath)))
         if trimcall.exitcode != 0 && expectedtopass
             @show trimcall.stdout
             @show trimcall.stderr


### PR DESCRIPTION
## Summary

- Julia 1.13 removed `juliac.jl` from the distribution; the trim compiler now lives in the `JuliaC` package. This was the cause of the `SystemError: opening file ".../share/julia/juliac/juliac.jl"` failure in the Trim CI lane.
- When the bundled script is absent, invoke `JuliaC.main(ARGS)` instead (added `JuliaC` to the trim test env deps/compat).
- JuliaC 0.3 requires `--output-exe` to be a bare name, so the compiler now runs from the output directory with absolute paths for the project and entry file.
- **Fix for the follow-up CI failure** (`Package JuliaC is required but does not seem to be installed`): under SciMLTesting, `activate_group_env` sandboxes the group env into an instantiated temp dir — so `test/Trim` itself has no Manifest. But JuliaC also copies the project dir into its own temp dir for the buildscript, and the sandbox env lacks `src/TrimTest.jl` — so neither `--project=test/Trim` (no Manifest) nor `--project=<sandbox>` (no sources) works. The test now assembles a temp project dir carrying the sources plus the active env's instantiated Project/Manifest, so `using TrimTest` resolves as the project package inside JuliaC's buildscript.
- Same approach as NonlinearSolve.jl#1252 (whose in-place `test/trim` activation makes `--project=test/trim` already correct there).

#### Test plan

- [x] Julia 1.13.0, `GROUP=Trim Pkg.test()` through SciMLTesting's `activate_group_env` (the real CI path): `Trim Tests | 9 pass / 1 broken / 10` — all 7 `Run trim` checks pass (binaries build via JuliaC and execute); the 1 broken is the MKL-unavailable skip.

🤖 Generated with Devin CLI 3000.10.21 (model: SWE-2 Max)
Session: /home/crackauc/.local/share/devin/cli/summaries/history_e8f04feb08b1400d.md