### PR TITLE
Read Krylov stats from the workspace the default solver chose

### DIFF
--- a/src/iterative_wrappers.jl
+++ b/src/iterative_wrappers.jl
@@ -725,7 +725,11 @@ function SciMLBase.solve!(cache::LinearCache, alg::KrylovJL; kwargs...)
         Krylov.krylov_solve!(args...; kwargs...)
     end
 
-    stats = @get_cacheval(cache, :KrylovJL_GMRES).stats
+    # `cacheval` above, not the `:KrylovJL_GMRES` slot: under the default solver the
+    # non-square operator defaults run on the `:KrylovJL_LSMR` / `:KrylovJL_CRAIGMR`
+    # workspace, and reading GMRES's untouched stats reported `ReturnCode.Failure`
+    # with `iters = 0` for every successful solve.
+    stats = cacheval.stats
     resid = !isempty(stats.residuals) ? last(stats.residuals) :
         zero(eltype(stats.residuals))
 
@@ -746,7 +750,6 @@ function SciMLBase.solve!(cache::LinearCache, alg::KrylovJL; kwargs...)
 
     # Copy the solution to the allocated output array (block workspaces store
     # the batched solution in `X` rather than `x`)
-    cacheval = @get_cacheval(cache, :KrylovJL_GMRES)
     xsol = cacheval isa Union{Krylov.BlockGmresWorkspace, Krylov.BlockMinresWorkspace} ?
         cacheval.X : cacheval.x
     if cache.u !== xsol && ArrayInterface.can_setindex(cache.u)

--- a/test/Core/default_algs.jl
+++ b/test/Core/default_algs.jl
@@ -249,6 +249,46 @@ sol1 = solve(prob)
 sol2 = solve(prob, LinearSolve.KrylovJL_CRAIGMR())
 @test sol1.u == sol2.u
 
+# One builder, so both operators share a closure type and `reinit!` can retype the cache.
+function nonsquare_funcop(A, b)
+    return FunctionOperator(
+        (w, v, u, p, t) -> mul!(w, A, v), zeros(size(A, 2)), b;
+        op_adjoint = (w, v, u, p, t) -> mul!(w, A', v)
+    )
+end
+
+# The non-square operator defaults ran on the LSMR / CRAIGMR workspace but read stats and
+# `x` back from the `:KrylovJL_GMRES` slot: `Failure` with `iters = 0`, and a stale `u`
+# once it stopped aliasing. https://github.com/SciML/LinearSolve.jl/issues/1294
+@testset "non-square operator defaults report their own stats" begin
+    for (m, n, alg) in (
+            (30, 12, LinearSolve.KrylovJL_LSMR()),
+            (12, 30, LinearSolve.KrylovJL_CRAIGMR()),
+        )
+        A = rand(m, n)
+        b = rand(m)
+        prob = LinearProblem(nonsquare_funcop(A, b), b)
+        sol1 = solve(prob; maxiters = 500)
+        sol2 = solve(prob, alg; maxiters = 500)
+        @test sol1.retcode === sol2.retcode
+        @test SciMLBase.successful_retcode(sol1)
+        @test sol1.iters == sol2.iters
+        @test sol1.u == sol2.u
+
+        # A `u` the workspaces do not alias must still get the current solve's answer.
+        cache = init(prob; maxiters = 500)
+        first_u = copy(solve!(cache).u)
+        A2 = rand(m, n)
+        b2 = rand(m)
+        SciMLBase.reinit!(cache; A = nonsquare_funcop(A2, b2), b = b2, u = zeros(n))
+        second_u = copy(solve!(cache).u)
+        @test second_u != first_u
+        @test second_u ≈ solve(
+            LinearProblem(nonsquare_funcop(A2, b2), b2), alg; maxiters = 500
+        ).u
+    end
+end
+
 # Default for Underdetermined problem but the size is a long rectangle.
 # `A` is rank-deficient, so the unpivoted-QR default falls back to column-pivoted
 # QR and returns the same least-squares solution as `A \ b` (it used to report


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API

## Additional context

Fixes #1294. `solve!(::LinearCache, ::KrylovJL)` picks the right workspace for the default solver, then reads `stats` and the solution vector back out of a hardcoded `:KrylovJL_GMRES` slot. A non-square matrix-free operator defaults to `KrylovJL_LSMR` or `KrylovJL_CRAIGMR`, so both reads land on a workspace that never ran, and every such solve returned `ReturnCode.Failure` with `iters = 0` and logged "Solver failed" whether or not it converged. Both reads now use the `cacheval` selected above.

The hardcoded name was right when GMRES was the only Krylov slot the default carried. 40743e1 added the CRAIGMR and LSMR choices along with the selection block, but left the two later reads alone.

`u` was usually still correct, though only because `init_cacheval` ends with `solver.x = u`, so all three slots alias `cache.u` and the copy back into it is a self-copy. Replace `cache.u`, as `reinit!(cache; u = ...)` does, and that copy overwrites the fresh answer with the previous solve's. The test covers the return code, the iteration count and that stale-`u` path, for both the tall and the wide default; a square operator was never affected, since there the slot the default uses really is `:KrylovJL_GMRES`.

`test/Core/default_algs.jl` already exercised both defaults but asserted only `sol1.u == sol2.u`, which passes on that aliasing, so nothing flagged the return code.

AI Disclosure: Used Opus 5
