### PR TITLE
Run Pardiso tests on MKL's sequential threading layer (Julia 1.13 fix)

### DIFF
--- a/test/LinearSolvePardiso/pardiso.jl
+++ b/test/LinearSolvePardiso/pardiso.jl
@@ -1,3 +1,10 @@
+# Julia 1.13's SparseArrays stdlib loads libgomp, which makes MKL select
+# libmkl_gnu_thread; its complex CGS path (used by MKLPardisoIterate) crashes or
+# returns zeros there. MKL must bind a threading layer at first use, before
+# `import Pardiso` triggers initialization, and refuses the intel layer while
+# libgomp is loaded, so run the suite on the sequential layer.
+get(ENV, "MKL_THREADING_LAYER", "") == "" && (ENV["MKL_THREADING_LAYER"] = "sequential")
+
 using LinearSolve, SparseArrays, Random, LinearAlgebra
 import Pardiso
 


### PR DESCRIPTION
## Summary

`Tests / LinearSolvePardiso` on Julia 1.13 fails at `test/LinearSolvePardiso/pardiso.jl:51` (`A2 * u ≈ b2`, `u` comes back all zeros) for the complex solve under `MKLPardisoIterate`.

Root cause (reproduced locally on Julia 1.13.0, Pardiso 1.1.2, MKL_jll 2025.2.0):

- Julia 1.13's SparseArrays stdlib now loads `libgomp` into the process (on 1.12 it is shipped but not loaded).
- When `Pardiso.__init__` first calls into MKL, MKL detects the loaded libgomp and binds `libmkl_gnu_thread` instead of `libmkl_intel_thread`.
- MKL's complex CGS hybrid iteration (`solver_type = 1`, i.e. `MKLPardisoIterate`) inside `libmkl_gnu_thread` either segfaults (`mkl_pds_lp64_zscap1 → c_cgs_a → c_pre_cgs_pardiso`) or silently returns zeros. Same Pardiso.jl/MKL_jll versions pass on Julia 1.12, where MKL binds `libmkl_intel_thread`.
- `MKL_Set_Threading_Layer(MKL_THREADING_INTEL)` only works if called before MKL's first computation; Pardiso's `__init__` already calls `get_nprocs_mkl()`, so by the time any LinearSolve or extension code runs the layer is bound. `MKL_THREADING_LAYER=intel` is ignored once libgomp is loaded; `sequential` is honored.

This PR sets `MKL_THREADING_LAYER=sequential` at the top of the Pardiso test file, before `import Pardiso` (the only Pardiso import in the group). The full file passes locally on Julia 1.13.0 (`90 passed` previously, now `96/96` incl. the complex iterate solve). Algorithm/matrix coverage is unchanged; only MKL's threading layer differs for this test process.

The real upstream fix belongs in Pardiso.jl (force `MKL_THREADING_INTEL` in `__init__` before `get_nprocs_mkl()` binds the layer) — happy to open that PR on JuliaSparse/Pardiso.jl too; noted here for tracking.

## Test plan

- [x] `test/LinearSolvePardiso/pardiso.jl` passes locally on Julia 1.13.0 with MKL_jll 2025.2.0
- [x] Same test file reproduces the CI failure on 1.13 without this change
- [x] Same solve passes on Julia 1.12.7 (regression is 1.13-specific)

🤖 Generated with [Devin](https://devin.ai) — Agent-Harness: Devin CLI 3000.10.21, Agent-Model: SWE-2 Max, Agent-Session: /home/crackauc/.local/share/devin/cli/summaries/history_4c9fddb81d834736.md (local session transcript; no shareable URL)